### PR TITLE
fix(#69): stop writing deprecated soul_file to init.json

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1431,11 +1431,6 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	if proceduresFile == "" {
 		proceduresFile = ProceduresPath(globalDir, lang)
 	}
-	soulFile := opts.SoulFile
-	if soulFile == "" {
-		soulFile = SoulFlowPath(globalDir, lang)
-	}
-
 	// Load existing init.json addons + mcp fields so we preserve them across
 	// regens. Critical for /setup: when the user changes non-addon settings,
 	// existing addon registrations and MCP activations must not be dropped.
@@ -1472,7 +1467,6 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 		"covenant_file":    covenantFile,
 		"principle_file":   principleFile,
 		"procedures_file":  proceduresFile,
-		"soul_file":        soulFile,
 		"env_file":       config.EnvFilePath(globalDir),
 		"venv_path":      filepath.Join(globalDir, "runtime", "venv"),
 		"pad":            "",

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -468,7 +468,7 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 	// inner shape — every consumer does p.Manifest["language"], ["llm"],
 	// ["capabilities"], etc. — so we extract the inner manifest dict.
 	// Stash the outer dict separately so enterAgentNameDir can read fields
-	// like covenant_file / principle_file / soul_file that live at top level.
+	// like covenant_file / principle_file that live at top level.
 	if orchDir != "" {
 		initPath := filepath.Join(orchDir, "init.json")
 		if data, err := os.ReadFile(initPath); err == nil {


### PR DESCRIPTION
## Fix for #69

**Problem:** The TUI writes `soul_file` as a top-level field in `init.json`, but the kernel retired this field in v0.7.6. This causes a `unknown top-level field: soul_file` warning on every `system(action='refresh')`.

**Changes (TUI - this PR):**
- Remove `soul_file` from the `initJSON` map in `preset.go:1470`
- Remove the now-unused `soulFile` variable computation
- Update comment in `firstrun.go`

**Changes (Kernel - already pushed to main):**
- Add `soul` and `soul_file` to `TOP_KNOWN` in `init_schema.py` so existing configs are silently ignored

**Testing:**
- `go build ./...` passes (TUI)
- All 47 init_schema tests pass (kernel)

Closes #69