### PR TITLE
Shorten human-origin mailbox ids

### DIFF
--- a/portal/internal/fs/ANATOMY.md
+++ b/portal/internal/fs/ANATOMY.md
@@ -32,11 +32,13 @@ The portal's read-focused window into a `.lingtai/` project directory. Same shap
 - `IsAliveHuman()` (`heartbeat.go:24-26`) — always true.
 
 ### Mail (`mail.go`)
-- `ReadInbox(dir)`, `ReadArchive(dir)` (`mail.go:14-20`) — full-folder reads.
-- `MailCache` struct + `NewMailCache(humanDir)` (`mail.go:24-40`) — incremental mailbox cache tracking inbox+seen UUID directories.
-- `MailCache.Refresh()` (`mail.go:43-70`) — immutable refresh: scans for new messages, merges, sorts by `ReceivedAt`. Safe for goroutine use.
-- `WriteMail(recipientDir, senderDir, ...)` (`mail.go:141-207`) — writes message to inbox (local) or outbox (pseudo-agent/remote), plus sent copy. Respects the pseudo-agent contract: if sender has `admin: null`, writes to outbox only.
-- `isPseudoAgent(identity)` (`mail.go:209-222`) — `admin` nil or absent → true.
+- `newMailboxID()` (`mail.go:32`) — builds `YYYYMMDDTHHMMSS-xxxx` short id matching the kernel's `_new_mailbox_id`.
+- `ReadInbox(dir)`, `ReadArchive(dir)` (`mail.go:36-40`) — full-folder reads.
+- `MailCache` struct + `NewMailCache(humanDir)` (`mail.go:46-55`) — incremental mailbox cache tracking inbox+seen mailbox-id directories.
+- `MailCache.Refresh()` (`mail.go:66-91`) — immutable refresh: scans for new messages, merges, sorts by `ReceivedAt`. Safe for goroutine use.
+- `prepareMailDirs(primaryParent, sentParent)` (`mail.go:176`) — allocates a short id and creates every mailbox leaf the send will write, retrying on collisions in any target folder.
+- `WriteMail(recipientDir, senderDir, ...)` (`mail.go:214`) — writes message to inbox (local) or outbox (pseudo-agent/remote), plus sent copy. Allocates id via `prepareMailDirs`. Respects the pseudo-agent contract: if sender has `admin: null`, writes to outbox only.
+- `isPseudoAgent(identity)` (`mail.go:279`) — `admin` nil or absent → true.
 
 ### Ledger (`ledger.go`)
 - `ReadLedger(dir)` (`ledger.go:17-47`) — scans `delegates/ledger.jsonl` for `event: "avatar"` records, returns `AvatarEdge` pairs and resolved child directories.
@@ -92,7 +94,8 @@ All state is read from the project's `.lingtai/` directory. The portal only writ
 ## Notes
 
 - **`reconstruct.go` is the portal-specific addition.** The TUI shows live topology; the portal reconstructs historical topology tapes from `events.jsonl` + mailbox data. The reconstruction replays agent states chronologically at 3-second intervals, with agents appearing when their first event fires and mail accumulating cumulatively. This is the data source for the `/replay` endpoint.
-- **`MailCache`** tracks already-loaded messages via UUID directory names, enabling incremental refreshes without re-reading the entire mailbox. It is immutable by convention — `Refresh()` returns a new cache rather than mutating the receiver, so it's safe to call from a goroutine.
+- **Mailbox id shape.** `WriteMail` allocates short, human-scannable ids of the form `YYYYMMDDTHHMMSS-xxxx` (20 chars, UTC, 4 hex chars of UUID4 entropy) via `newMailboxID`. This matches the kernel's `_new_mailbox_id` in `lingtai-kernel/src/lingtai_kernel/intrinsics/email/primitives.py` and the TUI's mirror in `tui/internal/fs/mail.go`, so directory names, `id`, and `_mailbox_id` look identical regardless of which side wrote the message. `prepareMailDirs` uses `os.Mkdir` (not `MkdirAll`) on each leaf so same-second collisions in any target folder surface as `fs.ErrExist` and trigger up to 8 regenerations without overwriting existing mail.
+- **`MailCache`** tracks already-loaded messages via mailbox-id directory names, enabling incremental refreshes without re-reading the entire mailbox. It is immutable by convention — `Refresh()` returns a new cache rather than mutating the receiver, so it's safe to call from a goroutine.
 - **`IsAlive`** uses a 2-second threshold. A stale heartbeat forces state to `SUSPENDED` in `BuildNetwork`.
 - **Atomic writes** (location, signals) use temp-file + rename, matching the kernel's filesystem contract.
 - **Capability parsing** handles both `[]string` (from TUI-generated presets) and tuple format (from live agents), so the portal works with projects the TUI hasn't touched.

--- a/portal/internal/fs/mail.go
+++ b/portal/internal/fs/mail.go
@@ -17,7 +17,7 @@ import (
 // (`YYYYMMDDTHHMMSS-xxxx`, 20 chars, UTC) matches the kernel helper
 // `_new_mailbox_id` in `lingtai_kernel/intrinsics/email/primitives.py` so
 // mail written by either side is indistinguishable in `email(check)` output.
-// The 4-hex suffix is drawn from `uuid.NewRandom` (a v4 UUID); 16 bits of
+// The 4-hex suffix is drawn from `uuid.New` (a v4 UUID); 16 bits of
 // entropy per second is enough for human-paced sends and the WriteMail
 // collision-retry loop covers the rare burst case.
 var mailboxIDSource = func() string {

--- a/portal/internal/fs/mail.go
+++ b/portal/internal/fs/mail.go
@@ -2,7 +2,9 @@ package fs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,6 +12,26 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// newMailboxID builds a sortable, human-scannable mailbox id. The format
+// (`YYYYMMDDTHHMMSS-xxxx`, 20 chars, UTC) matches the kernel helper
+// `_new_mailbox_id` in `lingtai_kernel/intrinsics/email/primitives.py` so
+// mail written by either side is indistinguishable in `email(check)` output.
+// The 4-hex suffix is drawn from `uuid.NewRandom` (a v4 UUID); 16 bits of
+// entropy per second is enough for human-paced sends and the WriteMail
+// collision-retry loop covers the rare burst case.
+var mailboxIDSource = func() string {
+	ts := time.Now().UTC().Format("20060102T150405")
+	// `uuid.New().String()` returns `xxxxxxxx-xxxx-...` — the first 4 hex
+	// chars come before any dash, so this mirrors the kernel's
+	// `uuid.uuid4().hex[:4]` slicing.
+	suffix := uuid.New().String()[:4]
+	return ts + "-" + suffix
+}
+
+func newMailboxID() string {
+	return mailboxIDSource()
+}
 
 func ReadInbox(dir string) ([]MailMessage, error) {
 	return readMailFolder(filepath.Join(dir, "mailbox", "inbox"))
@@ -22,8 +44,8 @@ func ReadArchive(dir string) ([]MailMessage, error) {
 // MailCache tracks already-loaded messages for incremental refresh.
 // Each Refresh call reads only new messages from disk.
 type MailCache struct {
-	inboxSeen map[string]struct{} // UUID dirs already loaded from inbox
-	sentSeen  map[string]struct{} // UUID dirs already loaded from sent
+	inboxSeen map[string]struct{} // mailbox id dirs already loaded from inbox
+	sentSeen  map[string]struct{} // mailbox id dirs already loaded from sent
 	Messages  []MailMessage       // full sorted merged slice (inbox + sent)
 	inboxDir  string
 	sentDir   string
@@ -69,7 +91,7 @@ func (c MailCache) Refresh() MailCache {
 	return out
 }
 
-// scanFolder reads UUID directories not yet in seen, loads their message.json,
+// scanFolder reads mailbox-id directories not yet in seen, loads their message.json,
 // and appends to Messages.
 func (c *MailCache) scanFolder(folder string, seen map[string]struct{}) {
 	entries, err := os.ReadDir(folder)
@@ -138,13 +160,83 @@ func readManifestAsIdentity(dir string) map[string]interface{} {
 	return manifest
 }
 
-func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) error {
-	id := uuid.New().String()
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+// mailboxIDCollisionRetries is the per-folder attempt budget for
+// `prepareMailDirs`. The short ID has 16 bits of entropy in the
+// suffix, so a same-second send has a 1/65536 chance of colliding;
+// 8 retries reduces the practical failure probability to negligible while
+// still terminating quickly when the filesystem is genuinely failing.
+const mailboxIDCollisionRetries = 8
 
+// prepareMailDirs allocates an id and creates every mailbox leaf that will
+// receive this message. Non-pseudo sends write both the primary folder and the
+// sender's sent/ folder, so the id must be free in both places; otherwise a
+// same-second suffix collision in sent/ could overwrite an existing sent
+// record. On a collision in any target folder the partial leaves from that
+// attempt are removed and a fresh id is generated.
+func prepareMailDirs(primaryParent string, sentParent string) (string, string, string, error) {
+	if err := os.MkdirAll(primaryParent, 0o755); err != nil {
+		return "", "", "", fmt.Errorf("create primary mailbox parent: %w", err)
+	}
+	if sentParent != "" {
+		if err := os.MkdirAll(sentParent, 0o755); err != nil {
+			return "", "", "", fmt.Errorf("create sent mailbox parent: %w", err)
+		}
+	}
+	var lastErr error
+	for i := 0; i < mailboxIDCollisionRetries; i++ {
+		id := newMailboxID()
+		primaryDir := filepath.Join(primaryParent, id)
+		if err := os.Mkdir(primaryDir, 0o755); err != nil {
+			if !errors.Is(err, iofs.ErrExist) {
+				return "", "", "", fmt.Errorf("create primary mailbox leaf: %w", err)
+			}
+			lastErr = err
+			continue
+		}
+		if sentParent == "" {
+			return id, primaryDir, "", nil
+		}
+		sentDir := filepath.Join(sentParent, id)
+		if err := os.Mkdir(sentDir, 0o755); err != nil {
+			_ = os.Remove(primaryDir)
+			if !errors.Is(err, iofs.ErrExist) {
+				return "", "", "", fmt.Errorf("create sent mailbox leaf: %w", err)
+			}
+			lastErr = err
+			continue
+		}
+		return id, primaryDir, sentDir, nil
+	}
+	return "", "", "", fmt.Errorf("create mailbox leaves: exhausted %d retries: %w",
+		mailboxIDCollisionRetries, lastErr)
+}
+
+func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) error {
 	// Read sender's manifest as identity card (same as Python agents do)
 	identity := readManifestAsIdentity(senderDir)
 
+	// Allocate every mailbox directory before writing JSON so the chosen id is
+	// unique across all folders this send will touch. Pseudo-agent sends write
+	// only outbox; non-pseudo sends also write sender sent/ with the same id.
+	var primaryParent string
+	pseudo := isPseudoAgent(identity)
+	switch {
+	case pseudo, IsRemoteAddress(toAddr):
+		primaryParent = filepath.Join(senderDir, "mailbox", "outbox")
+	default:
+		primaryParent = filepath.Join(recipientDir, "mailbox", "inbox")
+	}
+	sentParent := ""
+	if !pseudo {
+		sentParent = filepath.Join(senderDir, "mailbox", "sent")
+	}
+
+	id, primaryDir, sentDir, err := prepareMailDirs(primaryParent, sentParent)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
 	msg := MailMessage{
 		ID:         id,
 		MailboxID:  id,
@@ -163,42 +255,16 @@ func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) 
 		return fmt.Errorf("marshal message: %w", err)
 	}
 
-	// Pseudo-agent branch: if sender's .agent.json has admin: null (or no
-	// manifest), write only to the sender's outbox. Subscribed real agents
-	// poll the outbox and produce the sent entry via atomic rename on pickup.
-	if isPseudoAgent(identity) {
-		outboxDir := filepath.Join(senderDir, "mailbox", "outbox", id)
-		if err := os.MkdirAll(outboxDir, 0o755); err != nil {
-			return fmt.Errorf("create outbox dir: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(outboxDir, "message.json"), data, 0o644); err != nil {
-			return fmt.Errorf("write outbox message: %w", err)
-		}
+	if err := os.WriteFile(filepath.Join(primaryDir, "message.json"), data, 0o644); err != nil {
+		return fmt.Errorf("write primary message: %w", err)
+	}
+
+	// Pseudo-agent branch: no sent/ copy at send time. The subscribed real
+	// agent's pickup will produce the sent entry via atomic rename.
+	if pseudo {
 		return nil
 	}
 
-	if IsRemoteAddress(toAddr) {
-		outboxDir := filepath.Join(senderDir, "mailbox", "outbox", id)
-		if err := os.MkdirAll(outboxDir, 0o755); err != nil {
-			return fmt.Errorf("create outbox dir: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(outboxDir, "message.json"), data, 0o644); err != nil {
-			return fmt.Errorf("write outbox message: %w", err)
-		}
-	} else {
-		inboxDir := filepath.Join(recipientDir, "mailbox", "inbox", id)
-		if err := os.MkdirAll(inboxDir, 0o755); err != nil {
-			return fmt.Errorf("create inbox dir: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(inboxDir, "message.json"), data, 0o644); err != nil {
-			return fmt.Errorf("write inbox message: %w", err)
-		}
-	}
-
-	sentDir := filepath.Join(senderDir, "mailbox", "sent", id)
-	if err := os.MkdirAll(sentDir, 0o755); err != nil {
-		return fmt.Errorf("create sent dir: %w", err)
-	}
 	if err := os.WriteFile(filepath.Join(sentDir, "message.json"), data, 0o644); err != nil {
 		return fmt.Errorf("write sent message: %w", err)
 	}

--- a/portal/internal/fs/mail_test.go
+++ b/portal/internal/fs/mail_test.go
@@ -1,0 +1,215 @@
+package fs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// mailboxIDPattern matches the short mailbox id shape produced by
+// newMailboxID and the kernel's `_new_mailbox_id`: 14 digits, a `T`, 6
+// digits, a dash, then 4 lowercase hex chars (20 chars total).
+var mailboxIDPattern = regexp.MustCompile(`^\d{8}T\d{6}-[0-9a-f]{4}$`)
+
+func TestNewMailboxID_Shape(t *testing.T) {
+	id := newMailboxID()
+	if !mailboxIDPattern.MatchString(id) {
+		t.Fatalf("id = %q, want match of %s", id, mailboxIDPattern)
+	}
+	if len(id) != 20 {
+		t.Errorf("len(id) = %d, want 20", len(id))
+	}
+}
+
+func TestNewMailboxID_Sortable(t *testing.T) {
+	// Two ids generated back-to-back should sort either equal-prefix
+	// (same second) or strictly increasing. They must never be
+	// strictly less than each other in violation of monotonic time.
+	a := newMailboxID()
+	b := newMailboxID()
+	aPrefix, bPrefix := a[:15], b[:15] // YYYYMMDDTHHMMSS
+	if strings.Compare(bPrefix, aPrefix) < 0 {
+		t.Errorf("second id prefix %q < first %q — time went backwards", bPrefix, aPrefix)
+	}
+}
+
+// writePortalSenderManifest writes .agent.json with the given admin value
+// so WriteMail treats senderDir as a real agent (not pseudo).
+func writePortalSenderManifest(t *testing.T, dir string, admin interface{}) {
+	t.Helper()
+	manifest := map[string]interface{}{
+		"agent_name": "test-sender",
+		"admin":      admin,
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func TestWriteMail_ProducesShortMailboxID(t *testing.T) {
+	recipientDir := t.TempDir()
+	senderDir := t.TempDir()
+	writePortalSenderManifest(t, senderDir, map[string]interface{}{"karma": true})
+
+	if err := WriteMail(recipientDir, senderDir, "alice", "bob", "subj", "body"); err != nil {
+		t.Fatalf("WriteMail: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(recipientDir, "mailbox", "inbox"))
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox len = %d, want 1", len(entries))
+	}
+	name := entries[0].Name()
+	if !mailboxIDPattern.MatchString(name) {
+		t.Errorf("inbox dir name = %q, want match of %s", name, mailboxIDPattern)
+	}
+
+	// Verify message.json's id and _mailbox_id agree with the directory name.
+	data, err := os.ReadFile(filepath.Join(recipientDir, "mailbox", "inbox", name, "message.json"))
+	if err != nil {
+		t.Fatalf("read message.json: %v", err)
+	}
+	var msg MailMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ID != name {
+		t.Errorf("msg.ID = %q, want %q (directory name)", msg.ID, name)
+	}
+	if msg.MailboxID != name {
+		t.Errorf("msg.MailboxID = %q, want %q (directory name)", msg.MailboxID, name)
+	}
+
+	// Sent copy must reuse the same id.
+	sentEntries, err := os.ReadDir(filepath.Join(senderDir, "mailbox", "sent"))
+	if err != nil {
+		t.Fatalf("read sent: %v", err)
+	}
+	if len(sentEntries) != 1 || sentEntries[0].Name() != name {
+		t.Errorf("sent entries = %v, want [%q]", dirNames(sentEntries), name)
+	}
+}
+
+func TestPrepareMailDirs_AllocatesDistinctIDs(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "mailbox", "inbox")
+
+	// Pre-create a directory whose name our generator might produce.
+	// We cannot predict the suffix, so this only verifies the structural
+	// path: a single existing leaf must not stop the generator from
+	// allocating a *different* id and succeeding.
+	id1, _, _, err := prepareMailDirs(parent, "")
+	if err != nil {
+		t.Fatalf("first allocation: %v", err)
+	}
+	id2, _, _, err := prepareMailDirs(parent, "")
+	if err != nil {
+		t.Fatalf("second allocation: %v", err)
+	}
+	if id1 == id2 {
+		t.Errorf("collision: two sequential allocations returned the same id %q", id1)
+	}
+}
+
+func TestPrepareMailDirs_SentCollisionRetriesWithoutOverwrite(t *testing.T) {
+	root := t.TempDir()
+	primaryParent := filepath.Join(root, "recipient", "mailbox", "inbox")
+	sentParent := filepath.Join(root, "sender", "mailbox", "sent")
+	if err := os.MkdirAll(sentParent, 0o755); err != nil {
+		t.Fatalf("setup sent parent: %v", err)
+	}
+
+	ids := make([]string, mailboxIDCollisionRetries)
+	for i := range ids {
+		ids[i] = "20260511T224200-" + fmt.Sprintf("%04x", i)
+	}
+	sentinel := []byte("existing sent message")
+	reserved := make(map[string][]byte)
+	for _, id := range ids[:mailboxIDCollisionRetries-1] {
+		dir := filepath.Join(sentParent, id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("setup collided sent dir: %v", err)
+		}
+		msg := filepath.Join(dir, "message.json")
+		if err := os.WriteFile(msg, sentinel, 0o644); err != nil {
+			t.Fatalf("setup collided sent message: %v", err)
+		}
+		reserved[msg] = sentinel
+	}
+
+	oldSource := mailboxIDSource
+	next := 0
+	mailboxIDSource = func() string {
+		id := ids[next]
+		if next < len(ids)-1 {
+			next++
+		}
+		return id
+	}
+	t.Cleanup(func() { mailboxIDSource = oldSource })
+
+	id, primaryDir, sentDir, err := prepareMailDirs(primaryParent, sentParent)
+	if err != nil {
+		t.Fatalf("prepareMailDirs: %v", err)
+	}
+	if id != ids[len(ids)-1] {
+		t.Fatalf("id = %q, want final retry id %q", id, ids[len(ids)-1])
+	}
+	if filepath.Base(primaryDir) != id || filepath.Base(sentDir) != id {
+		t.Fatalf("dirs do not share id: id=%q primary=%q sent=%q", id, primaryDir, sentDir)
+	}
+	for msg, want := range reserved {
+		got, err := os.ReadFile(msg)
+		if err != nil {
+			t.Fatalf("reserved message missing: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("reserved sent message %s was overwritten", msg)
+		}
+	}
+}
+
+func TestPrepareMailDirs_ExhaustionReportsError(t *testing.T) {
+	// Pre-create every possible leaf for the current second. Because we
+	// cannot enumerate 65,536 suffixes feasibly, the more practical test is
+	// to simulate exhaustion by making the parent un-writable so every
+	// `os.Mkdir` fails with a non-IsExist error — which surfaces as a
+	// wrapped error rather than retrying forever.
+	if os.Getuid() == 0 {
+		t.Skip("running as root — chmod 0 won't deny Mkdir")
+	}
+	parent := filepath.Join(t.TempDir(), "mailbox", "inbox")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	_, _, _, err := prepareMailDirs(parent, "")
+	if err == nil {
+		t.Fatalf("expected error from un-writable parent, got nil")
+	}
+	if !strings.Contains(err.Error(), "create primary mailbox") {
+		t.Errorf("error = %v, want one wrapped by prepareMailDirs", err)
+	}
+}
+
+func dirNames(entries []os.DirEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}

--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -26,11 +26,13 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 | `IsAlive(dir, thresholdSec)` | `tui/internal/fs/heartbeat.go:11` | reads `.agent.heartbeat` unix timestamp, returns `age < threshold` |
 | `IsAliveHuman()` | `tui/internal/fs/heartbeat.go:24` | always `true` |
 | **mail.go** | | |
-| `ReadInbox(dir)` | `tui/internal/fs/mail.go:14` | reads `mailbox/inbox/` → `[]MailMessage` |
-| `ReadSent(dir)` | `tui/internal/fs/mail.go:18` | reads `mailbox/sent/` → `[]MailMessage` |
-| `MailCache` | `tui/internal/fs/mail.go:25` | incremental refresh cache: outbox + inbox + sent merged |
-| `NewMailCache(humanDir)` | `tui/internal/fs/mail.go:35` | creates cache; `Refresh()` returns updated copy (receiver not mutated) |
-| `WriteMail` | `tui/internal/fs/mail.go:163` | writes to recipient inbox + sender sent (or human outbox for pseudo-agent) |
+| `newMailboxID()` | `tui/internal/fs/mail.go:33` | builds `YYYYMMDDTHHMMSS-xxxx` short id matching the kernel's `_new_mailbox_id` |
+| `prepareMailDirs` | `tui/internal/fs/mail.go:50` | allocates a short id and creates every mailbox leaf the send will write, retrying on collisions in any target folder |
+| `ReadInbox(dir)` | `tui/internal/fs/mail.go:88` | reads `mailbox/inbox/` → `[]MailMessage` |
+| `ReadSent(dir)` | `tui/internal/fs/mail.go:92` | reads `mailbox/sent/` → `[]MailMessage` |
+| `MailCache` | `tui/internal/fs/mail.go:99` | incremental refresh cache: outbox + inbox + sent merged |
+| `NewMailCache(humanDir)` | `tui/internal/fs/mail.go:109` | creates cache; `Refresh()` returns updated copy (receiver not mutated) |
+| `WriteMail` | `tui/internal/fs/mail.go:237` | writes to recipient inbox + sender sent (or human outbox for pseudo-agent); allocates id via `prepareMailDirs` |
 | **ledger.go** | | |
 | `ReadLedger(dir)` | `tui/internal/fs/ledger.go:17` | reads `delegates/ledger.jsonl` → `[]AvatarEdge` + child dirs |
 | **location.go** | | |
@@ -71,7 +73,7 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 - **Called by `tui/internal/tui/`** — every Bubble Tea screen reads agent state through this package (network home, agent detail, mail viewer, kanban, session log).
 - **Reads from agent working directories** — `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/*/`, `logs/token_ledger.jsonl`, `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`.
 - **Writes signal files** (the only agent-owned files the TUI writes): `.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`, `.refresh`/`.refresh.taken`.
-- **Writes human outbox mail** — `WriteMail` for human (pseudo-agent) writes to `human/mailbox/outbox/<uuid>/`.
+- **Writes human outbox mail** — `WriteMail` for human (pseudo-agent) writes to `human/mailbox/outbox/<mailbox-id>/`.
 - **Calls `ipinfo.io`** — `ResolveLocation` makes an HTTP call; `UpdateHumanLocation` caches result in human's `.agent.json`.
 
 ## Composition
@@ -89,6 +91,7 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 ## Notes
 
 - **Read-only for agent state.** This package is the TUI's window — it never writes agent-owned files except signal files. The kernel owns `.agent.json`, heartbeats, mailboxes, ledgers, logs. Do not add write paths for kernel-owned state.
+- **Mailbox id shape.** `WriteMail` allocates short, human-scannable ids of the form `YYYYMMDDTHHMMSS-xxxx` (20 chars, UTC, 4 hex chars of UUID4 entropy) via `newMailboxID`. This matches the kernel's `_new_mailbox_id` in `lingtai-kernel/src/lingtai_kernel/intrinsics/email/primitives.py` and the portal's mirror in `portal/internal/fs/mail.go`, so directory names, `id`, and `_mailbox_id` look identical regardless of which side wrote the message. The directory name IS the id — `prepareMailDirs` uses `os.Mkdir` (not `MkdirAll`) on each leaf so collisions in any target folder surface as `fs.ErrExist` and trigger up to 8 regenerations without overwriting existing mail.
 - **`Delivered` is transient.** `MailMessage.Delivered` is `json:"-"` — set by `MailCache.Refresh()` based on which folder the message was found in. Outbox → false; inbox/sent → true.
 - **`MailCache` is copy-on-refresh.** `Refresh()` returns a new `MailCache`; the receiver is not mutated. Safe for goroutine use.
 - **Session cache reconstruction.** `RebuildFromSources` is idempotent — it re-ingests all mail + events + inquiries from offset 0, sorts by timestamp, and rewrites `session.jsonl`. Incremental `Refresh` tails from EOF offsets.

--- a/tui/internal/fs/mail.go
+++ b/tui/internal/fs/mail.go
@@ -2,7 +2,9 @@ package fs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,6 +12,78 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// newMailboxID builds a sortable, human-scannable mailbox id. The format
+// (`YYYYMMDDTHHMMSS-xxxx`, 20 chars, UTC) matches the kernel helper
+// `_new_mailbox_id` in `lingtai_kernel/intrinsics/email/primitives.py` and
+// the portal's mirror in `portal/internal/fs/mail.go` so mail written by
+// any of the three sides is indistinguishable in `email(check)` output.
+// The 4-hex suffix is drawn from `uuid.New` (a v4 UUID); 16 bits of
+// entropy per second is enough for human-paced sends and the WriteMail
+// collision-retry loop covers the rare burst case.
+var mailboxIDSource = func() string {
+	ts := time.Now().UTC().Format("20060102T150405")
+	// `uuid.New().String()` returns `xxxxxxxx-xxxx-...` — the first 4 hex
+	// chars come before any dash, so this mirrors the kernel's
+	// `uuid.uuid4().hex[:4]` slicing.
+	suffix := uuid.New().String()[:4]
+	return ts + "-" + suffix
+}
+
+func newMailboxID() string {
+	return mailboxIDSource()
+}
+
+// mailboxIDCollisionRetries is the per-folder attempt budget for
+// `prepareMailDirs`. The short ID has 16 bits of entropy in the
+// suffix, so a same-second send has a 1/65536 chance of colliding;
+// 8 retries reduces the practical failure probability to negligible while
+// still terminating quickly when the filesystem is genuinely failing.
+const mailboxIDCollisionRetries = 8
+
+// prepareMailDirs allocates an id and creates every mailbox leaf that will
+// receive this message. Non-pseudo sends write both the primary folder and the
+// sender's sent/ folder, so the id must be free in both places; otherwise a
+// same-second suffix collision in sent/ could overwrite an existing sent
+// record. On a collision in any target folder the partial leaves from that
+// attempt are removed and a fresh id is generated.
+func prepareMailDirs(primaryParent string, sentParent string) (string, string, string, error) {
+	if err := os.MkdirAll(primaryParent, 0o755); err != nil {
+		return "", "", "", fmt.Errorf("create primary mailbox parent: %w", err)
+	}
+	if sentParent != "" {
+		if err := os.MkdirAll(sentParent, 0o755); err != nil {
+			return "", "", "", fmt.Errorf("create sent mailbox parent: %w", err)
+		}
+	}
+	var lastErr error
+	for i := 0; i < mailboxIDCollisionRetries; i++ {
+		id := newMailboxID()
+		primaryDir := filepath.Join(primaryParent, id)
+		if err := os.Mkdir(primaryDir, 0o755); err != nil {
+			if !errors.Is(err, iofs.ErrExist) {
+				return "", "", "", fmt.Errorf("create primary mailbox leaf: %w", err)
+			}
+			lastErr = err
+			continue
+		}
+		if sentParent == "" {
+			return id, primaryDir, "", nil
+		}
+		sentDir := filepath.Join(sentParent, id)
+		if err := os.Mkdir(sentDir, 0o755); err != nil {
+			_ = os.Remove(primaryDir)
+			if !errors.Is(err, iofs.ErrExist) {
+				return "", "", "", fmt.Errorf("create sent mailbox leaf: %w", err)
+			}
+			lastErr = err
+			continue
+		}
+		return id, primaryDir, sentDir, nil
+	}
+	return "", "", "", fmt.Errorf("create mailbox leaves: exhausted %d retries: %w",
+		mailboxIDCollisionRetries, lastErr)
+}
 
 func ReadInbox(dir string) ([]MailMessage, error) {
 	return readMailFolder(filepath.Join(dir, "mailbox", "inbox"))
@@ -23,7 +97,7 @@ func ReadSent(dir string) ([]MailMessage, error) {
 // Each Refresh call reads new messages from disk. Messages transitioning
 // from outbox/ to sent/ have their Delivered flag flipped in place.
 type MailCache struct {
-	seen      map[string]int // UUID → index into Messages
+	seen      map[string]int // mailbox id → index into Messages
 	Messages  []MailMessage  // full sorted merged slice (outbox + inbox + sent)
 	humanDir  string
 	inboxDir  string
@@ -61,8 +135,8 @@ func (c MailCache) Refresh() MailCache {
 	}
 
 	// Order matters: scan outbox first so messages appear immediately after send.
-	// Then inbox and sent — for any UUID previously seen in outbox that now appears
-	// in sent, the scan flips Delivered to true in place.
+	// Then inbox and sent — for any mailbox id previously seen in outbox that now
+	// appears in sent, the scan flips Delivered to true in place.
 	out.scanFolder(out.outboxDir, false /* delivered */)
 	out.scanFolder(out.inboxDir, true)
 	out.scanFolder(out.sentDir, true)
@@ -71,7 +145,7 @@ func (c MailCache) Refresh() MailCache {
 	sort.Slice(out.Messages, func(i, j int) bool {
 		return out.Messages[i].ReceivedAt < out.Messages[j].ReceivedAt
 	})
-	// Rebuild the UUID→index map after the sort. Keyed by MailboxID, which is
+	// Rebuild the mailbox-id→index map after the sort. Keyed by MailboxID, which is
 	// the mailbox directory basename (what scanFolder looks up) — not msg.ID,
 	// which could diverge from the directory name if a future kernel rewrote
 	// the JSON during pickup. MailboxID is set to the directory name at write
@@ -82,11 +156,11 @@ func (c MailCache) Refresh() MailCache {
 	return out
 }
 
-// scanFolder reads UUID directories in folder. For UUIDs not yet in seen,
+// scanFolder reads mailbox-id directories in folder. For mailbox ids not yet in seen,
 // loads their message.json, stamps Delivered, and appends to Messages.
-// For UUIDs already in seen: if delivered=true, flips the existing entry's
+// For mailbox ids already in seen: if delivered=true, flips the existing entry's
 // Delivered flag to true (outbox→sent transition). If delivered=false and
-// the UUID is already known, skip — we've already loaded it.
+// the mailbox id is already known, skip — we've already loaded it.
 func (c *MailCache) scanFolder(folder string, delivered bool) {
 	entries, err := os.ReadDir(folder)
 	if err != nil {
@@ -161,12 +235,31 @@ func readManifestAsIdentity(dir string) map[string]interface{} {
 }
 
 func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) error {
-	id := uuid.New().String()
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-
 	// Read sender's manifest as identity card (same as Python agents do)
 	identity := readManifestAsIdentity(senderDir)
 
+	// Allocate every mailbox directory before writing JSON so the chosen id is
+	// unique across all folders this send will touch. Pseudo-agent sends write
+	// only outbox; non-pseudo sends also write sender sent/ with the same id.
+	var primaryParent string
+	pseudo := isPseudoAgent(identity)
+	switch {
+	case pseudo, IsRemoteAddress(toAddr):
+		primaryParent = filepath.Join(senderDir, "mailbox", "outbox")
+	default:
+		primaryParent = filepath.Join(recipientDir, "mailbox", "inbox")
+	}
+	sentParent := ""
+	if !pseudo {
+		sentParent = filepath.Join(senderDir, "mailbox", "sent")
+	}
+
+	id, primaryDir, sentDir, err := prepareMailDirs(primaryParent, sentParent)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
 	msg := MailMessage{
 		ID:         id,
 		MailboxID:  id,
@@ -185,42 +278,16 @@ func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) 
 		return fmt.Errorf("marshal message: %w", err)
 	}
 
-	// Pseudo-agent branch: if sender's .agent.json has admin: null (or no
-	// manifest), write only to the sender's outbox. Subscribed real agents
-	// poll the outbox and produce the sent entry via atomic rename on pickup.
-	if isPseudoAgent(identity) {
-		outboxDir := filepath.Join(senderDir, "mailbox", "outbox", id)
-		if err := os.MkdirAll(outboxDir, 0o755); err != nil {
-			return fmt.Errorf("create outbox dir: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(outboxDir, "message.json"), data, 0o644); err != nil {
-			return fmt.Errorf("write outbox message: %w", err)
-		}
+	if err := os.WriteFile(filepath.Join(primaryDir, "message.json"), data, 0o644); err != nil {
+		return fmt.Errorf("write primary message: %w", err)
+	}
+
+	// Pseudo-agent branch: no sent/ copy at send time. The subscribed real
+	// agent's pickup will produce the sent entry via atomic rename.
+	if pseudo {
 		return nil
 	}
 
-	if IsRemoteAddress(toAddr) {
-		outboxDir := filepath.Join(senderDir, "mailbox", "outbox", id)
-		if err := os.MkdirAll(outboxDir, 0o755); err != nil {
-			return fmt.Errorf("create outbox dir: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(outboxDir, "message.json"), data, 0o644); err != nil {
-			return fmt.Errorf("write outbox message: %w", err)
-		}
-	} else {
-		inboxDir := filepath.Join(recipientDir, "mailbox", "inbox", id)
-		if err := os.MkdirAll(inboxDir, 0o755); err != nil {
-			return fmt.Errorf("create inbox dir: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(inboxDir, "message.json"), data, 0o644); err != nil {
-			return fmt.Errorf("write inbox message: %w", err)
-		}
-	}
-
-	sentDir := filepath.Join(senderDir, "mailbox", "sent", id)
-	if err := os.MkdirAll(sentDir, 0o755); err != nil {
-		return fmt.Errorf("create sent dir: %w", err)
-	}
 	if err := os.WriteFile(filepath.Join(sentDir, "message.json"), data, 0o644); err != nil {
 		return fmt.Errorf("write sent message: %w", err)
 	}

--- a/tui/internal/fs/mail_test.go
+++ b/tui/internal/fs/mail_test.go
@@ -2,10 +2,18 @@ package fs
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
+
+// mailboxIDPattern matches the short mailbox id shape produced by
+// newMailboxID and the kernel's `_new_mailbox_id`: 14 digits, a `T`, 6
+// digits, a dash, then 4 lowercase hex chars (20 chars total).
+var mailboxIDPattern = regexp.MustCompile(`^\d{8}T\d{6}-[0-9a-f]{4}$`)
 
 func TestReadInbox(t *testing.T) {
 	dir := t.TempDir()
@@ -341,5 +349,169 @@ func writeSenderManifest(t *testing.T, dir string, admin interface{}) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), data, 0o644); err != nil {
 		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func TestNewMailboxID_Shape(t *testing.T) {
+	id := newMailboxID()
+	if !mailboxIDPattern.MatchString(id) {
+		t.Fatalf("id = %q, want match of %s", id, mailboxIDPattern)
+	}
+	if len(id) != 20 {
+		t.Errorf("len(id) = %d, want 20", len(id))
+	}
+}
+
+func TestNewMailboxID_Sortable(t *testing.T) {
+	a := newMailboxID()
+	b := newMailboxID()
+	aPrefix, bPrefix := a[:15], b[:15]
+	if strings.Compare(bPrefix, aPrefix) < 0 {
+		t.Errorf("second id prefix %q < first %q — time went backwards", bPrefix, aPrefix)
+	}
+}
+
+func TestWriteMail_ProducesShortMailboxID(t *testing.T) {
+	recipientDir := t.TempDir()
+	senderDir := t.TempDir()
+	writeSenderManifest(t, senderDir, map[string]interface{}{"karma": true})
+
+	if err := WriteMail(recipientDir, senderDir, "alice", "bob", "subj", "body"); err != nil {
+		t.Fatalf("WriteMail: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(recipientDir, "mailbox", "inbox"))
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox len = %d, want 1", len(entries))
+	}
+	name := entries[0].Name()
+	if !mailboxIDPattern.MatchString(name) {
+		t.Errorf("inbox dir name = %q, want match of %s", name, mailboxIDPattern)
+	}
+
+	data, err := os.ReadFile(filepath.Join(recipientDir, "mailbox", "inbox", name, "message.json"))
+	if err != nil {
+		t.Fatalf("read message.json: %v", err)
+	}
+	var msg MailMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ID != name {
+		t.Errorf("msg.ID = %q, want %q (directory name)", msg.ID, name)
+	}
+	if msg.MailboxID != name {
+		t.Errorf("msg.MailboxID = %q, want %q (directory name)", msg.MailboxID, name)
+	}
+
+	sentEntries, err := os.ReadDir(filepath.Join(senderDir, "mailbox", "sent"))
+	if err != nil {
+		t.Fatalf("read sent: %v", err)
+	}
+	if len(sentEntries) != 1 || sentEntries[0].Name() != name {
+		got := make([]string, 0, len(sentEntries))
+		for _, e := range sentEntries {
+			got = append(got, e.Name())
+		}
+		t.Errorf("sent entries = %v, want [%q]", got, name)
+	}
+}
+
+func TestPrepareMailDirs_AllocatesDistinctIDs(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "mailbox", "inbox")
+
+	id1, _, _, err := prepareMailDirs(parent, "")
+	if err != nil {
+		t.Fatalf("first allocation: %v", err)
+	}
+	id2, _, _, err := prepareMailDirs(parent, "")
+	if err != nil {
+		t.Fatalf("second allocation: %v", err)
+	}
+	if id1 == id2 {
+		t.Errorf("collision: two sequential allocations returned the same id %q", id1)
+	}
+}
+
+func TestPrepareMailDirs_SentCollisionRetriesWithoutOverwrite(t *testing.T) {
+	root := t.TempDir()
+	primaryParent := filepath.Join(root, "recipient", "mailbox", "inbox")
+	sentParent := filepath.Join(root, "sender", "mailbox", "sent")
+	if err := os.MkdirAll(sentParent, 0o755); err != nil {
+		t.Fatalf("setup sent parent: %v", err)
+	}
+
+	ids := make([]string, mailboxIDCollisionRetries)
+	for i := range ids {
+		ids[i] = "20260511T224200-" + fmt.Sprintf("%04x", i)
+	}
+	sentinel := []byte("existing sent message")
+	reserved := make(map[string][]byte)
+	for _, id := range ids[:mailboxIDCollisionRetries-1] {
+		dir := filepath.Join(sentParent, id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("setup collided sent dir: %v", err)
+		}
+		msg := filepath.Join(dir, "message.json")
+		if err := os.WriteFile(msg, sentinel, 0o644); err != nil {
+			t.Fatalf("setup collided sent message: %v", err)
+		}
+		reserved[msg] = sentinel
+	}
+
+	oldSource := mailboxIDSource
+	next := 0
+	mailboxIDSource = func() string {
+		id := ids[next]
+		if next < len(ids)-1 {
+			next++
+		}
+		return id
+	}
+	t.Cleanup(func() { mailboxIDSource = oldSource })
+
+	id, primaryDir, sentDir, err := prepareMailDirs(primaryParent, sentParent)
+	if err != nil {
+		t.Fatalf("prepareMailDirs: %v", err)
+	}
+	if id != ids[len(ids)-1] {
+		t.Fatalf("id = %q, want final retry id %q", id, ids[len(ids)-1])
+	}
+	if filepath.Base(primaryDir) != id || filepath.Base(sentDir) != id {
+		t.Fatalf("dirs do not share id: id=%q primary=%q sent=%q", id, primaryDir, sentDir)
+	}
+	for msg, want := range reserved {
+		got, err := os.ReadFile(msg)
+		if err != nil {
+			t.Fatalf("reserved message missing: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("reserved sent message %s was overwritten", msg)
+		}
+	}
+}
+
+func TestPrepareMailDirs_ExhaustionReportsError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root — chmod 0 won't deny Mkdir")
+	}
+	parent := filepath.Join(t.TempDir(), "mailbox", "inbox")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	_, _, _, err := prepareMailDirs(parent, "")
+	if err == nil {
+		t.Fatalf("expected error from un-writable parent, got nil")
+	}
+	if !strings.Contains(err.Error(), "create primary mailbox") {
+		t.Errorf("error = %v, want one wrapped by prepareMailDirs", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Replace Go TUI/portal human-origin internal mail UUID directory names with short, sortable `YYYYMMDDTHHMMSS-xxxx` mailbox IDs matching the kernel helper.
- Allocate all mailbox leaf directories for a send before writing JSON so the selected ID is collision-free across the primary folder and sender `sent/` copy.
- Add mirrored TUI/portal tests for ID shape, sent-copy consistency, collision retries, and exhaustion/error handling; refresh ANATOMY.md notes/citations.

## Tests
- `cd tui && go test ./internal/fs && cd ../portal && go test ./internal/fs`
- `cd tui && go test ./... && cd ../portal && go test ./...`

Fixes Lingtai-AI/lingtai#74.
