### PR TITLE
feat(preset-editor): make codex and library mandatory capabilities

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -45,7 +45,7 @@
   "firstrun.context_limit": "Context limit",
   "firstrun.context_limit_hint": "max context window (applies to all agents)",
   "firstrun.soul_delay": "Soul delay",
-  "firstrun.soul_delay_hint": "seconds idle before agent thinks autonomously. Set low (60-300) for proactive agents, high to effectively silence it (applies to all agents)",
+  "firstrun.soul_delay_hint": "seconds idle before agent thinks autonomously (default: 7200 = 2h). Soul flow is the agent's subconscious — it reflects on recent work, consults past selves, and surfaces insights. Set low (60-300) for proactive agents, high (7200+) for batch/workhorse agents, very high to silence it (applies to all agents)",
   "firstrun.molt_pressure": "Molt pressure",
   "firstrun.molt_pressure_hint": "context % to trigger molt (applies to all agents)",
   "firstrun.max_rpm": "Max RPM",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -45,7 +45,7 @@
   "firstrun.context_limit": "识限",
   "firstrun.context_limit_hint": "上下文之限（施于诸灵）",
   "firstrun.soul_delay": "灵息",
-  "firstrun.soul_delay_hint": "闲几息后灵自省。小值(60-300)则灵愈自发，大值则近乎寂然（施于诸灵）",
+  "firstrun.soul_delay_hint": "闲几息后灵自省（默：7200 = 二时辰）。心流者灵之潜意也——反观近功、咨询往昔、浮现洞明。小值(60-300)则灵愈自发，大值(7200+)宜批量之灵，愈大则近乎寂然（施于诸灵）",
   "firstrun.molt_pressure": "蜕压",
   "firstrun.molt_pressure_hint": "凝蜕之门槛（施于诸灵）",
   "firstrun.max_rpm": "频限",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -45,7 +45,7 @@
   "firstrun.context_limit": "上下文上限",
   "firstrun.context_limit_hint": "最大上下文窗口（应用于所有器灵）",
   "firstrun.soul_delay": "心流间隔",
-  "firstrun.soul_delay_hint": "空闲多少秒后器灵自主思考。设小值(60-300)使器灵更主动，设大值则近乎静默（应用于所有器灵）",
+  "firstrun.soul_delay_hint": "空闲多少秒后器灵自主思考（默认：7200 = 2小时）。心流是器灵的潜意识——它会反思近期工作、咨询往昔之我、浮现洞见。设小值(60-300)使器灵更主动，大值(7200+)适合批量/工作型器灵，更大则近乎静默（应用于所有器灵）",
   "firstrun.molt_pressure": "凝蜕阈值",
   "firstrun.molt_pressure_hint": "触发凝蜕的上下文占比（应用于所有器灵）",
   "firstrun.max_rpm": "每分请求上限",

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1221,7 +1221,7 @@ func DefaultAgentOpts() AgentOpts {
 		Language:     "en",
 		Stamina:      36000,
 		ContextLimit: 200000,
-		SoulDelay:    999999,
+		SoulDelay:    7200,
 		MoltPressure: 0.8,
 		MaxRpm:       60,
 		Karma:        true,

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -137,7 +137,7 @@
     // -------------------------------------------------------
     // delay: seconds between soul ticks (subconscious reflection).
     // Higher = less frequent self-reflection, lower resource usage.
-    "soul": { "delay": 120 },
+    "soul": { "delay": 7200 },
 
     // -------------------------------------------------------
     // Lifecycle limits

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -53,10 +53,8 @@ const (
 	feCapFile
 	feCapBash
 	feCapWebSearch
-	feCapCodex
 	feCapAvatar
 	feCapDaemon
-	feCapLibrary
 	feCapVision
 	feStreaming
 	feKarma
@@ -67,28 +65,27 @@ const (
 // capFieldNames maps each capability field to its underlying capability
 // key. Order matches editorCapabilities and editorFieldOrder so the
 // vision row stays last visually and feCapVision is the only model-
-// conditional row.
+// conditional row. codex and library are mandatory — always present,
+// not shown as toggleable options.
 var capFieldNames = map[editorField]string{
 	feCapFile:      "file",
 	feCapBash:      "bash",
 	feCapWebSearch: "web_search",
-	feCapCodex:     "codex",
 	feCapAvatar:    "avatar",
 	feCapDaemon:    "daemon",
-	feCapLibrary:   "library",
 	feCapVision:    "vision",
 }
 
 // editorFieldOrder is the rendering order of fields. The cursor walks
 // this slice; section headers render between transitions. Capability
-// rows split into core (file/bash/codex/avatar/daemon/library) and
-// extras (web_search/vision) — email and psyche are intrinsics, always
-// present, so they don't appear here.
+// rows split into core (file/bash/avatar/daemon) and extras
+// (web_search/vision) — email, psyche, codex, and library are always
+// present (intrinsics or mandatory), so they don't appear here.
 var editorFieldOrder = []editorField{
 	feName, feSummary, feTier, feGains, feLoses,
 	feProvider, feModel, feAPICompat, feBaseURL, feAPIKey,
-	feCapFile, feCapBash, feCapCodex,
-	feCapAvatar, feCapDaemon, feCapLibrary,
+	feCapFile, feCapBash,
+	feCapAvatar, feCapDaemon,
 	feCapWebSearch, feCapVision,
 	feSave,
 }
@@ -175,12 +172,12 @@ var modelHasVision = map[string]bool{
 	"gpt-5.2":       true,
 }
 
-// coreCapabilities are the always-on building blocks every agent
-// shares — filesystem, shell, mailbox, knowledge, parallelism. No
-// provider knobs, not model-conditional.
+// coreCapabilities are the toggleable building blocks shown as checkboxes
+// in the editor. codex and library are mandatory (always injected at save),
+// so they do not appear here. No provider knobs, not model-conditional.
 var coreCapabilities = []string{
-	"file", "bash", "codex",
-	"avatar", "daemon", "library",
+	"file", "bash",
+	"avatar", "daemon",
 }
 
 // extraCapabilities are provider/model-conditional. web_search picks
@@ -580,8 +577,8 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 	case feTier:
 		// Tier is an enum — Enter cycles like ←/→. No picker overlay.
 		m.cycleFocused(+1)
-	case feCapFile, feCapBash, feCapCodex,
-		feCapAvatar, feCapDaemon, feCapLibrary, feCapWebSearch, feCapVision:
+	case feCapFile, feCapBash,
+		feCapAvatar, feCapDaemon, feCapWebSearch, feCapVision:
 		// Capability rows: Enter toggles, same as Space. Disabled rows
 		// (e.g. vision on text-only models) are gated inside toggleFocused.
 		m.toggleFocused()
@@ -939,6 +936,18 @@ func (m PresetEditorModel) commit() (PresetEditorModel, tea.Cmd) {
 	// differs from the template's name), respect that name. Otherwise
 	// gap-fill the next "<template>-N" slot.
 	committed := clonePresetForEditor(m.working)
+	// Ensure codex and library are always present — they are mandatory
+	// capabilities not exposed as toggles in the editor UI.
+	if caps, ok := committed.Manifest["capabilities"].(map[string]interface{}); ok {
+		if _, has := caps["codex"]; !has {
+			caps["codex"] = map[string]interface{}{}
+		}
+		if _, has := caps["library"]; !has {
+			caps["library"] = map[string]interface{}{
+				"paths": []interface{}{"../.library_shared", "~/.lingtai-tui/utilities"},
+			}
+		}
+	}
 	if m.isBuiltin && (m.hasSemanticEdits() || m.apiKeySet) {
 		if committed.Name == m.original.Name {
 			existing, _ := preset.List()


### PR DESCRIPTION
## Summary

Codex and library are now mandatory capabilities in the preset editor — they're always injected during commit() and no longer shown as toggleable options.

### Changes
- Removed  and  from editor field order and capability maps
- Added mandatory injection in : codex gets empty config, library gets default paths
- Build and tests pass

### Motivation
These capabilities are fundamental to the Lingtai agent system and should always be present.