### PR TITLE
fix(tui): advance setup keep-current preset

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -994,9 +994,12 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					oauthCh := startOAuthFlow()
 					return m, func() tea.Msg { return <-oauthCh }
 				}
-				// Row: open the editor on the highlighted preset.
+				// Setup mode's synthetic "keep current" row is already the
+				// chosen default preset; Enter should advance just like the
+				// Next footer button. Editing remains disabled on this row
+				// (see Space/Ctrl+E below) because it has no preset file.
 				if m.setupMode && m.cursor == -1 {
-					return m, nil // can't edit the synthetic "keep current" entry
+					return m, m.enterAgentPresets()
 				}
 				p, ok := m.presetAtVisibleIdx(m.cursor)
 				if !ok {

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
 
@@ -130,5 +132,27 @@ func TestPresetNeedsKey_distinctEnvVars(t *testing.T) {
 	}
 	if !m.presetNeedsKey(work) {
 		t.Error("work preset uses a distinct env var that's unset, should need")
+	}
+}
+
+func TestSetupModeEnterOnKeepCurrentAdvancesToAgentPresets(t *testing.T) {
+	m := FirstRunModel{
+		setupMode: true,
+		step:      stepPickPreset,
+		cursor:    -1,
+		presets: []preset.Preset{
+			{
+				Name:   "saved-one",
+				Source: preset.SourceSaved,
+				Manifest: map[string]interface{}{
+					"llm": map[string]interface{}{"provider": "minimax"},
+				},
+			},
+		},
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.step != stepAgentPresets {
+		t.Fatalf("Enter on setup keep-current row should advance to agent presets; got step %v", m.step)
 	}
 }


### PR DESCRIPTION
## Summary
- make Enter on `/setup` Step 1's synthetic keep-current/default preset row advance to the next wizard step
- keep edit actions (Space / Ctrl+E) disabled on that synthetic row because it has no preset file
- add a regression test for setup-mode Enter behavior

## Why
In `/setup`, Step 1 includes a synthetic “keep current/default preset” row at cursor `-1`. The cursor could land on the row, but Enter returned `nil`, so the row looked selectable while not activating. The footer Next button did advance, but Enter on the selected row did not.

## Testing
- `cd tui && go test ./internal/tui -run 'TestSetupModeEnterOnKeepCurrentAdvancesToAgentPresets|TestPresetNeedsKey|TestGetPresetProvider' -count=1 -v`
- `cd tui && go test ./...`
- `cd tui && make build`
- `cd tui && ./bin/lingtai-tui --help | head -8`
- `git diff --check`
