### PR TITLE
fix(tui): refuse to launch when a lingtai run process already owns the workdir

### DIFF
--- a/tui/internal/process/check.go
+++ b/tui/internal/process/check.go
@@ -1,0 +1,40 @@
+package process
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// IsAgentRunning returns true if any `python -m lingtai run <agentDir>`
+// process exists on this machine. Independent of `.agent.heartbeat`: even
+// when the heartbeat file is missing or stale (a previous agent mid-teardown,
+// a crashed process, an old kernel version that unlinked the file early),
+// the lingering Python interpreter is still visible in `ps` and we can
+// refuse to spawn a duplicate.
+//
+// Used by LaunchAgent as a hard gate. Callers that want fast-path liveness
+// from the heartbeat freshness should use fs.IsAlive instead — this scan
+// shells out to ps and is meant for the launch boundary, not hot paths.
+func IsAgentRunning(agentDir string) bool {
+	abs, err := filepath.Abs(agentDir)
+	if err != nil {
+		abs = agentDir
+	}
+	out, err := exec.Command("ps", "-eo", "pid=,command=").Output()
+	if err != nil {
+		return false
+	}
+	needle := "lingtai run " + abs
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "lingtai run") {
+			continue
+		}
+		// Match either `... lingtai run <abs> ...` or `... lingtai run <abs>` (EOL).
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, needle+" ") || strings.HasSuffix(trimmed, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/tui/internal/process/launcher.go
+++ b/tui/internal/process/launcher.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,11 @@ import (
 	"github.com/anthropics/lingtai-tui/internal/migrate"
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
+
+// ErrAgentAlreadyRunning is returned by LaunchAgent when a `lingtai run`
+// process is already alive in the target workdir. Callers should surface this
+// to the user rather than re-attempting the launch.
+var ErrAgentAlreadyRunning = errors.New("a lingtai agent is already running in this workdir")
 
 func InitProject(lingtaiDir, globalDir string) error {
 	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
@@ -94,7 +100,17 @@ func resolvePython(agentDir, fallbackCmd string) string {
 
 // LaunchAgent starts an agent process. lingtaiCmd is the global fallback Python;
 // the agent's init.json venv_path is tried first.
+//
+// Refuses to launch if another `lingtai run <agentDir>` process is already
+// alive on this machine — this prevents the suspend→relaunch race where the
+// previous interpreter is still tearing down. Returns ErrAgentAlreadyRunning
+// in that case. The kernel's flock guarantees correctness of on-disk state,
+// but a duplicate Python process still shows up in `ps`/`lingtai-tui list`
+// and can mislead users; this guard keeps the process accounting honest.
 func LaunchAgent(lingtaiCmd, agentDir string) (*exec.Cmd, error) {
+	if IsAgentRunning(agentDir) {
+		return nil, ErrAgentAlreadyRunning
+	}
 	fs.CleanSignals(agentDir)
 	python := resolvePython(agentDir, lingtaiCmd)
 


### PR DESCRIPTION
## Summary

- The TUI's launch path used only `fs.IsAlive` (a freshness check on `.agent.heartbeat`) to decide whether to spawn a new agent. During a suspend→relaunch race, the previous interpreter unlinks `.agent.heartbeat` near the start of teardown but lingers in `ps` for 30–60 s. `IsAlive` returns false → a second agent is spawned → duplicate PIDs accumulate (observed 6 stacked PIDs in vivo).
- Add `process.IsAgentRunning(agentDir)` that scans `ps -eo pid,command` for `python -m lingtai run <agentDir>` and gate `LaunchAgent` on it. Returns `ErrAgentAlreadyRunning` when a duplicate is detected.
- Defense-in-depth alongside the kernel-side fix in `Lingtai-AI/lingtai-kernel#53` that keeps `.agent.heartbeat` fresh through teardown — the TUI guard also catches crashed processes, old kernel versions, and any future code path that bypasses `fs.IsAlive`.

## Why a `ps` scan and not flock-probing

Flock-probing the kernel's `.agent.lock` from Go would also work, but the user's request was explicit: *"always do check process in the same folder for lingtai CLI."* `ps` scanning matches that intent directly — and matches the existing `lingtai-tui list` / `lingtai-tui purge` parsers (which use the same shape).

## Test plan

- [ ] Launch agent in workdir A.
- [ ] Open a second TUI session, attempt to launch agent in workdir A → verify `ErrAgentAlreadyRunning` surfaces.
- [ ] Launch → suspend → immediately relaunch → verify second launch is refused while old Python interpreter is still in ps.
- [ ] After old interpreter exits, relaunch succeeds.
- [ ] Different workdir B is unaffected by an agent in A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)