### PR TITLE
docs(devguide): orchestrator/daemon discipline + portfolio sweep

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -10,7 +10,7 @@ description: >
   the pieces fit together, or develop a new MCP addon. Do NOT use for
   operational agent tasks (use lingtai-kernel-anatomy or lingtai-tui-anatomy
   instead) or for using LingTai as an end user (use the tutorial-guide skill).
-version: 1.1.0
+version: 1.2.0
 tags: [python, golang, typescript, agent, architecture, contributing, reference, mcp]
 ---
 
@@ -143,13 +143,15 @@ The 4 first-party MCP addons are:
 
 ## Contributing workflow
 
-1. **Fork → branch → PR.** All changes go through GitHub PRs.
-2. **Anatomy updates are mandatory.** If your change moves, renames, splits, merges, or deletes a file/function/class cited by an `ANATOMY.md`, update the anatomy in the **same commit**. See `lingtai-kernel-anatomy` (Python) or `lingtai-tui-anatomy` (Go) for the full convention.
-3. **Three-locale rule.** Adding an i18n key means updating all three of `en.json`, `zh.json`, `wen.json` in both `tui/i18n/` and (where applicable) `portal/i18n/`.
-4. **Filesystem-only IPC.** Any new cross-process communication must follow the file-based pattern.
-5. **Skill authoring for reusable procedures.** If your change creates a reusable workflow, write it as a skill.
+1. **Orchestrator + daemons, not hand-coding.** For any non-trivial coding, research, or change task, the orchestrator's job is to *plan, dispatch, and review* — not to hand-code. Decompose the work into daemon-sized tasks and dispatch them to Claude Code / Codex daemon backends, which are the right tools for code reading, modification, testing, refactoring, PR preparation, batch scanning, and mechanical validation. Use as much safe parallelism as the decomposition allows: independent daemons run concurrently in their own worktrees/branches, each with a scoped brief and a do-not-touch list.
+2. **Portfolio sweep before broad planning.** Before planning any broad LingTai dev work, run (or dispatch) a read-only org-wide issues/PRs scan via the `lingtai-repo-watch` skill or a `gh` org sweep, and let the current PR/issue surface guide what to pick up. Summarize stale, unreviewed, and relevant items.
+3. **Issue → worktree/branch → PR → merge.** Non-trivial changes are tracked end-to-end: open or pick an issue, work in an isolated worktree on a topic branch, push, open a PR, review, merge. No long-lived ad-hoc branches; no edits in the main checkout.
+4. **Anatomy updates are mandatory.** If your change moves, renames, splits, merges, or deletes a file/function/class cited by an `ANATOMY.md`, update the anatomy in the **same commit**. See `lingtai-kernel-anatomy` (Python) or `lingtai-tui-anatomy` (Go) for the full convention.
+5. **Three-locale rule.** Adding an i18n key means updating all three of `en.json`, `zh.json`, `wen.json` in both `tui/i18n/` and (where applicable) `portal/i18n/`.
+6. **Filesystem-only IPC.** Any new cross-process communication must follow the file-based pattern.
+7. **Skill authoring for reusable procedures.** If your change creates a reusable workflow, write it as a skill.
 
-For the full contributing guide (build commands, gotchas, anatomy maintenance, migration contract): read `reference/contributing.md`.
+For the full contributing guide (orchestrator/daemon discipline, portfolio sweep, build commands, gotchas, anatomy maintenance, migration contract): read `reference/contributing.md`.
 
 ## Reference files
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing.md
@@ -9,6 +9,61 @@ This guide covers how to make changes to each component of the LingTai project.
 3. **Three-locale rule.** Adding an i18n key means updating all three of `en.json`, `zh.json`, `wen.json` in both `tui/i18n/` and (where applicable) `portal/i18n/`. Missing translations render as the raw key on screen — they don't fall back.
 4. **Binary naming.** The TUI binary is `lingtai-tui`, never `lingtai`. `lingtai` is the Python agent CLI inside the runtime venv.
 
+## Orchestrator + daemons (how the work happens)
+
+This is the operating discipline for *any* non-trivial LingTai contribution — TUI, portal, kernel, addons, or skills. Read this before you start writing code.
+
+### 1. Clarify and restate the contract
+
+Before dispatching work, restate the task in your own words: what changes, what does not, what "done" looks like, and what is explicitly out of scope. If the request is ambiguous, ask before dispatching. A daemon that runs against a fuzzy brief will deliver a fuzzy diff — and you will pay for it in review time.
+
+### 2. Issue → worktree/branch → PR → merge
+
+Non-trivial work flows through this loop. No exceptions for "small" fixes that turn out to be non-small:
+
+1. **Issue.** Open or pick a GitHub issue that names the problem. If one does not exist, write one — it is the durable record of the contract.
+2. **Worktree + branch.** Create an isolated `git worktree` off `origin/main` on a topic branch (`fix/...`, `feat/...`, `docs/...`, `chore/...`). Never edit the main checkout, and never share a worktree across two parallel daemons.
+3. **PR.** Push the branch and open a PR against `Lingtai-AI/<repo>`. The PR body cites the issue, summarizes the change, and lists validation steps.
+4. **Merge.** After review, merge via the GitHub UI (or `gh pr merge`). Delete the branch and clean up the worktree.
+
+### 3. Decompose into daemon-sized tasks
+
+Orchestrators *plan, dispatch, and review*; they do not hand-code. The right tools for code reading, modification, testing, refactoring, PR preparation, batch scanning, and mechanical validation are the daemon backends:
+
+- **Claude Code daemons** — best for exploratory code reading, multi-file edits, skill/doc work, and PR composition.
+- **Codex daemons** — best for tightly-scoped diffs, deterministic refactors, and mechanical validation passes.
+
+Each dispatched daemon must receive:
+
+- **A scoped brief.** What to change, what to leave alone, what "done" looks like, where the source-of-truth files live (absolute paths).
+- **Its own worktree and branch.** Daemons do not share a working tree. Parallelism is safe only when worktrees are disjoint.
+- **Tests or validation steps.** Whatever check confirms the change works — `go test ./...`, `python -m pytest`, frontmatter parse, `git diff --check`, a grep for the new headings. If no test is applicable, say so explicitly.
+- **A do-not-touch list.** Files, directories, or branches the daemon must not modify (e.g., unrelated untracked files in the main checkout, sibling worktrees, the main branch).
+
+Use as much **safe parallelism** as the decomposition allows. Independent daemons run concurrently; dependent steps run sequentially. The orchestrator's leverage comes from running many disjoint daemons in parallel, not from doing more of the work itself.
+
+### 4. Orchestrator reviews diffs and tests; does not hand-code
+
+When a daemon reports back, the orchestrator's job is to:
+
+1. Read the diff (not the daemon's summary — diffs are the ground truth).
+2. Run or inspect the validation output.
+3. Check imports, cross-file consistency, and adherence to the brief.
+4. Either merge/forward, or send the daemon back with a tightened brief.
+
+The orchestrator hand-codes only in narrow cases: emergency hotfixes when daemon dispatch overhead is unjustified, throwaway scratch work, or steering the daemon out of a stuck state. Default to dispatch.
+
+### 5. Routine portfolio sweep before broad planning
+
+Before planning any broad LingTai dev work, run — or dispatch — an org-wide **portfolio sweep**:
+
+- Use the `lingtai-repo-watch` skill, or a read-only `gh` org sweep across `Lingtai-AI/*`, to enumerate open issues and PRs.
+- Summarize: stale items, unreviewed PRs, items relevant to the planned work, and items that conflict with what you are about to do.
+- Let the current PR/issue surface guide which pieces to pick up, defer, or coordinate around.
+- Keep the sweep **read-only**. It informs planning; it does not file new issues or comment on PRs as a side effect.
+
+Skipping the sweep is how you end up duplicating in-flight work, stomping on someone else's branch, or shipping a fix that conflicts with a pending refactor.
+
 ## Changing the TUI (`tui/`)
 
 ### Where to look


### PR DESCRIPTION
## Summary

Patches the embedded `lingtai-dev-guide` skill (`tui/internal/preset/skills/lingtai-dev-guide/`) to make orchestrator-and-daemons discipline the headline of the contributing workflow, and adds an authoritative section in `reference/contributing.md` covering the full operating discipline.

Refs issue #96 and a direct human request to encode this discipline into the dev-guide skill so future agents working on LingTai default to dispatching daemons rather than hand-coding.

### Changes

- **`SKILL.md`**
  - Bumps `version: 1.1.0` → `1.2.0`.
  - Replaces the terse 5-item "Contributing workflow" with a 7-item list that *leads* with:
    1. Orchestrator + daemons, not hand-coding (Claude Code / Codex backends; safe parallelism; scoped briefs; do-not-touch lists).
    2. Read-only portfolio sweep (via `lingtai-repo-watch` / `gh` org sweep) before broad planning.
    3. Issue → worktree/branch → PR → merge for non-trivial changes.
  - Existing anatomy / three-locale / filesystem-IPC / skill-authoring rules preserved as items 4–7.
  - Description field untouched (already retrieval-focused).

- **`reference/contributing.md`**
  - New top-level `## Orchestrator + daemons (how the work happens)` section inserted right after General principles, with five subsections:
    1. Clarify and restate the contract.
    2. Issue → worktree/branch → PR → merge.
    3. Decompose into daemon-sized tasks (Claude Code vs Codex backends; scoped brief / disjoint worktree / tests / do-not-touch list per daemon; safe parallelism).
    4. Orchestrator reviews diffs and tests; does not hand-code (except emergency/scratch/unstucking).
    5. Routine portfolio sweep before broad planning (read-only `lingtai-repo-watch` or `gh` sweep; summarize stale/unreviewed/relevant/conflicting items).

No unrelated files touched.

## Test plan

- [x] YAML frontmatter of `SKILL.md` parses cleanly via PyYAML (`name`, `version: 1.2.0`, `tags` intact; description length 680 chars, unchanged).
- [x] `grep` confirms new headings exist in both files (Contributing workflow leader bullets in SKILL.md; `## Orchestrator + daemons` + the five `###` subsections in `contributing.md`).
- [x] `git diff --check` clean — no whitespace errors.
- [ ] Go build / unit tests **not applicable** — this PR only changes embedded markdown content under `tui/internal/preset/skills/lingtai-dev-guide/`. The files are consumed as text by agents at runtime; no Go symbols, no compile-time embed shape changes.

## Risks

- Embedded skill content ships inside the `lingtai-tui` binary. The new content takes effect for end users only after the next TUI release rebuilds and re-embeds these files — existing installations carry the old `1.1.0` text until they upgrade. This is expected and matches every prior skill-content change.