### PR TITLE
feat(skills): add swiss-knife umbrella skill with token-usage

### DIFF
--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: swiss-knife
+description: >
+  Umbrella skill that bundles small, useful utility skills. Each sub-skill is
+  self-contained with its own scripts and assets. The umbrella introduces each
+  sub-skill with a one-liner — read the sub-skill's SKILL.md for full details.
+  Start here when the human asks about any utility; this file routes you to the
+  right sub-skill.
+version: 1.0.0
+tags: [utilities, umbrella, toolkit]
+---
+
+# Swiss Knife — Utility Toolkit
+
+A collection of small, useful skills. Each sub-skill lives in its own folder under `swiss-knife/` and is fully self-contained — scripts, assets, and a SKILL.md with complete instructions.
+
+## Sub-Skills
+
+| Sub-Skill | Description | When to Use |
+|-----------|-------------|-------------|
+| [token-usage](token-usage/) | Network-wide token cost calculator using litellm + OpenRouter pricing | Human asks about costs, budget, token usage, or spending |
+
+## How to Use
+
+1. **Identify the sub-skill** — match the human's request to the one-liner in the table above.
+2. **Read the sub-skill's SKILL.md** — `swiss-knife/<name>/SKILL.md` has full instructions, script paths, and examples.
+3. **Run the script** — each sub-skill bundles its own executable scripts. Follow the sub-skill's README for the exact command.
+
+## Adding New Sub-Skills
+
+To add a new utility to the swiss-knife:
+
+1. Create a folder: `swiss-knife/<name>/`
+2. Add a `SKILL.md` with frontmatter (`name`, `description`, `version`) and full usage instructions
+3. Add any scripts/assets in a `scripts/` subfolder
+4. Update the table above with a one-liner
+5. Refresh the library: `library(action='refresh')` or `system(action='refresh')`
+
+## Design Philosophy
+
+Each sub-skill follows these principles:
+- **Self-contained** — all code and assets live in the sub-skill folder
+- **Single-purpose** — one sub-skill does one thing well
+- **Documented** — SKILL.md has enough context to use without reading source code
+- **Small** — if it's bigger than ~200 lines of code, it probably deserves its own top-level skill

--- a/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
@@ -79,7 +79,11 @@ Each agent's `logs/token_ledger.jsonl` has one JSON object per LLM call:
 
 ## Dependencies
 
-- `litellm` — installed in the TUI venv (`pip install litellm`)
+- `litellm` — required. Check with `python3 -c "import litellm"`. If missing, ask the human before installing:
+
+  > token-usage needs `litellm` (~5MB) for model pricing. Install it? (`pip install litellm`)
+
+  Install only after they say yes.
 - Python 3.9+
 
 ## Tips

--- a/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: token-usage
+description: >
+  Network-wide token usage and cost calculator using litellm's model pricing database.
+  Reads token_ledger.jsonl from all agents, matches models to litellm pricing, and
+  produces a per-agent and grand-total cost report. Supports any model litellm knows
+  about (2700+ models) plus custom pricing overrides. Use when the human asks about
+  token usage, cost, budget, or spending.
+version: 2.0.0
+tags: [python, cost, tokens, litellm, budget]
+---
+
+# Token Usage & Cost Calculator v2
+
+Network-wide token cost analysis powered by [litellm](https://github.com/BerriAI/litellm)'s model pricing database (2700+ models).
+
+## Quick Usage
+
+Run the bundled script:
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python3 ~/.lingtai-tui/utilities/swiss-knife/token-usage/scripts/cost_report.py /path/to/.lingtai
+```
+
+Optional flags:
+- `--json` — output as JSON instead of table
+- `--by-model` — group by model instead of by agent
+- `--since YYYY-MM-DD` — only count entries after this date
+- `--top N` — show only top N agents (default: all)
+- `--custom-pricing FILE` — load custom pricing overrides from JSON
+
+## How It Works
+
+1. Scans all `logs/token_ledger.jsonl` files under the `.lingtai/` network directory
+2. For each entry, looks up the model in `litellm.model_cost` (2700+ models)
+3. Falls back to OpenRouter API (`/api/v1/models`) for real-time pricing (368 models)
+4. Falls back to custom pricing if the model isn't in either source
+5. Calculates per-agent and grand-total costs
+6. Reports cache hit rate, burn rate, and per-model breakdown
+
+## Pricing Sources
+
+**Primary:** litellm's `model_cost` dictionary — covers OpenAI, Anthropic, Google, Meta, Mistral, Xiaomi, and 100+ other providers.
+
+**Secondary:** OpenRouter API — real-time pricing for 368 models, more up-to-date than litellm for some providers.
+
+**Fallback:** Custom pricing in `scripts/custom_pricing.json` — for models not yet in litellm or OpenRouter (e.g., MiMo v2.5 Pro direct API).
+
+**Override:** Pass `--custom-pricing FILE` to add project-specific pricing.
+
+## Custom Pricing Format
+
+```json
+{
+  "mimo-v2.5-pro": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 0.0000002
+  }
+}
+```
+
+## Ledger Format
+
+Each agent's `logs/token_ledger.jsonl` has one JSON object per LLM call:
+
+```json
+{
+  "source": "main",
+  "ts": "2026-05-06T19:31:40Z",
+  "input": 53295,
+  "output": 277,
+  "thinking": 172,
+  "cached": 12288,
+  "model": "mimo-v2.5-pro",
+  "endpoint": "https://api.xiaomimimo.com/v1"
+}
+```
+
+## Dependencies
+
+- `litellm` — installed in the TUI venv (`pip install litellm`)
+- Python 3.9+
+
+## Tips
+
+- Check after spawning multiple avatars — they each burn their own system prompt
+- Cache hit rate is the key efficiency metric — aim for >90%
+- Daemon tokens are tracked in `daemons/<run_id>/logs/token_ledger.jsonl`
+- For per-session breakdown, use `--since` to filter by date

--- a/tui/internal/preset/skills/swiss-knife/token-usage/scripts/cost_report.py
+++ b/tui/internal/preset/skills/swiss-knife/token-usage/scripts/cost_report.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Network-wide token usage & cost calculator powered by litellm.
+
+Usage:
+    python3 cost_report.py /path/to/.lingtai [--json] [--by-model] [--since DATE] [--top N]
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Pricing lookup
+# ---------------------------------------------------------------------------
+
+# Custom pricing for models not yet in litellm.
+# Override with --custom-pricing FILE or edit scripts/custom_pricing.json.
+CUSTOM_PRICING = {
+    "mimo-v2.5-pro": {
+        "input_cost_per_token": 1.00 / 1_000_000,       # $1.00/M input
+        "output_cost_per_token": 3.00 / 1_000_000,      # $3.00/M output
+        "cache_read_input_token_cost": 0.20 / 1_000_000, # $0.20/M cached
+    },
+    "mimo-v2.5-lite": {
+        "input_cost_per_token": 0.20 / 1_000_000,
+        "output_cost_per_token": 0.60 / 1_000_000,
+        "cache_read_input_token_cost": 0.04 / 1_000_000,
+    },
+}
+
+
+def load_openrouter_pricing():
+    """Fetch model pricing from OpenRouter API. Returns dict keyed by model slug."""
+    import urllib.request
+    pricing = {}
+    try:
+        url = "https://openrouter.ai/api/v1/models"
+        req = urllib.request.Request(url, headers={"User-Agent": "lingtai-token-usage/2.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+        for model in data.get("data", []):
+            model_id = model.get("id", "")  # e.g. "openai/gpt-4o"
+            pricing_info = model.get("pricing", {})
+            if not pricing_info:
+                continue
+            prompt_price = float(pricing_info.get("prompt", 0))
+            completion_price = float(pricing_info.get("completion", 0))
+            pricing[model_id] = {
+                "input_cost_per_token": prompt_price,
+                "output_cost_per_token": completion_price,
+                "cache_read_input_token_cost": 0,  # OpenRouter doesn't expose cache pricing
+                "source": "openrouter",
+            }
+    except Exception as e:
+        print(f"Warning: Could not fetch OpenRouter pricing: {e}", file=sys.stderr)
+    return pricing
+
+
+def load_litellm_cost():
+    """Load litellm's model_cost dictionary. Returns empty dict on failure."""
+    try:
+        import litellm
+        return litellm.model_cost
+    except ImportError:
+        print("Warning: litellm not installed. Using custom pricing only.", file=sys.stderr)
+        return {}
+
+
+def load_custom_pricing(path=None):
+    """Load custom pricing overrides from a JSON file."""
+    pricing = dict(CUSTOM_PRICING)
+    if path and os.path.exists(path):
+        with open(path) as f:
+            pricing.update(json.load(f))
+    # Also try the bundled custom_pricing.json
+    bundled = os.path.join(os.path.dirname(__file__), "custom_pricing.json")
+    if os.path.exists(bundled):
+        with open(bundled) as f:
+            pricing.update(json.load(f))
+    return pricing
+
+
+def find_model_pricing(model_name, litellm_cost, custom_pricing, openrouter_pricing=None):
+    """Find pricing for a model: OpenRouter → litellm → custom → fuzzy match."""
+    if not model_name:
+        return None
+    if openrouter_pricing is None:
+        openrouter_pricing = {}
+
+    # Normalize: strip provider prefix (e.g., "openai/gpt-4" -> "gpt-4")
+    normalized = model_name.split("/")[-1] if "/" in model_name else model_name
+
+    # 1. Exact match in OpenRouter
+    for key in [model_name, normalized]:
+        if key in openrouter_pricing:
+            entry = openrouter_pricing[key]
+            return {"input": entry["input_cost_per_token"], "output": entry["output_cost_per_token"],
+                    "cached": entry.get("cache_read_input_token_cost", 0), "source": "openrouter"}
+
+    # 2. Exact match in litellm
+    for key in [model_name, normalized]:
+        if key in litellm_cost:
+            entry = litellm_cost[key]
+            return {"input": entry.get("input_cost_per_token", 0), "output": entry.get("output_cost_per_token", 0),
+                    "cached": entry.get("cache_read_input_token_cost", entry.get("input_cost_per_token_cache_hit", 0)),
+                    "source": "litellm"}
+
+    # 3. Exact match in custom pricing
+    for key in [model_name, normalized]:
+        if key in custom_pricing:
+            entry = custom_pricing[key]
+            return {"input": entry.get("input_cost_per_token", 0), "output": entry.get("output_cost_per_token", 0),
+                    "cached": entry.get("cache_read_input_token_cost", 0), "source": "custom"}
+
+    # 4. Fuzzy: suffix match in OpenRouter
+    for key in openrouter_pricing:
+        if key.endswith("/" + normalized) or key.endswith("/" + model_name):
+            entry = openrouter_pricing[key]
+            return {"input": entry["input_cost_per_token"], "output": entry["output_cost_per_token"],
+                    "cached": entry.get("cache_read_input_token_cost", 0), "source": f"openrouter:{key}"}
+
+    # 5. Fuzzy: suffix match in litellm
+    for key in litellm_cost:
+        if key.endswith("/" + normalized) or key.endswith("/" + model_name):
+            entry = litellm_cost[key]
+            return {"input": entry.get("input_cost_per_token", 0), "output": entry.get("output_cost_per_token", 0),
+                    "cached": entry.get("cache_read_input_token_cost", entry.get("input_cost_per_token_cache_hit", 0)),
+                    "source": f"litellm:{key}"}
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Ledger parsing
+# ---------------------------------------------------------------------------
+
+def parse_ledger(path, since=None):
+    """Parse a token_ledger.jsonl file, optionally filtering by date."""
+    entries = []
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    d = json.loads(line)
+                    if since:
+                        ts = d.get("ts", "")
+                        if ts and ts[:10] < since:
+                            continue
+                    entries.append(d)
+                except json.JSONDecodeError:
+                    continue
+    except (OSError, IOError):
+        pass
+    return entries
+
+
+def aggregate_entries(entries):
+    """Aggregate token entries into totals."""
+    total_in = 0
+    total_out = 0
+    total_cached = 0
+    total_think = 0
+    by_model = defaultdict(lambda: {"input": 0, "output": 0, "cached": 0, "thinking": 0, "calls": 0})
+
+    for d in entries:
+        inp = d.get("input", 0)
+        out = d.get("output", 0)
+        cached = d.get("cached", 0)
+        think = d.get("thinking", 0)
+        model = d.get("model", "unknown")
+
+        total_in += inp
+        total_out += out
+        total_cached += cached
+        total_think += think
+
+        m = by_model[model]
+        m["input"] += inp
+        m["output"] += out
+        m["cached"] += cached
+        m["thinking"] += think
+        m["calls"] += 1
+
+    return {
+        "input": total_in,
+        "output": total_out,
+        "cached": total_cached,
+        "thinking": total_think,
+        "calls": len(entries),
+        "by_model": dict(by_model),
+    }
+
+
+def calculate_cost(agg, pricing_fn):
+    """Calculate cost from aggregated tokens using a pricing function."""
+    cost = 0.0
+    cost_breakdown = {}
+    unmapped_models = []
+
+    for model, stats in agg["by_model"].items():
+        p = pricing_fn(model)
+        if p is None:
+            unmapped_models.append(model)
+            # Use zero pricing for unmapped models
+            p = {"input": 0, "output": 0, "cached": 0, "source": "unmapped"}
+
+        miss_input = stats["input"] - stats["cached"]
+        model_cost = (
+            miss_input * p["input"]
+            + stats["cached"] * p["cached"]
+            + (stats["output"] + stats["thinking"]) * p["output"]
+        )
+        cost += model_cost
+        cost_breakdown[model] = {
+            "cost": model_cost,
+            "pricing_source": p.get("source", "unknown"),
+            "stats": stats,
+        }
+
+    return cost, cost_breakdown, unmapped_models
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def format_tokens(n):
+    if n >= 1_000_000:
+        return f"{n/1_000_000:.1f}M"
+    elif n >= 1_000:
+        return f"{n/1_000:.1f}K"
+    return str(n)
+
+
+def print_table_report(results, grand_total, grand_cost, unmapped, openrouter_n=0, litellm_n=0):
+    """Print a human-readable table report."""
+    print("=" * 80)
+    print("  TOKEN USAGE & COST REPORT")
+    print(f"  Pricing: OpenRouter ({openrouter_n}) + litellm ({litellm_n}) models")
+    print("=" * 80)
+    print()
+    print(f"{'Agent':<28} {'Calls':>6} {'Input':>10} {'Output':>10} {'Cache%':>7} {'Cost':>10}")
+    print("-" * 80)
+
+    # Sort by cost descending
+    sorted_results = sorted(results, key=lambda x: x["cost"], reverse=True)
+
+    for r in sorted_results:
+        cache_pct = f"{r['cached']/r['input']*100:.0f}%" if r["input"] > 0 else "N/A"
+        print(f"{r['name']:<28} {r['calls']:>6} {format_tokens(r['input']):>10} "
+              f"{format_tokens(r['output']):>10} {cache_pct:>7} ${r['cost']:>8.2f}")
+
+    print("-" * 80)
+
+    cache_pct = f"{grand_total['cached']/grand_total['input']*100:.1f}%" if grand_total["input"] > 0 else "N/A"
+    print(f"{'TOTAL':<28} {grand_total['calls']:>6} {format_tokens(grand_total['input']):>10} "
+          f"{format_tokens(grand_total['output']):>10} {cache_pct:>7} ${grand_cost:>8.2f}")
+
+    if unmapped:
+        print()
+        print(f"⚠️  Models without pricing ({len(unmapped)}):")
+        for m in sorted(set(unmapped)):
+            print(f"    {m}")
+        print("    (cost shown as $0.00 — add to custom_pricing.json to track)")
+
+    print()
+    print(f"  Total tokens: {format_tokens(grand_total['input'] + grand_total['output'] + grand_total['thinking'])}")
+    print(f"  Total calls:  {grand_total['calls']}")
+    print(f"  Cache hit:    {cache_pct}")
+    print(f"  Est. cost:    ${grand_cost:.2f}")
+
+
+def print_model_report(results):
+    """Print a per-model breakdown across all agents."""
+    model_totals = defaultdict(lambda: {"input": 0, "output": 0, "cached": 0, "thinking": 0, "calls": 0, "agents": set()})
+
+    for r in results:
+        for model, stats in r["by_model"].items():
+            m = model_totals[model]
+            m["input"] += stats["input"]
+            m["output"] += stats["output"]
+            m["cached"] += stats["cached"]
+            m["thinking"] += stats["thinking"]
+            m["calls"] += stats["calls"]
+            m["agents"].add(r["name"])
+
+    print()
+    print("PER-MODEL BREAKDOWN")
+    print("-" * 80)
+    print(f"{'Model':<30} {'Calls':>6} {'Tokens':>10} {'Agents':>7}")
+    print("-" * 80)
+
+    for model, stats in sorted(model_totals.items(), key=lambda x: x[1]["calls"], reverse=True):
+        total = stats["input"] + stats["output"] + stats["thinking"]
+        print(f"{model:<30} {stats['calls']:>6} {format_tokens(total):>10} {len(stats['agents']):>7}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Network-wide token cost report")
+    parser.add_argument("network_dir", help="Path to .lingtai/ network directory")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--by-model", action="store_true", help="Show per-model breakdown")
+    parser.add_argument("--since", help="Only count entries after this date (YYYY-MM-DD)")
+    parser.add_argument("--top", type=int, help="Show only top N agents")
+    parser.add_argument("--custom-pricing", help="Path to custom pricing JSON file")
+    args = parser.parse_args()
+
+    network_dir = Path(args.network_dir)
+    if not network_dir.exists():
+        print(f"Error: {network_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    # Load pricing
+    openrouter_pricing = load_openrouter_pricing()
+    litellm_cost = load_litellm_cost()
+    custom_pricing = load_custom_pricing(args.custom_pricing)
+    pricing_fn = lambda model: find_model_pricing(model, litellm_cost, custom_pricing, openrouter_pricing)
+
+    # Scan all agents
+    results = []
+    all_unmapped = []
+    grand_total = {"input": 0, "output": 0, "cached": 0, "thinking": 0, "calls": 0}
+    grand_cost = 0.0
+
+    for agent_dir in sorted(network_dir.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        ledger_path = agent_dir / "logs" / "token_ledger.jsonl"
+        if not ledger_path.exists():
+            continue
+
+        entries = parse_ledger(ledger_path, args.since)
+        if not entries:
+            continue
+
+        agg = aggregate_entries(entries)
+        cost, cost_breakdown, unmapped = calculate_cost(agg, pricing_fn)
+        all_unmapped.extend(unmapped)
+
+        results.append({
+            "name": agent_dir.name,
+            "calls": agg["calls"],
+            "input": agg["input"],
+            "output": agg["output"],
+            "cached": agg["cached"],
+            "thinking": agg["thinking"],
+            "cost": cost,
+            "by_model": agg["by_model"],
+            "cost_breakdown": cost_breakdown,
+        })
+
+        grand_total["input"] += agg["input"]
+        grand_total["output"] += agg["output"]
+        grand_total["cached"] += agg["cached"]
+        grand_total["thinking"] += agg["thinking"]
+        grand_total["calls"] += agg["calls"]
+        grand_cost += cost
+
+    # Apply --top
+    if args.top:
+        results = sorted(results, key=lambda x: x["cost"], reverse=True)[:args.top]
+
+    # Output
+    if args.json:
+        output = {
+            "agents": results,
+            "total": grand_total,
+            "total_cost": grand_cost,
+            "unmapped_models": sorted(set(all_unmapped)),
+            "pricing_sources": {"openrouter": len(openrouter_pricing), "litellm": len(litellm_cost), "custom": len(custom_pricing)},
+        }
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        print_table_report(results, grand_total, grand_cost, all_unmapped,
+                          openrouter_n=len(openrouter_pricing), litellm_n=len(litellm_cost))
+        if args.by_model:
+            print_model_report(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tui/internal/preset/skills/swiss-knife/token-usage/scripts/custom_pricing.json
+++ b/tui/internal/preset/skills/swiss-knife/token-usage/scripts/custom_pricing.json
@@ -1,0 +1,22 @@
+{
+  "mimo-v2.5": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 0.0000002
+  },
+  "mimo-v2.5-pro": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 0.0000002
+  },
+  "mimo-v2.5-lite": {
+    "input_cost_per_token": 0.0000002,
+    "output_cost_per_token": 0.0000006,
+    "cache_read_input_token_cost": 0.00000004
+  },
+  "mimo-v2-flash": {
+    "input_cost_per_token": 0.00000009,
+    "output_cost_per_token": 0.00000029,
+    "cache_read_input_token_cost": 0.00000002
+  }
+}


### PR DESCRIPTION
## What

Adds a new **swiss-knife** umbrella skill to the preset skills directory. Swiss-knife bundles small, self-contained utility skills — each in its own subfolder with scripts and documentation.

### First sub-skill: token-usage

Network-wide token cost calculator powered by litellm's pricing database (2700+ models):

- Scans all `logs/token_ledger.jsonl` across the agent network
- Matches models to litellm pricing, falls back to OpenRouter API, then custom pricing
- Produces per-agent and grand-total cost reports
- Supports `--json`, `--by-model`, `--since`, `--top`, `--custom-pricing` flags

### Design

The umbrella SKILL.md has a routing table — one-liner descriptions that tell the agent which sub-skill to load. Adding new utilities is just creating a new subfolder.

## Structure

```
swiss-knife/
├── SKILL.md                          # Umbrella routing + design philosophy
└── token-usage/
    ├── SKILL.md                      # Full usage instructions
    └── scripts/
        ├── cost_report.py           # Main script
        └── custom_pricing.json      # Pricing overrides for models not in litellm
```

## Testing

Tested locally — cost_report.py successfully scans the network's token ledgers and produces cost reports using litellm pricing.