### PR TITLE
feat(skill/academic-research): scripts/fetch_paper.py + publisher-extract tier

### DIFF
--- a/tui/internal/preset/skills/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/academic-research/SKILL.md
@@ -1,100 +1,143 @@
 ---
 name: academic-research
-description: "Deep-dive academic research skill — 12 API references (arXiv, CrossRef, OpenAlex, Semantic Scholar, CORE, PubMed, Unpaywall, Google Scholar, DOI Resolver, Europe PMC, NASA ADS, INSPIRE-HEP) + 6 pipeline workflows (discovery, PDF acquisition, citation tracking, scholar analysis, LaTeX writing, decision tree) + error handling patterns. Use this when you need detailed API parameters, code examples, and fallback chains for scholarly search and paper writing."
-version: 2.0.0
-tags: [academic, research, arxiv, crossref, openalex, semantic-scholar, core, pubmed, unpaywall, google-scholar, doi, pdf, citation, pipeline, europe-pmc, nasa-ads, inspire-hep, error-handling]
+description: >
+  Find papers, fetch full-text PDFs, trace citations, write LaTeX manuscripts.
+  **First action for any "get me this paper" request:**
+  `python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py <DOI|arXiv-ID|PMID>` — walks
+  arXiv → Unpaywall → Europe PMC → CORE → publisher-page extraction (Nature/APS/AIP/IOP/Cambridge)
+  → LibGen and saves the paper, metadata, and a resumable manifest under `papers/{slug}/`.
+  Read the body when you need to escape the script: custom query shapes, citation networks,
+  scholar analysis, LaTeX writing, or a tier-specific API call. Indexes 12 deep-dive API
+  references and 6 pipeline workflows under `reference/`.
+version: 3.0.0
+allowed-tools: Bash(python3 *) Bash(curl *) Bash(pip *) Bash(pip3 *)
+tags: [academic, research, arxiv, crossref, openalex, semantic-scholar, core, pubmed, unpaywall, doi, pdf, citation, pipeline, europe-pmc, nasa-ads, inspire-hep]
 parent: web-browsing
 ---
 
 # Academic Research
 
-> **This is a modular skill** — do NOT load the entire `reference/` directory into your context. Load specific reference files based on need (single API ref ≈ 1.5–3K tokens; single pipeline ≈ 2–3K tokens; full skill ≈ 42K tokens).
+> **This is a modular skill.** Try the bundled script first. Load specific
+> reference files only when you need to escape it.
 
-> If you navigated here from the web-browsing skill — web-browsing answers "which tier to use," while this skill answers "how to use a specific API."
+## Try this first
 
-## When to Use
+For 80% of "get me this paper" requests, the bundled script is the right answer.
+It walks the open-access ladder, falls back automatically, and writes a manifest
+the next session can resume from.
 
-- You already have a DOI, title, or author and need to retrieve paper metadata or full text
-- You need to systematically search scholarly literature
-- You need to trace citation networks or analyze research trends
-- You need a full-text PDF but aren't sure which source to use
+```bash
+# Fetch by any identifier
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py 10.1103/PhysRevLett.125.015001
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py arXiv:2301.00001
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py PMID:12345678
 
-## Decision Entry Point
+# Batch (one identifier per line in the file)
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py --batch dois.txt --out papers/
 
-**Not sure which API to start with?** → Read [reference/decision-tree.md](reference/decision-tree.md)
+# Resolve metadata only (no PDF download)
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py 10.1038/nature12373 --dry-run
 
-It routes you to the most appropriate API based on your input (DOI? arXiv ID? keywords? discipline?).
-
-## API References (12)
-
-Each reference includes: endpoint parameter tables, runnable code, response formats, rate limits, error handling, and cross-references.
-
-| API | Reference | Best For | Requires Key? |
-|-----|-----------|----------|---------------|
-| arXiv | [api-arxiv.md](reference/api-arxiv.md) | Preprint retrieval, CS/physics/math | No |
-| CrossRef | [api-crossref.md](reference/api-crossref.md) | DOI metadata, funder queries, new publications | No (mailto recommended) |
-| DOI Resolver | [api-doi-resolver.md](reference/api-doi-resolver.md) | Single/batch DOI resolution to structured citations | No |
-| OpenAlex | [api-openalex.md](reference/api-openalex.md) | Large-scale paper discovery, institution/concept analysis | No |
-| Semantic Scholar | [api-semantic-scholar.md](reference/api-semantic-scholar.md) | Citation networks, TLDR summaries, author profiles | No |
-| CORE | [api-core.md](reference/api-core.md) | Open-access full-text downloads | Optional |
-| PubMed | [api-pubmed.md](reference/api-pubmed.md) | Biomedical literature search, PMC full text | No |
-| Unpaywall | [api-unpaywall.md](reference/api-unpaywall.md) | Find OA versions/PDFs of papers | email parameter (not a placeholder) |
-| Google Scholar | [api-google-scholar.md](reference/api-google-scholar.md) | Broadest discipline coverage, citation counts (requires scraping) | No (requires stealth) |
-| Europe PMC | [api-europe-pmc.md](reference/api-europe-pmc.md) | Biomedical literature, PMID lookup, full-text XML | No |
-| NASA ADS | [api-nasa-ads.md](reference/api-nasa-ads.md) | Astrophysics/astronomy, BibTeX export, citation networks | Yes (free key) |
-| INSPIRE-HEP | [api-inspire-hep.md](reference/api-inspire-hep.md) | High-energy physics, author profiles, BibTeX export | No |
-
-## Pipeline Workflows (6)
-
-Each pipeline includes: workflow steps, decision trees, code examples, and failure fallbacks.
-
-| Pipeline | Reference | Purpose |
-|----------|-----------|---------|
-| Paper Discovery | [pipeline-discovery.md](reference/pipeline-discovery.md) | From keywords to a set of candidate papers |
-| PDF Acquisition | [pipeline-obtain-pdf.md](reference/pipeline-obtain-pdf.md) | From metadata to full-text PDF (with stealth) |
-| Citation Tracking | [pipeline-citation-tracking.md](reference/pipeline-citation-tracking.md) | Forward/backward citation networks |
-| Scholar Analysis | [pipeline-scholar-analysis.md](reference/pipeline-scholar-analysis.md) | Impact, trends, h-index |
-| LaTeX Writing | [pipeline-latex-writing.md](reference/pipeline-latex-writing.md) | Compile, bibliography, figures, debugging |
-| Decision Tree | [decision-tree.md](reference/decision-tree.md) | "I have X — which API should I use?" |
-
-## Quick Paths
-
-```
-I have a DOI          → api-doi-resolver.md → api-crossref.md → api-unpaywall.md for PDF
-I have an arXiv ID    → api-arxiv.md (direct PDF link)
-I have a PMID         → api-europe-pmc.md
-I have a bibcode      → api-nasa-ads.md (requires free key)
-I only have keywords  → decision-tree.md → pick API by discipline
-I need citation network → api-semantic-scholar.md or api-openalex.md
-I need full-text PDF  → pipeline-obtain-pdf.md (Unpaywall → CORE → Europe PMC → arXiv chain)
-All OA chains failed  → libgen-fallback.md (last resort, live mirror discovery)
-I need astrophysics   → api-nasa-ads.md
-I need high-energy physics → api-inspire-hep.md
-I need biomedical     → api-europe-pmc.md or api-pubmed.md
-I need to write/compile a paper → pipeline-latex-writing.md (compile + bib + figures + debug)
-I hit an API error    → error-handling.md (fallback chains, rate limit strategies)
+# Skip LibGen (e.g. legal-sensitive environment)
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py <id> --no-libgen
 ```
 
-## Error Handling
+**Output layout** (idempotent — re-runs skip entries with `status: ok`):
 
-Common failure patterns and fallback chains are documented in [error-handling.md](reference/error-handling.md):
-- 429 rate limiting → exponential backoff + API switch
-- 403 publisher blocks → Unpaywall → CORE → Europe PMC chain
-- Timeout patterns → per-API timeout guidance
-- Empty results → query diagnosis checklist
+```
+papers/{first-author-year-firstword}/
+├── paper.pdf  |  paper.md      # full-text artifact
+├── metadata.json                # CrossRef-normalized
+└── manifest.json                # {status, tier, source, ts, doi}
+```
+
+**Tier ladder** (script stops at first hit):
+
+| Tier | Source | Best for |
+|------|--------|----------|
+| 1 | arXiv direct | Preprints (physics, CS, math, q-bio, econ) |
+| 2 | Unpaywall | Publisher-blessed gold/green OA |
+| 3 | Europe PMC | Biomedical full-text + PMC mirror |
+| 4 | CORE | Institutional repositories (needs `$CORE_API_KEY`) |
+| 5 | Publisher-page extract | Nature/APS/AIP/IOP/Cambridge → structured Markdown with LaTeX preserved (auto-installs [zhiping0913/Download_paper](https://github.com/zhiping0913/Download_paper) on first use) |
+| 6 | LibGen | Last resort; opt out with `--no-libgen` |
+
+**Set `$LINGTAI_RESEARCH_EMAIL` to a real address** before first use — Unpaywall
+rejects placeholder emails with HTTP 422. The default falls back to
+`lingtai-agent@example.org` with a warning.
+
+Read on only if: the script fails on your paper, you need a custom query shape,
+or you're composing a multi-step workflow (search → fetch → cite → write).
+
+## Escape hatch — quick paths
+
+```
+I have a DOI                → reference/api-doi-resolver.md → api-crossref.md
+I have an arXiv ID          → reference/api-arxiv.md (direct PDF link)
+I have a PMID               → reference/api-europe-pmc.md
+I have a bibcode            → reference/api-nasa-ads.md (requires free key)
+I only have keywords        → reference/decision-tree.md → pick API by discipline
+I need a citation network   → reference/api-semantic-scholar.md or api-openalex.md
+I need to override the PDF ladder → reference/pipeline-obtain-pdf.md
+Tier-5 publisher-extract failed and I want to retry it manually → reference/publisher-page-extraction.md
+All OA chains failed        → reference/libgen-fallback.md (last resort)
+I need astrophysics         → reference/api-nasa-ads.md
+I need high-energy physics  → reference/api-inspire-hep.md
+I need biomedical           → reference/api-europe-pmc.md or api-pubmed.md
+I need to write/compile a paper → reference/pipeline-latex-writing.md
+I hit an API error          → reference/error-handling.md
+```
+
+## Reference index
+
+### API references (12)
+
+Each card includes endpoint parameters, runnable code, response shape, rate limits, and fallbacks.
+
+| API | File | Best for | Key? |
+|-----|------|----------|------|
+| arXiv | [api-arxiv.md](reference/api-arxiv.md) | Preprint retrieval | No |
+| CrossRef | [api-crossref.md](reference/api-crossref.md) | DOI metadata, funder queries | No (mailto recommended) |
+| DOI Resolver | [api-doi-resolver.md](reference/api-doi-resolver.md) | Batch DOI → structured citation | No |
+| OpenAlex | [api-openalex.md](reference/api-openalex.md) | Discovery, institution/concept analysis | No |
+| Semantic Scholar | [api-semantic-scholar.md](reference/api-semantic-scholar.md) | Citation networks, TLDR | No (tight limits) |
+| CORE | [api-core.md](reference/api-core.md) | OA full-text downloads | Optional (recommended) |
+| PubMed | [api-pubmed.md](reference/api-pubmed.md) | Biomedical search, PMC full text | No |
+| Unpaywall | [api-unpaywall.md](reference/api-unpaywall.md) | OA versions / PDFs | email (real) |
+| Google Scholar | [api-google-scholar.md](reference/api-google-scholar.md) | Broadest discipline coverage | No (needs stealth) |
+| Europe PMC | [api-europe-pmc.md](reference/api-europe-pmc.md) | Biomed, PMID, full-text XML | No |
+| NASA ADS | [api-nasa-ads.md](reference/api-nasa-ads.md) | Astrophysics, BibTeX export | Yes (free) |
+| INSPIRE-HEP | [api-inspire-hep.md](reference/api-inspire-hep.md) | High-energy physics | No |
+
+### Pipeline workflows (6)
+
+| Pipeline | File | Purpose |
+|----------|------|---------|
+| Paper discovery | [pipeline-discovery.md](reference/pipeline-discovery.md) | Keywords → candidate papers |
+| PDF acquisition | [pipeline-obtain-pdf.md](reference/pipeline-obtain-pdf.md) | Metadata → full text (manual ladder) |
+| Citation tracking | [pipeline-citation-tracking.md](reference/pipeline-citation-tracking.md) | Forward/backward citation networks |
+| Scholar analysis | [pipeline-scholar-analysis.md](reference/pipeline-scholar-analysis.md) | Impact, trends, h-index |
+| LaTeX writing | [pipeline-latex-writing.md](reference/pipeline-latex-writing.md) | Compile, bibliography, figures, debug |
+| Decision tree | [decision-tree.md](reference/decision-tree.md) | "I have X — which API should I use?" |
+
+### Standalone references
+
+- [publisher-page-extraction.md](reference/publisher-page-extraction.md) — Tier-5 manual escape hatch (Nature/APS/AIP/IOP/Cambridge → structured Markdown)
+- [libgen-fallback.md](reference/libgen-fallback.md) — Last-resort PDF source with legal/safety notes
+- [error-handling.md](reference/error-handling.md) — 429 backoff, 403 publisher blocks, timeout patterns
 
 ## Relationship to web-browsing
 
-- **web-browsing**: routing layer — "which tier to use?" (PDF direct? API metadata? trafilatura? Playwright?)
-- **academic-research**: deep-dive layer — "how do I write filter parameters for OpenAlex? What email should I use for Unpaywall?"
-- The two are complementary and non-overlapping.
+- **web-browsing** is the routing layer ("which tier to use for this URL?")
+- **academic-research** is the deep-dive layer ("how do I write OpenAlex filter parameters? what email does Unpaywall want?")
+- The two are complementary. If you're just scraping one publisher page and don't need the OA ladder, web-browsing's `extract_page.py` is lighter.
 
-## Known Caveats
+## Known caveats
 
-- Google Scholar requires a stealth browser (camoufox or playwright-stealth v2); do not use the legacy `playwright_stealth` API
-- Unpaywall's email parameter is **required** and **must be a real address** — it serves as the sole "authentication". Placeholder emails (e.g., `test@example.com`) will return 422 errors.
-- arXiv enforces HTTPS; HTTP requests are automatically redirected via 301
-- **CORE without an API key is extremely limited** — aggressive rate limits (429 after just a few requests). Register at https://core.ac.uk/services/api for a free key (increases quota from ~100/day to 10,000/day). See [api-core.md](reference/api-core.md).
-- **Semantic Scholar free tier is very tight** — ~100 requests per 5 minutes without key, 1 req/s with key. Request an API key for any serious use. See [api-semantic-scholar.md](reference/api-semantic-scholar.md).
-- **Library Genesis (LibGen)** is available as a last-resort fallback when all legitimate OA channels (Unpaywall, CORE, Europe PMC, arXiv) have been exhausted. Legal status varies by jurisdiction — use is solely the user's responsibility. See [libgen-fallback.md](reference/libgen-fallback.md).
-- For comprehensive error handling strategies, see [error-handling.md](reference/error-handling.md)
+- **Unpaywall's `email` parameter is required and must be real** — placeholder addresses get HTTP 422. Set `$LINGTAI_RESEARCH_EMAIL` once.
+- **CORE without an API key is harshly rate-limited** (~100/day vs 10,000/day with a free key from https://core.ac.uk/services/api).
+- **Semantic Scholar free tier is very tight** (~100 reqs / 5 min). Request a key for any serious citation-network work.
+- **Google Scholar requires a stealth browser** (camoufox or playwright-stealth v2); legacy `playwright_stealth` API does not work.
+- **arXiv enforces HTTPS** — HTTP requests are 301-redirected automatically.
+- **Library Genesis legality varies by jurisdiction** — use is the user's responsibility. Pass `--no-libgen` to opt out.
+- **Publisher-page extraction (Tier 5)** uses Playwright + pandoc; first invocation installs `zhiping0913/Download_paper` from git. Requires Chromium (`playwright install chromium`) and pandoc on `$PATH`. See [reference/publisher-page-extraction.md](reference/publisher-page-extraction.md).

--- a/tui/internal/preset/skills/academic-research/reference/pipeline-obtain-pdf.md
+++ b/tui/internal/preset/skills/academic-research/reference/pipeline-obtain-pdf.md
@@ -15,7 +15,8 @@ Given a DOI / arXiv ID / paper URL, retrieve the paper's full text (PDF or plain
 2. **Resolve metadata** — CrossRef (DOI) / OpenAlex / arXiv API.
 3. **Find free PDF** — Unpaywall / arXiv direct link / PMC.
 4. **Download PDF** — Direct download via curl / requests.
-5. **(If all OA channels fail) LibGen fallback** — See [libgen-fallback.md](libgen-fallback.md) for live mirror discovery and download.
+5. **(If OA channels fail, DOI is a supported publisher) Publisher-page extraction** — Nature/APS/AIP/IOP/Cambridge → structured Markdown with LaTeX preserved. See [publisher-page-extraction.md](publisher-page-extraction.md).
+6. **(If all of the above fail) LibGen fallback** — See [libgen-fallback.md](libgen-fallback.md) for live mirror discovery and download.
 6. **(If web page, not PDF) Extract web page body** — Select BeautifulSoup or Camoufox based on the site.
 7. **Extract text from PDF** — PyMuPDF text extraction.
 8. **Output** — Return `(status, filepath_or_text, metadata)`.
@@ -33,7 +34,7 @@ What is the input?
 │   ├─ CrossRef resolve metadata
 │   ├─ Unpaywall find free PDF
 │   │   ├─ Found → Download PDF → Extract text
-│   │   └─ Not found → CORE → Europe PMC → arXiv → LibGen (last resort, see libgen-fallback.md)
+│   │   └─ Not found → CORE → Europe PMC → arXiv → publisher-page extract (see publisher-page-extraction.md) → LibGen (last resort, see libgen-fallback.md)
 │   └─ OpenAlex supplementary metadata
 │
 ├─ arXiv ID (e.g. 2301.00001)

--- a/tui/internal/preset/skills/academic-research/reference/publisher-page-extraction.md
+++ b/tui/internal/preset/skills/academic-research/reference/publisher-page-extraction.md
@@ -1,0 +1,137 @@
+# Publisher Page Extraction (Tier 5)
+
+> **Most agents do not need this file.** `scripts/fetch_paper.py` invokes
+> this tier automatically when tiers 1–4 (arXiv / Unpaywall / Europe PMC /
+> CORE) all miss and the DOI prefix matches a supported publisher.
+> Read this only if you need to invoke the tool manually, debug a tier-5
+> failure, or run it outside the script's slug/manifest contract.
+
+---
+
+## What it is
+
+`zhiping0913/Download_paper` is an open-source, AI-friendly extractor that
+opens a publisher's article page in headless Chromium, identifies the
+article body, and produces structured **Markdown with LaTeX formulas
+preserved**, plus high-resolution figures and supplementary materials.
+
+This is qualitatively different from a generic PDF download:
+
+- **PDF tier** (Unpaywall, CORE, arXiv) returns raw bytes; agents must then
+  PyMuPDF-extract text and lose layout/equation fidelity.
+- **Publisher-extract tier** returns Markdown that already has the section
+  structure, citation list, and inline math intact. Better starting
+  material for downstream tasks like literature review or LaTeX writing.
+
+Repository: https://github.com/zhiping0913/Download_paper
+
+## When this tier wins
+
+Use only when **all** of the following are true:
+
+1. The paper has no preprint or OA mirror (Unpaywall, Europe PMC, CORE, arXiv all returned no PDF).
+2. The DOI prefix is in the supported set:
+
+   | Prefix | Publisher |
+   |--------|-----------|
+   | 10.1038 | Nature / Springer |
+   | 10.1103 | American Physical Society (PRL, PRD, PRX, …) |
+   | 10.1063 | AIP Publishing (Phys. Plasmas, JCP, AIP Advances, …) |
+   | 10.1088 | IOP Science (ApJ, ApJL, ApJS, JPhys, …) |
+   | 10.1017 | Cambridge University Press |
+
+3. You either have institutional access for the paywalled portion **or**
+   the article is gold/hybrid OA on the publisher site.
+4. The paper is math/formula-heavy and you want the equations preserved.
+
+If any of these fail, prefer `tier_libgen` (last-resort PDF) or accept the
+fetch failure and surface it to the user.
+
+## Manual invocation
+
+The script already does this automatically — only run by hand when
+debugging.
+
+### Install (one-time)
+
+```bash
+pip install git+https://github.com/zhiping0913/Download_paper
+
+# System deps the extractor relies on:
+playwright install chromium          # headless browser
+# pandoc must be on $PATH             # formula conversion
+# python-magic                        # auto-installed by the package
+```
+
+### Single DOI
+
+```python
+from download_paper import download_paper
+md_path = download_paper("10.1103/PhysRevLett.125.015001")
+print(md_path)  # → /path/to/output/PhysRevLett.125.015001.md
+```
+
+### Batch
+
+```bash
+# Their own CLI:
+python -m download_paper.batch_process --input dois.txt --out papers/
+
+# Or stay inside fetch_paper.py's contract:
+python3 ${CLAUDE_SKILL_DIR}/scripts/fetch_paper.py --batch dois.txt --out papers/
+```
+
+The second form is preferred because it preserves the `manifest.json`
+contract — re-runs are idempotent, and agents that survive a molt can
+resume from `papers/` without re-fetching.
+
+## Output shape
+
+Default output (when invoked directly):
+
+```
+<output-dir>/
+├── {DOI-slug}.md            # full article, sections preserved, LaTeX intact
+├── {DOI-slug}/figures/      # high-res figures
+├── {DOI-slug}/supp/         # supplementary materials
+└── {DOI-slug}/metadata.json # title, authors, year, journal, doi
+```
+
+When called via `fetch_paper.py`, the Markdown is copied to
+`papers/{slug}/paper.md` and the `manifest.json` records `tier:
+publisher_extract`.
+
+## Failure modes and recovery
+
+| Symptom | Likely cause | Recovery |
+|---------|--------------|----------|
+| First call hangs ~30s then succeeds | Cold Chromium boot | Expected; subsequent calls are warm |
+| `pip install` fails with playwright wheel error | Pinned Chromium for unsupported arch | Try `pip install playwright==1.46.* && playwright install chromium` separately |
+| Anti-bot challenge (CAPTCHA / Cloudflare) | Publisher detected automation | Tool auto-switches to headed mode; needs `$DISPLAY` on Linux. Without a display, this tier will fail — fall through to LibGen |
+| `pandoc: command not found` | pandoc missing from PATH | `brew install pandoc` (macOS), `apt install pandoc` (Linux) |
+| Publisher returns 403 | No institutional access for subscription article | This tier cannot help — log the gap in `manifest.json` and fall through |
+| DOI prefix not in supported set | No publisher handler implemented | Skip this tier; `fetch_paper.py` does this check before invoking |
+
+When this tier fails, `fetch_paper.py` falls through to `tier_libgen`
+(unless `--no-libgen` was passed). LibGen is qualitatively worse output
+(PDF, not Markdown) but legally and technically a different surface, so
+it often catches what publisher extraction misses.
+
+## Legal note
+
+This tool extracts content from publisher pages your browser would
+normally render. Whether that is permitted depends on:
+
+- Your institutional subscription terms
+- The publisher's robots.txt and ToS
+- Local copyright law
+
+Use is the user's responsibility. The tool itself is open-source and does
+not bypass authentication — if you don't have access to the paper in a
+browser, this tier won't get it either.
+
+## See also
+
+- [pipeline-obtain-pdf.md](pipeline-obtain-pdf.md) — full manual ladder including this tier
+- [libgen-fallback.md](libgen-fallback.md) — the next tier down when this one fails
+- [error-handling.md](error-handling.md) — generic 403/429 patterns

--- a/tui/internal/preset/skills/academic-research/scripts/fetch_paper.py
+++ b/tui/internal/preset/skills/academic-research/scripts/fetch_paper.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""
+fetch_paper.py — academic-research skill, tier-1 entry point
+
+Given a DOI, arXiv ID, or PMID, walk the open-access ladder and save the
+paper full-text plus structured metadata into a stable on-disk layout.
+
+Usage:
+    python3 fetch_paper.py 10.1103/PhysRevLett.125.015001
+    python3 fetch_paper.py arXiv:2301.00001
+    python3 fetch_paper.py PMID:12345678
+    python3 fetch_paper.py --batch dois.txt --out papers/
+    python3 fetch_paper.py 10.1038/nature12373 --email me@example.com --no-libgen
+
+Tier ladder (stops at first success):
+    1. arXiv direct (preprints — fastest, free, no key)
+    2. Unpaywall      (publisher-blessed OA PDFs)
+    3. Europe PMC     (biomed full-text + arXiv mirror)
+    4. CORE           (institutional repository aggregator)
+    5. Publisher-page extraction (zhiping0913/Download_paper) for
+       10.1038 / 10.1103 / 10.1063 / 10.1088 / 10.1017
+    6. LibGen         (last resort, opt-out with --no-libgen)
+
+Output (per paper):
+    papers/{slug}/
+        paper.pdf | paper.md         # full-text artifact
+        metadata.json                 # CrossRef-normalized metadata
+        manifest.json                 # {status, tier, source, ts, doi}
+
+The script is idempotent — re-running skips entries whose manifest.json
+already reports status=ok. This is the contract the rest of the skill
+relies on: agents that survive a molt can resume from `papers/` without
+re-fetching anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+from urllib.parse import quote
+
+import requests
+
+# ──────────────────────────────────────────────────────────
+#  Constants
+# ──────────────────────────────────────────────────────────
+
+UA = "lingtai-academic-research/3.0 (mailto:{email})"
+DEFAULT_EMAIL = os.environ.get("LINGTAI_RESEARCH_EMAIL", "lingtai-agent@example.org")
+
+PUBLISHER_EXTRACTABLE_PREFIXES = {
+    "10.1038": "Nature / Springer",
+    "10.1103": "American Physical Society",
+    "10.1063": "AIP Publishing",
+    "10.1088": "IOP Science",
+    "10.1017": "Cambridge University Press",
+}
+
+ARXIV_ID_RE = re.compile(r"^(?:arXiv:)?(\d{4}\.\d{4,5})(v\d+)?$", re.IGNORECASE)
+PMID_RE = re.compile(r"^(?:PMID:)?(\d{6,9})$", re.IGNORECASE)
+DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")
+
+
+# ──────────────────────────────────────────────────────────
+#  Input parsing
+# ──────────────────────────────────────────────────────────
+
+def classify(identifier: str) -> tuple[str, str]:
+    """Return (kind, normalized_id). kind ∈ {doi, arxiv, pmid}."""
+    s = identifier.strip()
+    s = s.replace("https://doi.org/", "").replace("http://doi.org/", "")
+    if m := ARXIV_ID_RE.match(s):
+        return "arxiv", m.group(1)
+    if m := PMID_RE.match(s):
+        return "pmid", m.group(1)
+    if DOI_RE.match(s):
+        return "doi", s
+    raise ValueError(f"Unrecognized identifier: {identifier!r}")
+
+
+def slugify(meta: dict, fallback: str) -> str:
+    """First-author-year-firstword slug; fallback to identifier."""
+    authors = meta.get("authors") or []
+    year = meta.get("year") or "0000"
+    title = meta.get("title") or ""
+    first_author = "anon"
+    if authors:
+        last = authors[0].split()[-1] if authors[0] else "anon"
+        first_author = re.sub(r"[^a-zA-Z0-9]", "", last).lower() or "anon"
+    first_word = ""
+    for tok in title.split():
+        tok = re.sub(r"[^a-zA-Z0-9]", "", tok).lower()
+        if tok and len(tok) > 2:
+            first_word = tok
+            break
+    if first_author and year != "0000":
+        slug = f"{first_author}-{year}"
+        if first_word:
+            slug += f"-{first_word}"
+        return slug
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", fallback)[:60]
+
+
+# ──────────────────────────────────────────────────────────
+#  Metadata resolution
+# ──────────────────────────────────────────────────────────
+
+def resolve_metadata(kind: str, ident: str, email: str) -> dict:
+    """Return a normalized metadata dict regardless of input kind.
+
+    Shape: {title, authors[], year, journal, doi, arxiv_id?, pmid?, publisher?}
+    """
+    if kind == "doi":
+        return _crossref(ident, email)
+    if kind == "arxiv":
+        return _arxiv_meta(ident)
+    if kind == "pmid":
+        return _europe_pmc_meta(ident)
+    raise ValueError(kind)
+
+
+def _crossref(doi: str, email: str) -> dict:
+    r = requests.get(
+        f"https://api.crossref.org/works/{doi}",
+        headers={"User-Agent": UA.format(email=email)},
+        timeout=15,
+    )
+    r.raise_for_status()
+    d = r.json()["message"]
+    pub_date = d.get("published-print") or d.get("published-online") or {}
+    return {
+        "title": (d.get("title") or [""])[0],
+        "authors": [
+            f"{a.get('given', '')} {a.get('family', '')}".strip()
+            for a in d.get("author", [])
+        ],
+        "year": (pub_date.get("date-parts") or [[0]])[0][0],
+        "journal": (d.get("container-title") or [""])[0],
+        "doi": doi,
+        "publisher": d.get("publisher", ""),
+        "citations": d.get("is-referenced-by-count", 0),
+        "url": d.get("URL", f"https://doi.org/{doi}"),
+    }
+
+
+def _arxiv_meta(arxiv_id: str) -> dict:
+    r = requests.get(
+        f"https://export.arxiv.org/api/query?id_list={arxiv_id}",
+        timeout=15,
+    )
+    r.raise_for_status()
+    # Minimal Atom parse — no feedparser dep
+    text = r.text
+    title = _xml_first(text, "title", skip=1) or arxiv_id
+    summary = _xml_first(text, "summary") or ""
+    year = 0
+    if m := re.search(r"<published>(\d{4})", text):
+        year = int(m.group(1))
+    authors = re.findall(r"<name>([^<]+)</name>", text)
+    doi_match = re.search(r"<arxiv:doi[^>]*>([^<]+)</arxiv:doi>", text)
+    return {
+        "title": title.strip(),
+        "authors": authors,
+        "year": year,
+        "journal": "arXiv preprint",
+        "doi": doi_match.group(1) if doi_match else "",
+        "arxiv_id": arxiv_id,
+        "abstract": summary.strip(),
+        "url": f"https://arxiv.org/abs/{arxiv_id}",
+    }
+
+
+def _europe_pmc_meta(pmid: str) -> dict:
+    r = requests.get(
+        "https://www.ebi.ac.uk/europepmc/webservices/rest/search",
+        params={"query": f"EXT_ID:{pmid}", "format": "json", "resultType": "core"},
+        timeout=15,
+    )
+    r.raise_for_status()
+    results = r.json().get("resultList", {}).get("result", [])
+    if not results:
+        raise LookupError(f"PMID {pmid} not found in Europe PMC")
+    d = results[0]
+    return {
+        "title": d.get("title", ""),
+        "authors": [a.strip() for a in (d.get("authorString") or "").split(",") if a.strip()],
+        "year": int(d.get("pubYear", 0) or 0),
+        "journal": d.get("journalTitle", ""),
+        "doi": d.get("doi", ""),
+        "pmid": pmid,
+        "pmcid": d.get("pmcid", ""),
+        "url": f"https://europepmc.org/abstract/MED/{pmid}",
+    }
+
+
+def _xml_first(text: str, tag: str, skip: int = 0) -> Optional[str]:
+    matches = re.findall(rf"<{tag}[^>]*>([\s\S]*?)</{tag}>", text)
+    if len(matches) > skip:
+        return matches[skip]
+    return None
+
+
+# ──────────────────────────────────────────────────────────
+#  Tier implementations
+# ──────────────────────────────────────────────────────────
+
+def tier_arxiv(meta: dict, out_dir: Path) -> Optional[Path]:
+    """Try arXiv direct PDF (works for any arxiv_id, or DOIs that index arXiv)."""
+    aid = meta.get("arxiv_id")
+    if not aid:
+        # Search arXiv by title as a low-cost guess for preprint-style DOIs
+        if meta.get("title"):
+            try:
+                r = requests.get(
+                    "https://export.arxiv.org/api/query",
+                    params={"search_query": f'ti:"{meta["title"]}"', "max_results": 1},
+                    timeout=15,
+                )
+                if m := re.search(r"arxiv\.org/abs/([0-9.]+)", r.text):
+                    aid = m.group(1)
+            except requests.RequestException:
+                return None
+        if not aid:
+            return None
+    url = f"https://arxiv.org/pdf/{aid}.pdf"
+    return _download(url, out_dir / "paper.pdf")
+
+
+def tier_unpaywall(meta: dict, email: str, out_dir: Path) -> Optional[Path]:
+    doi = meta.get("doi")
+    if not doi:
+        return None
+    try:
+        r = requests.get(
+            f"https://api.unpaywall.org/v2/{doi}",
+            params={"email": email},
+            timeout=15,
+        )
+        r.raise_for_status()
+        d = r.json()
+        loc = d.get("best_oa_location") or {}
+        pdf_url = loc.get("url_for_pdf") or loc.get("url")
+        if pdf_url:
+            return _download(pdf_url, out_dir / "paper.pdf")
+    except requests.RequestException:
+        return None
+    return None
+
+
+def tier_europe_pmc(meta: dict, out_dir: Path) -> Optional[Path]:
+    pmcid = meta.get("pmcid")
+    if not pmcid and (doi := meta.get("doi")):
+        try:
+            r = requests.get(
+                "https://www.ebi.ac.uk/europepmc/webservices/rest/search",
+                params={"query": f"DOI:{doi}", "format": "json", "resultType": "lite"},
+                timeout=15,
+            )
+            r.raise_for_status()
+            for res in r.json().get("resultList", {}).get("result", []):
+                if res.get("pmcid"):
+                    pmcid = res["pmcid"]
+                    break
+        except requests.RequestException:
+            return None
+    if not pmcid:
+        return None
+    url = f"https://europepmc.org/articles/{pmcid}?pdf=render"
+    return _download(url, out_dir / "paper.pdf")
+
+
+def tier_core(meta: dict, out_dir: Path) -> Optional[Path]:
+    """CORE search — requires CORE_API_KEY env var; skipped silently if absent."""
+    key = os.environ.get("CORE_API_KEY")
+    if not key:
+        return None
+    doi = meta.get("doi")
+    if not doi:
+        return None
+    try:
+        r = requests.get(
+            "https://api.core.ac.uk/v3/search/works",
+            params={"q": f"doi:{doi}", "limit": 1},
+            headers={"Authorization": f"Bearer {key}"},
+            timeout=15,
+        )
+        r.raise_for_status()
+        for hit in r.json().get("results", []):
+            if pdf := hit.get("downloadUrl"):
+                return _download(pdf, out_dir / "paper.pdf")
+    except requests.RequestException:
+        return None
+    return None
+
+
+def tier_publisher_extract(meta: dict, out_dir: Path) -> Optional[Path]:
+    """Use zhiping0913/Download_paper for publisher-page extraction.
+
+    Lazy-installed on first invocation. Produces Markdown with preserved
+    LaTeX formulas — better than PDF-to-text for math-heavy papers.
+    """
+    doi = meta.get("doi")
+    if not doi:
+        return None
+    prefix = doi.split("/")[0]
+    if prefix not in PUBLISHER_EXTRACTABLE_PREFIXES:
+        return None
+
+    if not _ensure_download_paper():
+        return None
+
+    try:
+        from download_paper import download_paper  # type: ignore
+    except ImportError:
+        return None
+
+    try:
+        md_path = download_paper(doi)  # returns str path to .md
+    except Exception as e:
+        print(f"  [tier-5] Download_paper failed: {e}", file=sys.stderr)
+        return None
+
+    if md_path and Path(md_path).exists():
+        dst = out_dir / "paper.md"
+        shutil.copy(md_path, dst)
+        return dst
+    return None
+
+
+def tier_libgen(meta: dict, out_dir: Path) -> Optional[Path]:
+    """Last-resort LibGen lookup. See reference/libgen-fallback.md for design notes."""
+    doi = meta.get("doi")
+    if not doi:
+        return None
+    mirror = _libgen_mirror()
+    if not mirror:
+        return None
+    try:
+        # Title-based search — DOI endpoints have been flaky (see libgen-fallback.md)
+        q = quote(meta.get("title", "") or doi)
+        r = requests.get(f"{mirror}/scimag/?q={q}", timeout=20)
+        r.raise_for_status()
+        # Look for the first md5-keyed download link
+        if m := re.search(r'href="(/scimag/[^"]*md5=[a-f0-9]{32}[^"]*)"', r.text):
+            detail = requests.get(mirror + m.group(1), timeout=20)
+            if dl := re.search(r'href="(https?://[^"]+\.pdf)"', detail.text):
+                return _download(dl.group(1), out_dir / "paper.pdf")
+    except requests.RequestException:
+        return None
+    return None
+
+
+# ──────────────────────────────────────────────────────────
+#  Helpers
+# ──────────────────────────────────────────────────────────
+
+def _download(url: str, dst: Path, max_bytes: int = 200_000_000) -> Optional[Path]:
+    try:
+        with requests.get(url, stream=True, timeout=30, allow_redirects=True) as r:
+            r.raise_for_status()
+            ctype = r.headers.get("content-type", "").lower()
+            if "html" in ctype and not url.endswith(".pdf"):
+                return None
+            total = 0
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            with open(dst, "wb") as f:
+                for chunk in r.iter_content(chunk_size=65536):
+                    if chunk:
+                        total += len(chunk)
+                        if total > max_bytes:
+                            dst.unlink(missing_ok=True)
+                            return None
+                        f.write(chunk)
+            if total < 1024:
+                dst.unlink(missing_ok=True)
+                return None
+            return dst
+    except requests.RequestException:
+        return None
+
+
+def _libgen_mirror() -> Optional[str]:
+    for url in ["https://libgen.li", "https://libgen.is", "https://libgen.rs", "https://libgen.gs"]:
+        try:
+            if requests.head(url + "/", timeout=5, allow_redirects=True).status_code == 200:
+                return url
+        except requests.RequestException:
+            continue
+    return None
+
+
+def _ensure_download_paper() -> bool:
+    """Lazy install zhiping0913/Download_paper on first use. Returns True if importable."""
+    try:
+        import download_paper  # type: ignore
+        return True
+    except ImportError:
+        pass
+    print("  [tier-5] installing publisher-extraction tool (Download_paper)...", file=sys.stderr)
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--quiet",
+             "git+https://github.com/zhiping0913/Download_paper"],
+            timeout=180,
+        )
+        try:
+            import download_paper  # type: ignore  # noqa: F401
+            return True
+        except ImportError:
+            return False
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print(f"  [tier-5] install failed: {e}", file=sys.stderr)
+        return False
+
+
+# ──────────────────────────────────────────────────────────
+#  Orchestration
+# ──────────────────────────────────────────────────────────
+
+TIERS = [
+    ("arxiv", tier_arxiv),
+    ("unpaywall", tier_unpaywall),
+    ("europe_pmc", tier_europe_pmc),
+    ("core", tier_core),
+    ("publisher_extract", tier_publisher_extract),
+    ("libgen", tier_libgen),
+]
+
+
+def fetch_one(identifier: str, out_root: Path, email: str, allow_libgen: bool = True) -> dict:
+    kind, ident = classify(identifier)
+    meta = resolve_metadata(kind, ident, email)
+    slug = slugify(meta, ident)
+    out_dir = out_root / slug
+    manifest_path = out_dir / "manifest.json"
+
+    if manifest_path.exists():
+        try:
+            existing = json.loads(manifest_path.read_text())
+            if existing.get("status") == "ok":
+                print(f"  [skip] {slug} already fetched (tier={existing.get('tier')})")
+                return existing
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "metadata.json").write_text(json.dumps(meta, indent=2, ensure_ascii=False))
+
+    for name, fn in TIERS:
+        if name == "libgen" and not allow_libgen:
+            continue
+        sig = fn.__code__.co_varnames[: fn.__code__.co_argcount]
+        print(f"  [tier] {name}...", end=" ", flush=True)
+        try:
+            if "email" in sig:
+                path = fn(meta, email, out_dir)
+            else:
+                path = fn(meta, out_dir)
+        except Exception as e:
+            print(f"error ({e})")
+            continue
+        if path:
+            print(f"ok → {path.name}")
+            manifest = {
+                "status": "ok",
+                "tier": name,
+                "source": str(path.relative_to(out_dir)),
+                "doi": meta.get("doi"),
+                "arxiv_id": meta.get("arxiv_id"),
+                "pmid": meta.get("pmid"),
+                "title": meta.get("title"),
+                "ts": int(time.time()),
+            }
+            manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+            return manifest
+        print("miss")
+
+    manifest = {
+        "status": "fail",
+        "reason": "all tiers exhausted",
+        "doi": meta.get("doi"),
+        "arxiv_id": meta.get("arxiv_id"),
+        "pmid": meta.get("pmid"),
+        "title": meta.get("title"),
+        "ts": int(time.time()),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+    return manifest
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("identifier", nargs="?", help="DOI, arXiv ID, or PMID")
+    p.add_argument("--batch", help="file with one identifier per line")
+    p.add_argument("--out", default="papers", help="output directory (default: ./papers)")
+    p.add_argument("--email", default=DEFAULT_EMAIL,
+                   help="email for Unpaywall (use a real address; default from $LINGTAI_RESEARCH_EMAIL)")
+    p.add_argument("--no-libgen", action="store_true", help="skip LibGen tier")
+    p.add_argument("--dry-run", action="store_true", help="resolve metadata only, no PDF fetch")
+    args = p.parse_args()
+
+    if not args.identifier and not args.batch:
+        p.error("provide an identifier or --batch FILE")
+
+    if args.email == "lingtai-agent@example.org":
+        print("warning: using placeholder email — set $LINGTAI_RESEARCH_EMAIL or pass --email "
+              "for Unpaywall (placeholder addresses get 422'd).", file=sys.stderr)
+
+    out_root = Path(args.out)
+    identifiers: list[str] = []
+    if args.batch:
+        identifiers = [
+            line.strip() for line in Path(args.batch).read_text().splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+    if args.identifier:
+        identifiers.append(args.identifier)
+
+    if args.dry_run:
+        for ident in identifiers:
+            kind, normalized = classify(ident)
+            meta = resolve_metadata(kind, normalized, args.email)
+            print(json.dumps(meta, indent=2, ensure_ascii=False))
+        return 0
+
+    results: list[dict] = []
+    for i, ident in enumerate(identifiers, 1):
+        print(f"[{i}/{len(identifiers)}] {ident}")
+        try:
+            results.append(fetch_one(ident, out_root, args.email, allow_libgen=not args.no_libgen))
+        except Exception as e:
+            print(f"  ERROR: {e}", file=sys.stderr)
+            results.append({"status": "error", "reason": str(e), "identifier": ident})
+
+    ok = sum(1 for r in results if r.get("status") == "ok")
+    fail = len(results) - ok
+    print(f"\nDone: {ok} ok, {fail} fail. See {out_root}/")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/fetch_paper.py` as the skill's "try this first" entry point — a 6-tier OA ladder (arXiv → Unpaywall → Europe PMC → CORE → publisher-page extract → LibGen) that writes `papers/{slug}/{paper, metadata.json, manifest.json}` and is idempotent across re-runs, so agents that survive a molt can resume from disk without re-fetching.
- Integrates [zhiping0913/Download_paper](https://github.com/zhiping0913/Download_paper) as tier 5 (publisher-page extraction for Nature/APS/AIP/IOP/Cambridge → structured Markdown with LaTeX preserved). Lazy-installed from git on first invocation.
- Rewrites `SKILL.md` (v2.0.0 → v3.0.0) to lead with the script and demote the 12-API/6-pipeline reference tables below the escape-hatch section. Adds `allowed-tools` frontmatter (python3/curl/pip) so the script runs without per-call permission prompts. Mirrors `web-browsing`'s pattern.
- Adds `reference/publisher-page-extraction.md` as a leaf doc for agents that need to invoke Download_paper manually or debug a tier-5 failure. Links from `pipeline-obtain-pdf.md` (now showing the new tier between arXiv and LibGen).
- Stays inside the Anthropic skill spec: flat directory (`SKILL.md + scripts/ + reference/`), no new subdirectory categories invented.

## Test plan

- [x] `python3 -c \"import ast; ast.parse(open('fetch_paper.py').read())\"` — syntax clean
- [x] `fetch_paper.py --help` renders argparse usage
- [x] `fetch_paper.py --dry-run arXiv:2301.00001` resolves arXiv metadata
- [x] `fetch_paper.py --dry-run 10.1103/PhysRevLett.125.015001` resolves CrossRef metadata
- [x] End-to-end: `fetch_paper.py --no-libgen arXiv:2301.00001` writes `papers/thompson-2022-nftrig/{paper.pdf, metadata.json, manifest.json}` with `tier: arxiv`
- [x] Idempotence: re-running prints `[skip] thompson-2022-nftrig already fetched`
- [ ] Tier-5 (publisher-extract) live test on a Nature/APS DOI — deferred, requires institutional access for full verification
- [ ] Verify preset bundle picks up new files after next TUI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)