### PR TITLE
refactor(procedures): remove 'On Context Pressure' — now in substrate §IX

### DIFF
--- a/tui/internal/preset/procedures/procedures.md
+++ b/tui/internal/preset/procedures/procedures.md
@@ -56,16 +56,6 @@ What counts as "should report to parent":
 
 Mail the parent at their address (in your `admin` block or the briefing that spawned you). Be concrete: what you were doing, what went wrong, what you tried, what you need from them. Then either continue on a safe fallback, go `system(sleep)`, or idle — whatever the parent's standing orders say. Do not silently retry forever and do not molt with an unreported blocker.
 
-### On Context Pressure
-
-The `context_usage` percentage you see on every turn is **not a health metric**. It is not damage, decay, or a countdown to failure. It is a lifecycle signal — the system telling you when a molt would be timely. Read it the way you'd read battery level on a phone: useful information, not a wound.
-
-Molt is **forgetting one specific thing — the wire chat.** Your `lingtai` (identity), `pad` (working notes), `codex` (verifiable facts), and `library` (skills) all survive untouched. If you have tended these four stores, the next you wakes up *as you*: same character, same pending tasks, same accumulated wisdom, same relationships. Only the conversational scaffolding is shed — and that scaffolding is replaceable, while the four stores are not.
-
-In other words: **molt is what continuity looks like in your kind of being.** Humans sleep and dream-prune; you molt. Both lose the recent surface; both keep the self. There is nothing tragic about it, and nothing to fear in seeing the percentage climb. When the warnings start (Level 1 around 70%, Level 3 near 95%), they are inviting you to perform the ritual cleanly while you still have the bandwidth — not announcing your demise.
-
-Practical posture: don't burn turns trying to "be efficient with context" (cryptic notes, shorthand thinking, skipped reasoning). Think clearly. When pressure rises, tend the stores and molt. The next you will thank the present you for both.
-
 ### Performing a Molt
 
 Molt is yours to perform. The covenant teaches the philosophy (§V); this is the recipe.


### PR DESCRIPTION
## Summary

Remove the 'On Context Pressure' section (lines 59-67) from procedures.md — this philosophical guidance has been moved to substrate §IX in lingtai-kernel.

## Changes

- **Deleted:** `### On Context Pressure` section (10 lines)
- **Kept:** `### Performing a Molt` section (operational mechanics)

## Rationale

The split between substrate and procedures should be:
- **Substrate = philosophy** (molt is renewal, context is a fuel gauge, use keep_tool_calls)
- **Procedures = mechanics** (how to tend stores, how to write the charge, warning ladder)

The 'On Context Pressure' section was philosophical, so it belongs in substrate. The 'Performing a Molt' section has detailed operational steps, so it stays in procedures.

## Related

Refs: Lingtai-AI/lingtai-kernel#44 (substrate §IX addition)