### PR TITLE
feat: add 'lingtai' alias for 'lingtai-tui'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,10 @@ jobs:
                 ldflags = "-X main.version=#{version}"
                 system "go", "build", *std_go_args(ldflags: ldflags), "-o", bin/"lingtai-tui", "."
                 # Create 'lingtai' alias for backward compatibility
-                bin.install_symlink "lingtai-tui" => "lingtai"
+                # Only if 'lingtai' doesn't exist or is already a symlink to lingtai-tui
+                unless (bin/"lingtai").exist? && (!(bin/"lingtai").symlink? || (bin/"lingtai").readlink.to_s != "lingtai-tui")
+                  bin.install_symlink "lingtai-tui" => "lingtai"
+                end
               end
 
               cd "portal" do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
               cd "tui" do
                 ldflags = "-X main.version=#{version}"
                 system "go", "build", *std_go_args(ldflags: ldflags), "-o", bin/"lingtai-tui", "."
+                # Create 'lingtai' alias for backward compatibility
+                bin.install_symlink "lingtai-tui" => "lingtai"
               end
 
               cd "portal" do
@@ -92,6 +94,7 @@ jobs:
 
             test do
               assert_match "lingtai-tui", shell_output("#{bin}/lingtai-tui version 2>&1", 0)
+              assert_match "lingtai-tui", shell_output("#{bin}/lingtai version 2>&1", 0)
             end
           end
           FORMULA

--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,8 @@ fi
 
 echo "==> Installing to $BIN_DIR ..."
 install -m 755 "$BUILD_DIR/lingtai-tui" "$BIN_DIR/lingtai-tui"
+# Create 'lingtai' alias for backward compatibility
+ln -sf "$BIN_DIR/lingtai-tui" "$BIN_DIR/lingtai"
 if [[ -f "$BUILD_DIR/lingtai-portal" ]]; then
   install -m 755 "$BUILD_DIR/lingtai-portal" "$BIN_DIR/lingtai-portal"
 fi

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,12 @@ fi
 echo "==> Installing to $BIN_DIR ..."
 install -m 755 "$BUILD_DIR/lingtai-tui" "$BIN_DIR/lingtai-tui"
 # Create 'lingtai' alias for backward compatibility
-ln -sf "$BIN_DIR/lingtai-tui" "$BIN_DIR/lingtai"
+# Only if 'lingtai' doesn't exist or is already a symlink to lingtai-tui
+if [[ ! -e "$BIN_DIR/lingtai" ]] || [[ -L "$BIN_DIR/lingtai" && "$(readlink "$BIN_DIR/lingtai")" == "$BIN_DIR/lingtai-tui" ]]; then
+  ln -sfn "$BIN_DIR/lingtai-tui" "$BIN_DIR/lingtai"
+else
+  echo "  (skipping 'lingtai' alias — $BIN_DIR/lingtai already exists)"
+fi
 if [[ -f "$BUILD_DIR/lingtai-portal" ]]; then
   install -m 755 "$BUILD_DIR/lingtai-portal" "$BIN_DIR/lingtai-portal"
 fi

--- a/tui/Makefile
+++ b/tui/Makefile
@@ -5,13 +5,15 @@ LDFLAGS := -X main.version=$(VERSION)
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o bin/lingtai-tui .
+	@cd bin && ln -sf lingtai-tui lingtai
 
 # Fast local rebuild. The Homebrew binary at /opt/homebrew/bin/lingtai-tui is
 # already a symlink to bin/lingtai-tui, so `make dev` immediately updates the
 # installed TUI. Skips version stamp for speed; tags `dev` build.
 dev:
 	go build -ldflags "-X main.version=dev" -o bin/lingtai-tui .
-	@echo "built bin/lingtai-tui (dev) — run: lingtai-tui"
+	@cd bin && ln -sf lingtai-tui lingtai
+	@echo "built bin/lingtai-tui (dev) — run: lingtai-tui or lingtai"
 
 cross-compile:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/lingtai-darwin-arm64 .

--- a/tui/Makefile
+++ b/tui/Makefile
@@ -5,14 +5,14 @@ LDFLAGS := -X main.version=$(VERSION)
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o bin/lingtai-tui .
-	@cd bin && ln -sf lingtai-tui lingtai
+	@cd bin && ln -sfn lingtai-tui lingtai
 
 # Fast local rebuild. The Homebrew binary at /opt/homebrew/bin/lingtai-tui is
 # already a symlink to bin/lingtai-tui, so `make dev` immediately updates the
 # installed TUI. Skips version stamp for speed; tags `dev` build.
 dev:
 	go build -ldflags "-X main.version=dev" -o bin/lingtai-tui .
-	@cd bin && ln -sf lingtai-tui lingtai
+	@cd bin && ln -sfn lingtai-tui lingtai
 	@echo "built bin/lingtai-tui (dev) — run: lingtai-tui or lingtai"
 
 cross-compile:


### PR DESCRIPTION
Add 'lingtai' symlink to 'lingtai-tui' for backward compatibility. Users can run either name.