### PR TITLE
fix(tui): make codex and library mandatory in firstrun wizard

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -3335,6 +3335,15 @@ func (m *FirstRunModel) applyCapSelections() {
 			delete(caps, name)
 		}
 	}
+	// Codex and library are mandatory — always present regardless of user toggles.
+	if _, exists := caps["codex"]; !exists {
+		caps["codex"] = map[string]interface{}{}
+	}
+	if _, exists := caps["library"]; !exists {
+		caps["library"] = map[string]interface{}{
+			"paths": []interface{}{"../.library_shared", "~/.lingtai-tui/utilities"},
+		}
+	}
 }
 
 // enterAgentNameDir initialises all fields and transitions to stepAgentNameDir.

--- a/tui/internal/tui/presets.go
+++ b/tui/internal/tui/presets.go
@@ -7,10 +7,11 @@ type UsePresetMsg struct {
 
 // AllCapabilities is the list of all available capability names.
 // email and psyche are kernel intrinsics (always loaded), not capabilities.
+// codex and library are mandatory — always injected at save time, not shown as toggleable.
 var AllCapabilities = []string{
-	"file", "bash", "web_search", "codex",
+	"file", "bash", "web_search",
 	"vision",
-	"avatar", "daemon", "library",
+	"avatar", "daemon",
 }
 
 // AllAddons is the list of available addon names.


### PR DESCRIPTION
AllCapabilities still listed codex and library as toggleable options in the firstrun wizard.\n\nChanges:\n1. Remove codex/library from AllCapabilities in presets.go\n2. Inject codex/library as mandatory in applyCapSelections() in firstrun.go\n\nThis matches the behavior already implemented in preset_editor.go (commit c08fe31).