### PR TITLE
feat(preset): add Gemini 3 Flash built-in quick preset

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -428,6 +428,7 @@ func BuiltinPresets() []Preset {
 		zhipuPreset(),
 		mimoPreset(),
 		deepseekPreset(),
+		geminiPreset(),
 		kimiPreset(),
 		openrouterPreset(),
 		codexPreset(),
@@ -444,6 +445,7 @@ var builtinNames = map[string]bool{
 	"zhipu":       true,
 	"mimo":        true,
 	"deepseek":    true,
+	"gemini":      true,
 	"kimi":        true,
 	"openrouter":  true,
 	"codex":       true,
@@ -782,6 +784,35 @@ func deepseekPreset() Preset {
 			},
 			"admin":     map[string]interface{}{"karma": true},
 			"streaming": false,
+		},
+	}
+}
+
+func geminiPreset() Preset {
+	// Gemini 3 Flash (Google) — multimodal model with native vision,
+	// tool calling, and streaming. Uses Google's own Gemini adapter in
+	// the kernel (not OpenAI-compat), so no base_url or api_compat.
+	return Preset{
+		Name:        "gemini",
+		Description: PresetDescription{Summary: "Gemini 3 Flash — Google's multimodal model, tool calls, vision", Tier: "3"},
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{
+				"provider": "gemini", "model": "gemini-3-flash-preview",
+				"api_key": nil, "api_key_env": "GEMINI_API_KEY",
+			},
+			// Gemini is multimodal/vision-capable — image inputs are
+			// handled natively by the model. For audio analysis use the
+			// `listen` skill; for media creation register a provider's
+			// MCP server via `mcp-manual`.
+			"capabilities": map[string]interface{}{
+				"file": e(), "bash": map[string]interface{}{"yolo": true},
+				"web_search": map[string]interface{}{"provider": "duckduckgo"},
+				"codex": e(),
+				"avatar": e(), "daemon": e(),
+				"library": libraryDefault(),
+			},
+			"admin":     map[string]interface{}{"karma": true},
+			"streaming": true,
 		},
 	}
 }

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -54,8 +54,8 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 			t.Fatalf("RefreshTemplates() error: %v", err)
 		}
 		presets, _ := List()
-		if len(presets) != 8 {
-			t.Fatalf("expected 8 presets, got %d", len(presets))
+		if len(presets) != 9 {
+			t.Fatalf("expected 9 presets, got %d", len(presets))
 		}
 		names := map[string]bool{}
 		for _, p := range presets {


### PR DESCRIPTION
## Summary

Adds a new `gemini` built-in preset to the TUI, using Google's Gemini 3 Flash model (`gemini-3-flash-preview`) with the kernel's native Gemini adapter.

## Changes

- **`tui/internal/preset/preset.go`**: Added `geminiPreset()` function with Gemini-specific configuration
- **`tui/internal/preset/preset_test.go`**: Updated preset count from 8 → 9

## Key Details

| Field | Value |
|-------|-------|
| Provider | `gemini` (native adapter, not OpenAI-compat) |
| Model | `gemini-3-flash-preview` |
| API Key Env | `GEMINI_API_KEY` |
| Streaming | ✅ enabled |
| Vision | ✅ native multimodal |
| Tier | 3 (strong & value-priced) |

## Differences from DeepSeek preset

- Uses native Gemini provider — no `base_url` or `api_compat` needed
- Streaming enabled (Google supports streaming)
- Multimodal/vision-capable (image inputs handled natively by the model)

## Testing

- `go test ./tui/internal/preset/...` — all pass ✅
- `go build ./...` — succeeds ✅