### PR TITLE
chore(#69): remove deprecated soul/soul_file from templates and examples

### DIFF
--- a/examples/init.jsonc
+++ b/examples/init.jsonc
@@ -219,11 +219,6 @@
   "pad": "",
   // Or use a file: "pad_file": "pad.md"
 
-  // Soul flow — the agent's subconscious inner monologue prompt.
-  // Shapes the periodic self-reflection triggered by soul.delay.
-  "soul": "",
-  // Or use a file: "soul_file": "soul-flow.md"
-
   // First message — what the agent sees when it wakes up.
   // This is the initial user prompt that starts the conversation.
   "prompt": "Hello! How can I help you today?"

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -286,11 +286,6 @@
   "pad": "",
   // Or use a file: "pad_file": "pad.md"
 
-  // Soul flow — the agent's subconscious inner monologue prompt.
-  // Shapes the periodic self-reflection triggered by soul.delay.
-  "soul": "",
-  // Or use a file: "soul_file": "soul-flow.md"
-
   // First message — what the agent sees when it wakes up.
   // This is the initial user prompt that starts the conversation.
   "prompt": "Hello! How can I help you today?"


### PR DESCRIPTION
Follow-up to PR #70. Removes remaining  references from JSONC templates and example files.

Changes:
-  — removed soul/soul_file block
-  — removed soul/soul_file block

Documentation-only; no functional change.