### PR TITLE
feat(preset): strip default-on core capabilities from init templates

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -687,18 +687,14 @@ func CountSavedByProvider(presets []Preset, provider string) int {
 
 func e() map[string]interface{} { return map[string]interface{}{} }
 
-// libraryKnowledgeDefault returns the default durable library capability config.
-func libraryKnowledgeDefault() map[string]interface{} {
-	return map[string]interface{}{
-		"library_limit": 50,
-	}
-}
-
 // skillsDefault returns the default skills capability config — two Tier 1
 // paths: the network-shared skills shelf (resolved relative to the agent dir)
 // and the TUI's per-user utilities directory. Users can edit init.json to
 // add or remove paths; init.json is the ground truth and the capability
 // reads it on every setup.
+//
+// `skills` itself is default-on in the kernel; this entry exists only to
+// override the default kwargs (which carry no extra paths).
 func skillsDefault() map[string]interface{} {
 	return map[string]interface{}{
 		"paths": []interface{}{
@@ -707,6 +703,7 @@ func skillsDefault() map[string]interface{} {
 		},
 	}
 }
+
 
 func minimaxPreset() Preset {
 	mm := map[string]interface{}{"provider": "minimax"}
@@ -719,11 +716,14 @@ func minimaxPreset() Preset {
 				"api_key": nil, "api_key_env": "MINIMAX_API_KEY",
 				"base_url": ProviderRegionURLs["minimax"][0].URL,
 			},
+			// Core caps (knowledge, skills, bash, avatar, daemon, mcp,
+			// read/write/edit/glob/grep + psyche/email intrinsics) are
+			// default-on in the kernel — only overrides and opt-in caps
+			// belong here. See lingtai-kernel capabilities.CORE_DEFAULTS.
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
-				"web_search": mm, "library": libraryKnowledgeDefault(),
-				"vision": mm, "avatar": e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"web_search": mm,
+				"vision":     mm,
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -741,11 +741,9 @@ func zhipuPreset() Preset {
 				"base_url": ProviderRegionURLs["zhipu"][0].URL, "api_compat": "openai",
 			},
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
-				"web_search": zp, "library": libraryKnowledgeDefault(),
-				"vision": zp,
-				"avatar": e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"web_search": zp,
+				"vision":     zp,
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -772,12 +770,9 @@ func mimoPreset() Preset {
 				"base_url": "https://api.xiaomimimo.com/v1", "api_compat": "openai",
 			},
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
-				"library":    libraryKnowledgeDefault(),
 				"vision":     mp,
-				"avatar":     e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -798,11 +793,8 @@ func deepseekPreset() Preset {
 			// skill; for media creation, register the MiniMax-Media MCP server
 			// via the `mcp-manual` skill (kernel `mcp` capability).
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
-				"library":    libraryKnowledgeDefault(),
-				"avatar":     e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -825,11 +817,8 @@ func geminiPreset() Preset {
 			// `listen` skill; for media creation register a provider's
 			// MCP server via `mcp-manual`.
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
-				"library":    libraryKnowledgeDefault(),
-				"avatar":     e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -854,11 +843,8 @@ func kimiPreset() Preset {
 			// analysis use the `listen` skill; for media creation register
 			// the MiniMax-Media MCP server via the `mcp-manual` skill.
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
-				"library":    libraryKnowledgeDefault(),
-				"avatar":     e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -878,11 +864,8 @@ func openrouterPreset() Preset {
 			// generation. For audio analysis use the `listen` skill; for
 			// media creation register a provider's MCP server via `mcp-manual`.
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
-				"library":    libraryKnowledgeDefault(),
-				"avatar":     e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -905,11 +888,9 @@ func codexPreset() Preset {
 				"base_url": "https://chatgpt.com/backend-api/codex",
 			},
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
-				"web_search": cx, "library": libraryKnowledgeDefault(),
-				"vision": cx,
-				"avatar": e(), "daemon": e(),
-				"skills": skillsDefault(),
+				"web_search": cx,
+				"vision":     cx,
+				"skills":     skillsDefault(),
 			},
 		},
 	}
@@ -925,8 +906,7 @@ func customPreset() Preset {
 				"api_key": nil, "api_key_env": "LLM_API_KEY", "base_url": nil,
 			},
 			"capabilities": map[string]interface{}{
-				"file": e(), "bash": map[string]interface{}{"yolo": true},
-				"web_search": e(), "library": libraryKnowledgeDefault(),
+				"web_search": e(),
 				// Inherit vision through the LLM's own endpoint. When the
 				// relay is OpenAI-compatible and the underlying model
 				// supports vision (gpt-4o/4.x, gpt-5.5, etc.), the kernel
@@ -934,7 +914,6 @@ func customPreset() Preset {
 				// base_url. If the relay or model can't do vision the
 				// call fails at runtime — no special handling.
 				"vision": map[string]interface{}{"provider": "inherit"},
-				"avatar": e(), "daemon": e(),
 				"skills": skillsDefault(),
 			},
 		},

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -56,80 +56,47 @@
     // -------------------------------------------------------
     // Capabilities — the agent's tool surface
     // -------------------------------------------------------
-    // Each key is a capability name. Value is {} for defaults
-    // or a dict of kwargs passed to the capability's setup().
+    // The kernel boots the `lingtai.core.*` floor by default on every
+    // agent: knowledge, skills, bash, avatar, daemon, mcp, read, write,
+    // edit, glob, grep — plus the always-on intrinsics psyche and email.
+    // You do NOT need to list those here unless you want to OVERRIDE
+    // their default kwargs (e.g. give `bash` a deny-list policy file
+    // instead of the default yolo mode).
     //
-    // "file" is a group shorthand that expands to:
-    //   read, write, edit, glob, grep
+    // Top-level "disable" (sibling of "capabilities") opts a capability
+    // out entirely: e.g. "disable": ["avatar"].
+    //
+    // Entries below are either:
+    //   1. Overrides for default-on capabilities (bash, skills here).
+    //   2. Opt-in capabilities not in the default set (vision, web_search).
     // -------------------------------------------------------
     "capabilities": {
-      // --- File I/O (read, write, edit, glob, grep) ---
-      // Lets the agent read/write/edit files and search by pattern.
-      "file": {},
-
-      // --- Shell access ---
-      // policy_file: path to JSON deny-list (see bash_policy.json).
-      // Alternative: { "yolo": true } to allow ALL commands (dangerous!).
+      // --- Shell access (override) ---
+      // Kernel default is { "yolo": true } (no deny-list). The TUI ships
+      // a deny-list at bash_policy.json so agents started via lingtai-tui
+      // get the sandboxed surface by default.
       "bash": { "policy_file": "bash_policy.json" },
 
-      // --- Identity & pad (upgrades eigen intrinsic) ---
-      // Evolving character, knowledge codex integration,
-      // pad.edit with file imports. Includes molt (context compaction).
-      "psyche": {},
-
-      // --- Durable knowledge library ---
-      // Persistent knowledge store. Works with psyche for
-      // importing library entries into working pad.
-      "library": { "library_limit": 50 },
-
-      // --- Email (upgrades mail intrinsic) ---
-      // Filesystem-based mailbox with reply, CC/BCC, contacts,
-      // archive, delayed send, scheduled recurring sends.
-      // Used for inter-agent communication.
-      "email": {},
-
-      // --- Avatar (分身) ---
-      // Spawn independent child agents as separate processes.
-      // Each avatar gets its own working directory and LLM session.
-      // Survives parent death.
-      "avatar": {},
-
-      // --- Daemon (神識) ---
-      // Ephemeral sub-agent sessions running in parallel threads.
-      // Override kernel defaults by passing keys, e.g.
-      //   {"max_emanations": N, "max_turns": N, "timeout": N}.
-      "daemon": {},
-
-      // --- Vision (image understanding) ---
-      // Providers: "minimax", "anthropic", "openai", "gemini", "local" (no API key).
-      "vision": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
-
-      // --- Web search ---
-      // Providers: "minimax", "anthropic", "openai", "gemini", "duckduckgo" (no API key).
-      "web_search": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
-
-      // --- Web page reader ---
-      // Removed. URL fetching is folded into the `web-browsing` skill —
-      // its scripts/extract_page.py wraps trafilatura plus six other
-      // tiers (PDF, BeautifulSoup, Playwright, Jina, etc.). Removed: "web_read".
-
-      // --- Media creation (compose / video / draw / talk) ---
-      // Removed from in-tree capabilities. Use the `media-creation` skill
-      // and register a provider's MCP server (see `mcp-manual` skill).
-      // Removed: "compose", "video", "draw", "talk".
-
-      // --- Audio analysis (transcribe / appreciate) ---
-      // Removed. Use the `listen` skill — bundled scripts run faster-whisper
-      // and librosa locally; no provider or API key needed.
-      // Removed: "listen".
-
-      // --- Skills (skill catalog) ---
-      // Per-agent .library/{intrinsic,custom}/ is managed automatically.
-      // "paths" adds extra directories to the prompt catalog. Defaults:
+      // --- Skills catalog (override) ---
+      // `skills` is default-on; this entry adds extra search paths to the
+      // prompt catalog. Defaults overlaid:
       //   ../.library_shared       — network-shared skill shelf
       //   ~/.lingtai-tui/utilities — TUI-shipped utility skills
       // Edit and call system.refresh to apply. init.json is ground truth.
-      "skills": { "paths": ["../.library_shared", "~/.lingtai-tui/utilities"] }
+      "skills": { "paths": ["../.library_shared", "~/.lingtai-tui/utilities"] },
+
+      // --- Vision (opt-in) ---
+      // Providers: "minimax", "anthropic", "openai", "gemini", "local" (no API key).
+      "vision": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" },
+
+      // --- Web search (opt-in) ---
+      // Providers: "minimax", "anthropic", "openai", "gemini", "duckduckgo" (no API key).
+      "web_search": { "provider": "minimax", "api_key_env": "MINIMAX_API_KEY" }
+
+      // --- Removed capabilities (for reference) ---
+      // "web_read"        — folded into the `web-browsing` skill.
+      // "compose"/"video"/"draw"/"talk" — use the `media-creation` skill + an MCP server.
+      // "listen"          — use the `listen` skill (faster-whisper + librosa).
     },
 
     // -------------------------------------------------------


### PR DESCRIPTION
## Summary

- Pairs with lingtai-kernel PR [Lingtai-AI/lingtai-kernel#111](https://github.com/Lingtai-AI/lingtai-kernel/pull/111) that boots the \`lingtai.core.*\` floor by default.
- Strips redundant default-on capability entries from \`tui/internal/preset/templates/init.jsonc\` and all 9 provider presets in \`tui/internal/preset/preset.go\` (minimax, zhipu, mimo, deepseek, gemini, kimi, openrouter, codex, custom).
- Keeps the entries that actually carry overrides or are opt-in: \`bash\` (policy_file sandbox override), \`skills\` (extra paths), \`vision\` and \`web_search\` (provider + API key).

## Why

Closes [#105](https://github.com/Lingtai-AI/lingtai/issues/105). Each preset shrinks from ~9 capability keys to ~3, making the actual provider intent (which vision/search backend) the dominant signal instead of being buried among redundant \`{}\`s. Also removes the stale \`\"library\": {...}\` entry that triggered #105 — durable-memory capability advertised in the skill catalog but never registered because the kernel had already renamed it to \`knowledge\`.

## What changes

- \`tui/internal/preset/templates/init.jsonc\` — capabilities block reduced from 11 entries to 4; comments rewritten to explain the new contract (default-on core + opt-out via top-level \`disable\` + override via kwargs).
- \`tui/internal/preset/preset.go\` — removes \`libraryKnowledgeDefault()\`; strips redundant \`file\` / \`bash{yolo:true}\` / \`avatar\` / \`daemon\` / \`library\` entries from every provider preset. Adds a brief comment block above each shrunken capabilities map pointing readers at \`lingtai-kernel capabilities.CORE_DEFAULTS\`.

## No migration needed

Existing per-project \`init.json\` files still listing \`\"library\": {...}\` continue to work: the kernel hits the silent \`capability_skipped\` path on the unknown name, and the default-on \`knowledge\` capability provides the durable-memory tool the agent was already instructed to use. New agents created after this PR ships with the kernel's defaults-on contract get \`knowledge\` automatically.

## Ordering

Blocked on kernel PR #111 + a fresh \`lingtai\` PyPI release. Until then, the TUI's auto-upgrader will pull whichever PyPI version is latest; if it's pre-defaults-on, new agents created from these stripped templates would have no \`knowledge\` tool. Hold this PR until the kernel ships.

## Test plan

- [x] \`cd tui && go build ./...\` — clean.
- [x] \`cd tui && go test ./...\` — all packages pass.
- [ ] After kernel 0.10.2 ships and TUI venv upgrades, manually create a new agent via \`/setup\` with each preset and verify \`tool inventory\` lists \`knowledge\`, \`skills\`, \`bash\`, \`avatar\`, \`daemon\`, file tools — sourced from kernel defaults, not from init.json.
- [ ] Verify \`/refresh\` on an existing agent with a stale \`\"library\": {...}\` entry doesn't regress (silent skip + knowledge still present from defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)