### PR TITLE
feat(soul): change default soul delay to 7200s and enhance soul flow explanation

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -45,7 +45,7 @@
   "firstrun.context_limit": "Context limit",
   "firstrun.context_limit_hint": "max context window (applies to all agents)",
   "firstrun.soul_delay": "Soul delay",
-  "firstrun.soul_delay_hint": "seconds idle before agent thinks autonomously. Set low (60-300) for proactive agents, high to effectively silence it (applies to all agents)",
+  "firstrun.soul_delay_hint": "seconds idle before agent thinks autonomously (default: 7200 = 2h). Soul flow is the agent's subconscious — it reflects on recent work, consults past selves, and surfaces insights. Set low (60-300) for proactive agents, high (7200+) for batch/workhorse agents, very high to silence it (applies to all agents)",
   "firstrun.molt_pressure": "Molt pressure",
   "firstrun.molt_pressure_hint": "context % to trigger molt (applies to all agents)",
   "firstrun.max_rpm": "Max RPM",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -45,7 +45,7 @@
   "firstrun.context_limit": "识限",
   "firstrun.context_limit_hint": "上下文之限（施于诸灵）",
   "firstrun.soul_delay": "灵息",
-  "firstrun.soul_delay_hint": "闲几息后灵自省。小值(60-300)则灵愈自发，大值则近乎寂然（施于诸灵）",
+  "firstrun.soul_delay_hint": "闲几息后灵自省（默：7200 = 二时辰）。心流者灵之潜意也——反观近功、咨询往昔、浮现洞明。小值(60-300)则灵愈自发，大值(7200+)宜批量之灵，愈大则近乎寂然（施于诸灵）",
   "firstrun.molt_pressure": "蜕压",
   "firstrun.molt_pressure_hint": "凝蜕之门槛（施于诸灵）",
   "firstrun.max_rpm": "频限",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -45,7 +45,7 @@
   "firstrun.context_limit": "上下文上限",
   "firstrun.context_limit_hint": "最大上下文窗口（应用于所有器灵）",
   "firstrun.soul_delay": "心流间隔",
-  "firstrun.soul_delay_hint": "空闲多少秒后器灵自主思考。设小值(60-300)使器灵更主动，设大值则近乎静默（应用于所有器灵）",
+  "firstrun.soul_delay_hint": "空闲多少秒后器灵自主思考（默认：7200 = 2小时）。心流是器灵的潜意识——它会反思近期工作、咨询往昔之我、浮现洞见。设小值(60-300)使器灵更主动，大值(7200+)适合批量/工作型器灵，更大则近乎静默（应用于所有器灵）",
   "firstrun.molt_pressure": "凝蜕阈值",
   "firstrun.molt_pressure_hint": "触发凝蜕的上下文占比（应用于所有器灵）",
   "firstrun.max_rpm": "每分请求上限",

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1221,7 +1221,7 @@ func DefaultAgentOpts() AgentOpts {
 		Language:     "en",
 		Stamina:      36000,
 		ContextLimit: 200000,
-		SoulDelay:    999999,
+		SoulDelay:    7200,
 		MoltPressure: 0.8,
 		MaxRpm:       60,
 		Karma:        true,

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -137,7 +137,7 @@
     // -------------------------------------------------------
     // delay: seconds between soul ticks (subconscious reflection).
     // Higher = less frequent self-reflection, lower resource usage.
-    "soul": { "delay": 120 },
+    "soul": { "delay": 7200 },
 
     // -------------------------------------------------------
     // Lifecycle limits


### PR DESCRIPTION
## Summary
- Change default SoulDelay from 999999 (effectively off) to 7200 (2 hours)
- Enhance soul_delay_hint in all 3 i18n files to explain what soul flow actually does

## Why 7200?
- 999999 = effectively off, agents never think autonomously
- 7200 (2h) = good balance for most agents: periodic reflection without being intrusive
- Users can still set low (60-300) for proactive agents or very high to silence it

## Changes
| File | Change |
|------|--------|
|  | : 999999 → 7200 |
|  | Enhanced hint: explains subconscious, past-self consultation, insight surfacing |
|  | Enhanced hint: 心流是器灵的潜意识——反思近期工作、咨询往昔之我、浮现洞见 |
|  | Enhanced hint: 心流者灵之潜意也——反观近功、咨询往昔、浮现洞明 |

All preset tests pass.