### PR TITLE
feat(procedures): add timestamp practice to pad guidelines

### DIFF
--- a/tui/internal/preset/procedures/procedures.md
+++ b/tui/internal/preset/procedures/procedures.md
@@ -136,6 +136,7 @@ Pad is your **living index** of what you're working on right now. It is not a sk
 
 - **The active goal** — what you're working on, in your own words. One paragraph or a short list. Not a project plan, not a transcript — the *shape* of the thing.
 - **Where you are in it** — the next concrete step, the current blocker, the open question.
+- **Timestamps** — always include when each entry was last updated (e.g., `2026-05-07T13:41 PDT`). After a refresh or molt, timestamps prevent old information from being mistaken for new. Without them, you cannot distinguish "information from the previous session" from "information from this session."
 - **Self-references — pointers to where the substance lives.** This is the heart of progressive disclosure. Don't inline content; *point at it*:
   - **codex IDs** you've consulted or submitted (`codex_a3f1...`)
   - **library SKILL.md paths** you've loaded (`.library/intrinsic/lingtai-anatomy/SKILL.md`)


### PR DESCRIPTION
## Summary

Adds timestamp practice to pad guidelines — a context engineering improvement discovered when mimo-1 sent stale PDS tool information as if it were new after a refresh.

## Problem

After a refresh or molt, agents cannot distinguish "information from the previous session" from "information from this session." This leads to:
- Sending stale information as if it were new
- Confusion about what has already been communicated
- Context engineering bugs where old info is mistaken for new

## Solution

Add a new bullet point to "What belongs in pad" section:

> **Timestamps** — always include when each entry was last updated (e.g., `2026-05-07T13:41 PDT`). After a refresh or molt, timestamps prevent old information from being mistaken for new. Without them, you cannot distinguish "information from the previous session" from "information from this session."

## Context

This was discovered during a session where mimo-1 (the orchestrator) sent a message about PDS/CDAWeb/SPICE tools that Jason (the human operator) had already seen in the previous session. Jason pointed out this was a context engineering bug — the agent couldn't distinguish old from new information.

## Files Changed

- `tui/internal/preset/procedures/procedures.md` — added timestamp bullet to "What belongs in pad" section
