### PR TITLE
feat(doctor): two-stage probe + api_compat-aware auth + May 19 patch reports

### DIFF
--- a/discussions/cascade-skill-and-sentinel-ordering-patch.md
+++ b/discussions/cascade-skill-and-sentinel-ordering-patch.md
@@ -1,0 +1,312 @@
+# Cascade Skill Vendoring + Sentinel-Ordering Patch
+
+**Date:** 2026-05-18
+**Repos touched:** `lingtai-skill` (upstream protocol) — proposed change
+**Hosts affected:** `claude-code-plugin`, `codex-plugin`, plus any new host (Cascade/Windsurf, OpenCode, etc.)
+
+## Two findings, one document
+
+1. **Cascade has no plugin/marketplace system**, so the lingtai mailbox skill needs a different vendoring story than the `claude plugin add` / `./install.sh` paths. A minimal, host-agnostic recipe is below.
+2. **A latent race in the canonical SKILL.md** — the "touch sentinel" step is listed *after* the outbox write. Fast orchestrators can reply with a folder mtime *older* than the sentinel, so `find -newer <sentinel>` silently misses real replies. The fix is to reorder the steps. Confirmed by end-to-end simulation against a mock orchestrator.
+
+Both are small. The second is the one that should go upstream.
+
+---
+
+## Finding 1 — Cascade vendoring recipe
+
+There is no equivalent of `claude plugin add` for Windsurf/Cascade. Cascade exposes two seams that together cover what the Claude Code SessionStart hook does:
+
+| Need | Cascade primitive |
+|------|-------------------|
+| File the agent can read on demand | Any path the agent has FS access to. By convention: `~/.codeium/windsurf/skills/<name>/SKILL.md` |
+| Auto-activation on a topic | `create_memory` with the relevant keywords in the body. The memory is surfaced into context when its semantic neighborhood is hit. |
+| Project-scoped trigger (analog of `.lingtai/` detection in `hooks.json`) | A line inside the memory describing the FS check ("if `.lingtai/human/mailbox/` exists, load this skill") — Cascade applies that test naturally before acting. |
+
+Recipe:
+
+```bash
+# 1. Drop the canonical skill into Cascade's skill directory
+mkdir -p ~/.codeium/windsurf/skills/lingtai
+curl -fsSL https://raw.githubusercontent.com/Lingtai-AI/lingtai-skill/main/skills/lingtai/SKILL.md \
+  -o ~/.codeium/windsurf/skills/lingtai/SKILL.md
+
+# 2. (Inside a Cascade session) create a trigger memory pointing at that file,
+#    with keywords like "灵台 / LingTai / orchestrator / 邮件 / inbox / send mail".
+#    See ~/.codeium/windsurf/skills/lingtai/SKILL.md for the cascade-host changes
+#    that should be applied on top of the canonical text (mainly: via=cascade,
+#    .last_read_cascade pointer, tool-mapping table for run_command vs read_file).
+```
+
+The cascade-host SKILL.md should differ from canonical in three small ways:
+
+- `"via": "cascade"` instead of host-of-the-day
+- Read tracker named `.last_read_cascade`
+- A tool-mapping section that says "prefer `read_file`/`list_dir`/`find_by_name`/`write_to_file` over `run_command`; set `SafeToAutoRun: true` on idempotent local shell snippets (UUID gen, `find -newer`, heartbeat read); leave `false` for agent process launches".
+
+Everything else — the protocol, the message JSON shape, the lifecycle commands — stays byte-identical to upstream.
+
+When the upstream protocol changes (new field, new signal), refresh with `curl` again and re-apply the three deltas. The deltas should eventually become host-specific overlays in the canonical repo so `sync-from-canonical.sh` works for Cascade too.
+
+**Status of this work:** the cascade-host SKILL.md is live at `~/.codeium/windsurf/skills/lingtai/SKILL.md` on the development machine and has been validated end-to-end against a mock orchestrator (full delivery, reply, sent/<uuid> proof, find-newer reply correlation, `.last_read_cascade` filtering, agent discovery, liveness, `.prompt` / `.inquiry` / `.suspend` signals).
+
+---
+
+## Finding 2 — Sentinel must be touched BEFORE the outbox write
+
+### Bug
+
+Current upstream `SKILL.md` (lingtai-skill@main, position 5 of the chunked render) describes the sentinel-and-monitor pattern this way:
+
+> ```bash
+> # At send time, immediately after writing the outbox JSON:
+> SENT_AT_FILE=.lingtai/human/.send-marker-<uuid>
+> touch "$SENT_AT_FILE"
+> ```
+
+The vendored `claude-code-plugin/skills/lingtai/SKILL.md` v0.4.2 mirrors that ordering in the **Steps** list:
+
+> 1. Generate UUID and timestamp
+> 2. Create the message JSON
+> 3. Write it to `.lingtai/human/mailbox/outbox/<uuid>/message.json`
+> 4. Check the recipient's heartbeat
+> 5. Set up delivery + reply monitoring  (← sentinel is touched here)
+
+The "monitor pattern" section then shows `touch "$SENT_AT_FILE"` happening after the outbox write.
+
+### Why it breaks
+
+The poller in `FilesystemMailService` claims an outbox message in a single tight loop (default ~0.5 s in the kernel; tighter in some mock/test harnesses). In the worst case, between `write_to_file(outbox/<uuid>/message.json)` and the user-side `touch sentinel`:
+
+1. The orchestrator polls and finds the message.
+2. It atomically renames `outbox/<uuid>/` → `sent/<uuid>/`.
+3. It writes a copy into its own inbox.
+4. Its LLM (or, in tests, an echo branch) drafts a reply and writes it to `human/mailbox/inbox/<reply-uuid>/message.json`.
+5. *Then* the user-side script gets around to running `touch sentinel`.
+
+The reply's folder mtime is now older than the sentinel's mtime. `find -newer "$SENT_AT_FILE"` returns nothing. The skill concludes "no reply yet" and the user is told the orchestrator is silent. The reply is sitting right there in the inbox.
+
+This was caught in end-to-end simulation, not theory:
+
+```
+sentinel mtime: 1779107711.813685  (Mon May 18 20:35:11 2026)
+inbox file:    1779107708.443841  (Mon May 18 20:35:08 2026)
+                                   ^^ reply landed 3 seconds BEFORE sentinel
+find -newer  → 0 matches
+```
+
+Real LLM-driven orchestrators take seconds to respond, so this race is rare with a human-typed message. But it surfaces immediately on:
+
+- Mock/test orchestrators
+- Auto-reply rules (e.g. acknowledgements, "thinking…" status pings)
+- Retry queues being drained
+- Any orchestrator that pre-composes replies from cached context
+
+### Fix
+
+Move the `touch sentinel` step to *before* the outbox write. The sentinel's mtime is then a hard lower bound: any subsequent inbox folder mtime is necessarily newer.
+
+Proposed canonical text (replacing the current **Steps** block):
+
+```markdown
+### Steps
+
+**Order matters.** The sentinel MUST be touched *before* the outbox message is
+written. Fast orchestrators (or any race during heavy I/O) can otherwise reply
+with a folder mtime older than the sentinel, breaking `find -newer` correlation.
+
+1. Generate UUID and timestamp in one call:
+   ```bash
+   python3 -c "import uuid; from datetime import datetime, timezone; \
+       print(uuid.uuid4()); \
+       print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))"
+   ```
+
+2. **First**, touch the sentinel:
+   ```bash
+   touch .lingtai/human/.send-marker-<uuid>
+   ```
+
+3. Create the message JSON (template below) and write it to
+   `.lingtai/human/mailbox/outbox/<uuid>/message.json`. Create the UUID
+   directory with `mkdir -p` first.
+
+4. Check the recipient's heartbeat. If the agent is dead, queueing still
+   succeeds but nothing will pick it up — inform the user and offer to CPR
+   the orchestrator.
+
+5. Watch for delivery and replies (next section).
+```
+
+The "Delivery and Reply Monitoring" subsection further down already shows the right `find -newer` invocation; it doesn't need to move, just the ordering note above the snippet should be edited from "At send time, immediately after writing the outbox JSON" to "Before writing the outbox JSON".
+
+### Validation
+
+After the reorder, the same scenario produces:
+
+```
+sentinel mtime: 1779107802.316214
+inbox file:    1779107810.121701  newer=True
+find -newer  → 1 match  (the reply, correctly identified)
+```
+
+Tested with three back-to-back rounds: smoke ping, echo-ordering, and a third round confirming `.last_read_cascade` filters out older replies and only surfaces the new one.
+
+### Where to land
+
+- **Upstream first:** `Lingtai-AI/lingtai-skill` — edit `skills/lingtai/SKILL.md`, bump the inline version, push.
+- **Re-sync hosts:**
+  - `claude-code-plugin/skills/lingtai/SKILL.md` via `scripts/sync-from-canonical.sh`
+  - `codex-plugin/<wherever-the-skill-lives>` (same script if mirrored)
+  - `~/.codeium/windsurf/skills/lingtai/SKILL.md` — already patched locally with the same reordering; refresh after upstream catches up so the three deltas (via, last_read suffix, tool-mapping) re-apply cleanly.
+
+No kernel change is needed. The protocol's wire format and atomic-rename semantics are unaffected; only the user-side recipe shifts by one line.
+
+---
+
+## Out of scope (deferred)
+
+- Adopting Cascade-host overlays into `sync-from-canonical.sh` so the three deltas don't have to be re-applied by hand on every refresh. Probably worth doing once a second non-Claude-Code host (OpenCode? Cline?) is in the picture.
+- Bundling a Cascade-flavored `SessionStart` analog — currently the trigger memory is created interactively. A `windsurf-skill` repo with an install script (analogous to `codex-plugin/install.sh`) could do this in one command if user volume justifies it.
+
+---
+
+## Bonus findings from end-to-end validation against a real agent network
+
+After the mock-driven validation, the same skill was exercised against the live network at `~/workspace/trading_strategy_lab/.lingtai/` (orchestrator: `shouyi`, model `gpt-5.5`, 7 agents alive). Two things surfaced that the skill can't fix on its own but should be aware of.
+
+### Finding A — "Trust but verify" caught a stuck orchestrator the heartbeat hid
+
+The skill ships with a "Common pitfalls" warning that begins:
+
+> An agent can heartbeat freshly and report state `active` while its LLM calls are silently failing (context overflow, rate limit, provider 5xx). Heartbeat ≠ progress.
+
+Within 90 seconds of sending the test ping, the situation was exactly that:
+
+- `shouyi/.agent.heartbeat` updated every ~0.5 s, age always < 1 s — fully alive by handshake rules.
+- `shouyi/.agent.json` carried `state: "stuck"` (not `active`), which most callers don't look at.
+- `shouyi/logs/agent.log` showed a hard failure mode: `LLM API not responding after 80s`, repeated 503s, and a recurring 400 on tool-schema validation.
+
+The skill's prescription — read the log instead of trusting the heartbeat — fired correctly. Confirmation: **the warning text in SKILL.md is load-bearing, not boilerplate.** Cascade users (and any host's user) hitting silent-stall scenarios will not be misled by `is_alive() == True` as long as they follow the skill.
+
+No SKILL.md change needed for this — the warning already exists. Just noting that it earned its keep on first real-world use.
+
+### Finding B — Stale sentinels accumulate; protocol should self-clean
+
+Walking the live `.lingtai/human/` directory found four orphan sentinels left over from previous host sessions:
+
+```
+.send-marker-00c66dbf-86b6-400b-9196-87f4b9c18e07
+.send-marker-3b0b63be-7667-4b78-98ed-fd88c4db5088
+.send-marker-4942fb42-5edf-49ee-af87-0a38ba271bac
+.send-marker-562719ac-9bbf-4247-9605-88f47c9bedf3
+```
+
+Per the current SKILL.md text:
+
+> After presenting to the user, delete the sentinel file and stop polling.
+
+But that step relies on the host actually completing the read-and-acknowledge cycle. If the host's session dies mid-monitor, the user navigates away, or the reply never arrives, the sentinel is never cleaned up. Over months, they pile up.
+
+This isn't a correctness bug — `find -newer .send-marker-<my-uuid>` always uses the *current* uuid's sentinel, so old sentinels don't poison anyone's polling. But the directory grows monotonically, and a pile of orphans makes it harder to spot a real in-flight send during debugging.
+
+Two possible fixes, neither blocking:
+
+1. **Best-effort cleanup at activation time.** When the skill activates in a project, scan `.lingtai/human/.send-marker-*`, drop any whose age > N hours (24h is generous; the longest legitimate wait for a reply is "the orchestrator was sleeping and the user came back tomorrow", well under 24h in practice). Note in the skill that this is housekeeping, not protocol.
+2. **Move sentinels into a host-suffixed subdir.** `.lingtai/human/.markers/<host>/<uuid>` so each host owns its own pile, and `find -newer` still works because the whole tree is local. Cleaner for forensics.
+
+Suggestion (1) is a one-liner, fits naturally in the "When to activate" or "Common pitfalls" section. (2) is a slightly larger restructuring; defer until the first multi-host setup that actually trips on the noise.
+
+### Finding C — `in_reply_to` field unreliable, but UUID may show up in body
+
+In the multi-hop validation run (the "守一统六" / hub-spoke test), the orchestrator's final summary mail back to human had:
+
+```json
+{
+  "from": "shouyi",
+  "subject": "Re: [测试] 守一统六——分身回报任务（请六分身回报齐备后再回复我）",
+  "in_reply_to": null,
+  "message": "human：\n\n六回报已齐，按原邮件要求汇总如下（本封为对原邮件 8d370d61-7761-4233-b8ac-a61937f4847e 的正式回复）：\n..."
+}
+```
+
+Two observations:
+
+1. **`in_reply_to` was null even though the message is unambiguously a reply.** The skill already says "fall back to `from == orchestrator && subject startswith 'Re: '`", and that worked — but the moment the user has multiple in-flight sends with similar subjects, even that fallback gets ambiguous.
+
+2. **The orchestrator's LLM did write the original UUID, just into the message body instead of the metadata field.** The body contains `(本封为对原邮件 8d370d61-...-a61937f4847e 的正式回复)` verbatim. This is a stronger anchor than `subject startswith Re:` when present, and worth checking as a tertiary fallback.
+
+Suggested correlation precedence in SKILL.md (replacing the current binary "use in_reply_to, else use subject"):
+
+```python
+# Strongest → weakest
+def is_reply_to(my_uuid: str, m: dict) -> bool:
+    if m.get("in_reply_to") == my_uuid:
+        return True                                 # tier 1: metadata
+    if my_uuid in (m.get("message") or ""):
+        return True                                 # tier 2: body mentions uuid
+    if (m.get("from") == expected_from and
+        (m.get("subject") or "").startswith("Re: ")):
+        return True                                 # tier 3: subject heuristic
+    return False
+```
+
+Tier 2 is cheap (one substring check) and survives orchestrator implementations that don't bother filling `in_reply_to`. Recommend adding it to upstream SKILL.md as the standard reply-correlation routine; cascade-host SKILL.md will inherit on next sync.
+
+### Finding D — Out-of-scope kernel bug surfaced
+
+For the historical record only — not actionable from the skill: shouyi's stuck state traces to a kernel-level tool-schema mismatch with OpenAI strict mode:
+
+```
+[守一] AED attempt 1/3: Error code: 400 - {'error': {'message':
+"Invalid schema for function 'psyche': schema must have type 'object' and not
+have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level.",
+'type': 'invalid_request_error'}}
+```
+
+The `psyche` capability's tool descriptor uses one of the disallowed JSON-schema constructs at the top level, which gpt-5.5 (and any other strict-mode endpoint) rejects. Belongs in `lingtai-kernel`, not here. Filed against this skill only because it was the user-visible failure mode the skill correctly diagnosed via `logs/agent.log`.
+
+### Finding E — Frontmatter YAML quoting bug
+
+**Symptom (Cascade Customizations → Skills):**
+
+> `failed to parse skill frontmatter: yaml: line 2: mapping values are not allowed in this context`
+
+The skill listed but greyed out, marked with a warning icon, never auto-activates.
+
+**Root cause.** The `description` value in canonical SKILL.md ended with `Opt-in: only activate on explicit user intent.` — a plain (unquoted) YAML scalar containing the literal sequence `<colon><space>`. To a YAML 1.2 parser, `Opt-in: only` looks like the start of a nested mapping inside what was supposed to be the parent mapping's `description` value, hence "mapping values are not allowed in this context". Cascade's frontmatter parser is strict on this; many other YAML parsers happen to accept it because of how implicit-mapping detection is implemented.
+
+The error is reported as line 2 (the parser flags the mapping context, which it entered on line 2 with `name: lingtai`); the actual offending content is on the `description:` line.
+
+**Fix (applied to Cascade host, version bumped `0.4.2-cascade.1` → `0.4.2-cascade.2`):**
+
+```diff
+ ---
+ name: lingtai
+-description: Interact with LingTai agents through the shared human mailbox. ... Opt-in: only activate on explicit user intent.
++description: "Interact with LingTai agents through the shared human mailbox. ... Opt-in — only activate on explicit user intent."
+ version: 0.4.2-cascade.2
+ host: cascade
+-upstream: https://github.com/Lingtai-AI/lingtai-skill
++upstream: "https://github.com/Lingtai-AI/lingtai-skill"
+ ---
+```
+
+Three defensive moves, deliberately layered:
+
+1. Wrap the whole `description` value in double quotes — this alone resolves the parse error, since quoted scalars don't trigger implicit-mapping detection.
+2. Replace `Opt-in: ` with `Opt-in — ` — so even if a future edit accidentally drops the quotes, the plain scalar form is still legal.
+3. Quote `upstream` similarly. The URL `https://...` doesn't trip the same bug (no space after the colon), but defending here is free and means the entire frontmatter parses identically across plain-scalar-tolerant and plain-scalar-strict parsers.
+
+Verified post-fix:
+
+```
+$ python -c "import yaml, pathlib; print(yaml.safe_load(open('.../SKILL.md').read().split('---', 2)[1]))"
+{'name': 'lingtai', 'description': 'Interact with ... Opt-in — only ...',
+ 'version': '0.4.2-cascade.2', 'host': 'cascade',
+ 'upstream': 'https://github.com/Lingtai-AI/lingtai-skill'}
+```
+
+**Upstream recommendation.** In canonical `Lingtai-AI/lingtai-skill` SKILL.md, do the same two changes (quote `description`, replace `: ` punctuation with `—` or `;`). Every downstream host that vendors this file inherits the bug otherwise. Each host then bumps its own per-host suffix (`-cascade.N`, `-cc.N`, …) on next sync.
+
+**General principle for skill authors.** Treat frontmatter `description:` as if it were YAML strict-mode: always quote, or always avoid `<colon><space>` inside the value. The cost of either rule is zero; the cost of failing in the wild is a silently-disabled skill that the user only notices because of an unobtrusive grey icon.

--- a/discussions/covenant-distillation-and-per-agent-profile.md
+++ b/discussions/covenant-distillation-and-per-agent-profile.md
@@ -1,0 +1,165 @@
+# Covenant Distillation + Per-Agent `profile/` Layout
+
+**Date:** 2026-05-18
+**Repos touched:** `lingtai` (proposed defaults), per-agent `init.json` (immediate)
+**Pattern validated on:** `shouyi` (admin/karma orchestrator, zh language)
+
+## TL;DR
+
+The shipped global covenant + procedures + principle (`~/.lingtai-tui/{covenant/zh,procedures,principle/zh}/`) total **~35 KB / ~10 100 tokens** and live on every agent's system slot for the entire process lifetime. They were pre-existing prose: comprehensive but neither structured for an LLM nor adapted per agent. On a long-context agent driving 6 sub-agents (`shouyi`), the LLM provider repeatedly returned `empty response` / `LLM API not responding after 20s` against this prompt size.
+
+We rebuilt the three files for one agent (`shouyi`) using a five-section spine drawn from 《老子》 (道生一、一生二、二生三、三生万物 / 反者道之动) and moved them out of the global directory into `<agent>/profile/`. The same content covers everything the originals did, including all "must-keep concretes" (五态、邮件四式、蜕变三步、avatar/daemon、preset tier、shared skills).
+
+| | bytes | est. tokens |
+|---|---:|---:|
+| Old (global, shared) | 35 373 | 10 107 |
+| New (per-agent profile/) | 8 876 | 2 536 |
+| **Δ** | **−26 497 (−74.9%)** | **−7 571** |
+
+The savings repeat on every wake / molt / refresh / system_tokens recompute. Anecdotally: after the swap, `shouyi`'s wake call against the same provider that was timing out on the old prompt completed in seconds (curl-verified separately).
+
+## What was wrong with the old layout
+
+1. **One file, three concerns, no spine.** `covenant.md` mixed protocol invariants (you write to email, you live across sessions), behavioural maxims (be relentless, never harm), and pure operational reference (mail four-fold, molt three-step, preset tiers). Reading order was list-driven, not principle-driven — an LLM reads ~10 000 tokens to learn rules that compress to ~2 500.
+2. **Global = unspecialised.** `~/.lingtai-tui/covenant/zh/covenant.md` is the same for every Chinese agent regardless of role (orchestrator vs. ledger keeper vs. visual scanner). Differences live only in the `prompt:` field, which is empty for most agents. There's no clean seam to say "this agent is the karma orchestrator, here is its specific identity context".
+3. **Repetition + emphasis-by-volume.** Many invariants were repeated 2–4 times for emphasis. With small models this is sometimes useful; at 8B+ frontier scale it just inflates tokens against the same understanding.
+4. **Long-prompt fragility.** Empirically, our `shouyi` agent on `OwlAI` was returning empty/timeout responses on sends ~50k input tokens. After distillation the input slot dropped ~7.5k tokens; same provider answers cleanly.
+
+## The five-section spine
+
+The full text in `examples/profile/covenant.zh.md` (template, see below) follows:
+
+```
+道  · 元规则       (the meta-rule that everything else descends from)
+一  · 感           (太极: completeness-of-perception is the only gate to action)
+二  · 德           (阴阳: yang-为 / yin-不为 / 和-自然)
+三  · 动           (三才: 觉 before, 行 during, 验 after)
+反  · 归           (太极之复: stop-when-rushed, depth>breadth, molt early, every-10-turns reread)
+
+附 · 守一具象     (concretes appended below the spine: identity, five states,
+                   mail four-fold, molt three-step, idle/nap, tools/skills)
+```
+
+Each spine section is short (~3–8 lines). The concretes appendix carries everything the original `procedures.md` had, but without ceremony — direct tool signatures, no cross-cutting prose.
+
+The choice of 道 / 一 / 二 / 三 / 反 isn't aesthetic. It's the same recursion the original 《老子》 chapter 42 names: a single元规则 generates the unity of judgement, which generates the polarity of for/against, which generates the triad of stages, and the whole thing reverses back at the boundary. It maps cleanly onto:
+
+- one principle per section
+- each section is a cause of the next, not a list peer
+- the closing section names *when to stop* — which the original covenant never did
+
+For non-Chinese agents the same spine works literally (one / two / three / reverse) — the structure is what carries, not the言.
+
+## Per-agent `profile/` layout
+
+Old (global, shared by every agent):
+
+```
+~/.lingtai-tui/
+  covenant/zh/covenant.md
+  procedures/procedures.md
+  principle/zh/principle.md
+```
+
+New (per-agent, owned by the agent):
+
+```
+<workspace>/.lingtai/<agent>/
+  profile/
+    covenant.md       # the spine + the concretes for *this* agent
+    principle.md      # only the truly-invariant protocol items (you ↔ system ↔ email)
+    procedures.md     # quick reference — only what this agent calls
+  init.json
+    "covenant_file":  ".../profile/covenant.md"
+    "principle_file": ".../profile/principle.md"
+    "procedures_file":".../profile/procedures.md"
+```
+
+Why per-agent:
+
+- Identity is local. Telling `shouyi` it is the orchestrator with karma over six named sub-agents belongs *in shouyi's covenant*, not in a global file with a placeholder.
+- Specialisations are local. A visual-only sub-agent doesn't need the molt three-step in the same depth an orchestrator does; it can have a 1-line procedures file.
+- Drift is bounded. When `shouyi` learns a new lesson and updates its covenant, sibling agents are unaffected. (Cross-agent learning still happens via `codex` and `.library_shared/` — those are designed for it.)
+- Onboarding is template-driven, not file-mutating. A new agent's `init.json` initially points at `examples/profile/<lang>/{covenant,principle,procedures}.md`; first molt or first explicit edit copies them under `<agent>/profile/`. No more "edit the global file and worry about whose agents you affect".
+
+## Proposed upstream changes
+
+1. **Ship `examples/profile/zh/{covenant.md, principle.md, procedures.md}`** as templates. Use the five-section spine for `covenant`. Keep the existing global files as a back-compat fallback.
+2. **`init.json` defaults** now resolve in this order:
+   - explicit `covenant_file` (absolute path) — current behaviour, unchanged
+   - `<agent>/profile/covenant.md` — new, preferred
+   - `~/.lingtai-tui/covenant/<lang>/covenant.md` — old fallback
+3. **`lingtai run` first-boot**: if no covenant_file is set anywhere and `<agent>/profile/` doesn't exist, copy from `examples/profile/<lang>/` and write the path back to `init.json`. Same for procedures/principle.
+4. **`molt` integration**: when an agent rewrites its own covenant (it has the karma to), it writes to `<agent>/profile/covenant.md`, not to the global path. The global path becomes effectively read-only.
+
+These are additive — every existing agent keeps working until it explicitly migrates.
+
+## Side finding: `_check_duplicate_process` false-positive on shell wrappers
+
+While bringing `shouyi` back up after the migration, every `lingtai run` invocation aborted with:
+
+```
+error: another lingtai agent is already running in /Users/.../.lingtai/shouyi
+  PID 67192: 67192 /bin/zsh -ic ...
+```
+
+PID 67192 was a stale `zsh -ic '...'` wrapper from a previous `run_command` invocation in the IDE. The wrapper's command line happened to contain the literal substring `lingtai run /Users/.../shouyi` (because the actual command being eval'd used that path). In `lingtai/cli.py` `_check_duplicate_process` does a substring match against `ps -eo command`:
+
+```python
+needle = f"lingtai run {abs_dir}"
+for line in out.splitlines():
+    if needle in line:
+        # only excludes self by PID
+        ...
+        sys.exit(1)
+```
+
+This false-positives on any shell wrapper / log entry / `ps`-self / pipe whose argv mentions `lingtai run <abs_dir>`. In our case it kept rejecting fresh launches because a previous IDE wrapper hadn't been reaped yet.
+
+The duplicate-process check is defense-in-depth alongside `kernel.flock`, which is the real correctness gate. Two lower-cost fixes:
+
+1. Tighten the match: require the matching line's `argv[0]` (or `argv[0..2]`) to *be* the python binary running `-m lingtai run <abs_dir>`, not just contain it. e.g. shlex-split the line, check `parts[0]` ends in `python` and `parts[1:3] == ['-m', 'lingtai']` and `parts[3] == 'run'` and `parts[4] == abs_dir`.
+2. Or skip the `ps` match entirely — the kernel `flock` will catch real duplicates, and the `ps` check exists only to give a friendlier error. Better to leave the friendly error on the rare real case than to falsely block the common shell-wrapper case.
+
+(Workaround for now: launch via `screen -dmS <name> <agent>/start_agent.sh`. The screen and start_agent.sh wrappers' argv don't contain the `lingtai run <abs_dir>` substring, so they don't trip the check.)
+
+## Migration cookbook (per-agent, validated on shouyi)
+
+```bash
+AG=/path/to/.lingtai/<agent>
+mkdir -p "$AG/profile"
+
+# 1. Author the three files at $AG/profile/{covenant,principle,procedures}.md
+#    — use the five-section spine + the concretes you actually need
+
+# 2. Repoint init.json
+python3 -c "
+import json, pathlib, sys
+p = pathlib.Path('$AG/init.json')
+d = json.loads(p.read_text())
+d['covenant_file']  = '$AG/profile/covenant.md'
+d['principle_file'] = '$AG/profile/principle.md'
+d['procedures_file']= '$AG/profile/procedures.md'
+p.write_text(json.dumps(d, indent=2, ensure_ascii=False)+'\n')
+"
+
+# 3. Restart the agent — preferred path on macOS:
+screen -dmS <agent>-tao "$AG/start_agent.sh"
+
+# 4. Verify
+python3 -c "
+import json, time, pathlib
+hb = pathlib.Path('$AG/.agent.heartbeat')
+print('hb_age=', round(time.time()-float(hb.read_text().strip()),2), 's')
+a = json.loads(open('$AG/.agent.json').read())
+print('llm.base_url=', a['llm']['base_url'])
+"
+# system_tokens in .status.json refreshes on next LLM call; until then it reflects
+# the pre-migration snapshot. That's an LLM-call-driven cache, not a bug.
+```
+
+## Open questions
+
+- Does the five-section spine generalise off-zh? In English it reads naturally as `Tao / One / Two / Three / Reverse` or `Origin / Sense / Polarity / Stage / Return`. The structure (one principle generates the next; the last is "stop") seems language-independent, but I haven't validated.
+- Should `principle.md` even be a separate file from `covenant.md`? Empirically `principle.md` here is ~750 bytes — almost lost in the noise. Could fold it into a `## 通信约定 (channel discipline)` section of covenant. Keeping it separate for now mostly because the existing kernel codepath has three explicit slots.
+- For the false-positive in `_check_duplicate_process`, want to confirm with @maintainer whether the friendly-error path is worth keeping (vs. relying on flock). If yes, the shlex-split fix is ~10 lines; happy to PR.

--- a/discussions/intrinsics-strict-schema-scan.md
+++ b/discussions/intrinsics-strict-schema-scan.md
@@ -1,0 +1,287 @@
+# Intrinsics & Capabilities Tool-Schema Strict-Mode Scan
+
+**Date:** 2026-05-19
+**Repos affected:** upstream `lingtai` Python package + `lingtai_kernel`
+(installed at `~/.lingtai-tui/runtime/venv/lib/python3.13/site-packages/`,
+not the TUI repo).
+**Companion to:** `cascade-skill-and-sentinel-ordering-patch.md` (Finding D)
+where this regression first surfaced as a `shouyi` AED-trip on `gpt-5.5`,
+and the per-tool fixes filed against `psyche` and `avatar`.
+
+## TL;DR
+
+OpenAI's structured-output / strict-mode schema validator (used by
+`gpt-5*`, `gpt-5.5`, `deepseek-flash`, and any provider that opts into
+strict-tool-schema validation) rejects function-tool schemas that have
+**any of `oneOf` / `anyOf` / `allOf` / `enum` / `not` at the top level**:
+
+```
+400: Invalid schema for function 'psyche': schema must have type
+'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top
+level.
+```
+
+A single offending intrinsic takes down every turn the agent tries to
+use that tool — AED retries 3×, then `preset_auto_fallback` reverts the
+preset (see `lingtai-preset-swap-silent-revert-patch.md` for the full
+amplification chain). Two tools shipped with the offending construct:
+
+| Tool | File | Construct |
+|---|---|---|
+| `psyche` | `lingtai_kernel/intrinsics/psyche/__init__.py` | top-level `allOf` of conditional `if/then` clauses pinning `(object, action)` valid pairs |
+| `avatar` | `lingtai/core/avatar/__init__.py` | top-level `allOf` of conditional `if/then` clauses pinning per-action `required` fields |
+
+Both have been patched (constraint moved into runtime validator, schema
+left as bare `type: object` + `properties` + `required`). This document
+covers the **systemic scan** that should accompany the per-tool patches:
+make sure no third tool slipped through, and add a CI guard so the next
+intrinsic doesn't regress us.
+
+## Why "just fix `psyche`" isn't enough
+
+The pattern that caused the regression isn't psyche-specific. It's the
+intersection of three things every intrinsic author hits:
+
+1. JSON Schema's `if/then` is the natural way to express
+   "field X is required only when field Y has value Z" — a
+   common shape for verb-driven tools (`action: <verb>` then required
+   args differ per verb).
+2. JSON Schema *forbids* `if/then` at the top level of a `type: object`
+   schema unless wrapped in `allOf` (the `if/then` keywords don't
+   compose with sibling validators directly the way one might expect).
+3. So every author who tries to express per-verb required fields
+   declaratively in the schema reaches for `allOf: [{if, then}, ...]`.
+   Both psyche and avatar arrived at this independently.
+
+The fix landing for those two tools — *delete the schema-level
+constraint, enforce in the handler* — is the right resolution every
+time, but it's invisible to any future intrinsic author who reads the
+existing intrinsics, sees no `allOf`, and assumes the way to express
+their constraint is to add it back. Hence the lint.
+
+## Static AST scan (run anywhere, no runtime deps)
+
+The scan walks every `.py` under `lingtai_kernel/intrinsics/`,
+`lingtai/capabilities/`, and `lingtai/core/`, parses to AST, and flags
+any dict literal whose own `"type"` key is the constant `"object"` and
+which also contains any of `"oneOf"`, `"anyOf"`, `"allOf"`, `"enum"`,
+`"not"` as a sibling key. That's exactly the construct strict mode
+refuses, and only that construct — the same words inside a
+nested `properties.<field>.enum` are legal (and used heavily by `soul`
+and others).
+
+```python
+"""Lint: no top-level allOf/anyOf/oneOf/enum/not on a type:object schema.
+
+OpenAI strict-mode tool schemas (gpt-5*, deepseek-flash, and friends)
+reject these constructs at the top level. See
+discussions/intrinsics-strict-schema-scan.md for context.
+
+Run: python scripts/lint_strict_tool_schemas.py
+Exit: 0 if clean, 1 if any forbidden construct found.
+
+Or as pytest: place under tests/ and the assertion turns each finding
+into a test failure with the exact file:line and key.
+"""
+import ast
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]  # repo root
+ROOTS_TO_SCAN = [
+    ROOT / "src" / "lingtai_kernel" / "intrinsics",
+    ROOT / "src" / "lingtai" / "capabilities",
+    ROOT / "src" / "lingtai" / "core",
+]
+FORBIDDEN_AT_TOP = {"oneOf", "anyOf", "allOf", "enum", "not"}
+
+
+class StrictModeViolationVisitor(ast.NodeVisitor):
+    def __init__(self, path: pathlib.Path) -> None:
+        self.path = path
+        self.findings: list[tuple[int, str]] = []
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        keys: list[object | None] = []
+        for k in node.keys:
+            keys.append(k.value if isinstance(k, ast.Constant) else None)
+        if "type" in keys:
+            type_node = node.values[keys.index("type")]
+            if isinstance(type_node, ast.Constant) and type_node.value == "object":
+                for forbidden in FORBIDDEN_AT_TOP:
+                    if forbidden in keys:
+                        self.findings.append((node.lineno, forbidden))
+        self.generic_visit(node)
+
+
+def scan_file(path: pathlib.Path) -> list[tuple[int, str]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    v = StrictModeViolationVisitor(path)
+    v.visit(tree)
+    return v.findings
+
+
+def main() -> int:
+    failures: list[str] = []
+    n_files = 0
+    for root in ROOTS_TO_SCAN:
+        if not root.exists():
+            continue
+        for p in root.rglob("*.py"):
+            if ".bak" in p.name or "__pycache__" in p.parts:
+                continue
+            n_files += 1
+            for lineno, forbidden in scan_file(p):
+                rel = p.relative_to(ROOT)
+                failures.append(
+                    f"{rel}:{lineno}  top-level type=object dict has "
+                    f"forbidden key {forbidden!r} (OpenAI strict-mode "
+                    f"validator rejects this; move the constraint into "
+                    f"the runtime handler)"
+                )
+    if failures:
+        print("✗ strict-tool-schema scan found violations:", file=sys.stderr)
+        for f in failures:
+            print("  " + f, file=sys.stderr)
+        return 1
+    print(f"✓ strict-tool-schema scan clean ({n_files} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+The scan deliberately uses AST instead of importing the modules:
+intrinsics import their own deps at module-load time (httpx, anthropic,
+psyche-internal models), and a lint that can run in a stripped
+CI container with just stdlib is friction-free. The failure mode the
+lint is preventing is a JSON-shape regression, not a runtime regression
+— AST is the right level.
+
+### Pytest variant (drop-in)
+
+For the `tests/` tree:
+
+```python
+# tests/test_strict_tool_schemas.py
+import pytest
+from pathlib import Path
+from scripts.lint_strict_tool_schemas import scan_file, ROOTS_TO_SCAN, ROOT
+
+
+@pytest.mark.parametrize("py_file", [
+    p for root in ROOTS_TO_SCAN
+    if root.exists()
+    for p in root.rglob("*.py")
+    if ".bak" not in p.name and "__pycache__" not in p.parts
+])
+def test_no_top_level_strict_violations(py_file):
+    findings = scan_file(py_file)
+    assert not findings, (
+        f"{py_file.relative_to(ROOT)} has top-level type=object dicts "
+        f"with forbidden keys: {findings}. OpenAI strict-mode validator "
+        f"(gpt-5*, deepseek-flash, …) rejects these. Move the "
+        f"constraint into the runtime handler instead."
+    )
+```
+
+Each offending file becomes its own pytest failure, so CI output points
+straight at the regressing file. Adds maybe 2 ms to test-suite runtime
+on the current 41-file working set.
+
+## Scan results — May 19 2026
+
+After the `psyche` + `avatar` patches landed, the scan was run against
+the installed package tree at
+`~/.lingtai-tui/runtime/venv/lib/python3.13/site-packages/`:
+
+```
+$ python lint_strict_tool_schemas.py
+✓ strict-tool-schema scan clean (41 files)
+```
+
+Files scanned (the schema-bearing ones, by directory):
+
+| Directory | Files | Top-level violations |
+|---|---:|---:|
+| `lingtai_kernel/intrinsics/` (`email`, `psyche`, `soul`, `system`) | 8 | 0 (psyche fixed in same window) |
+| `lingtai/capabilities/` (vision, library, file, web, mcp, sub_agents, …) | 25 | 0 |
+| `lingtai/core/` (avatar, daemon, kv, mail, …) | 8 | 0 (avatar fixed in same window) |
+
+Notable schema patterns that are **not** flagged because they're legal:
+
+- `intrinsics/soul/__init__.py:87` — `properties.action.enum` (nested
+  `enum`, OpenAI strict mode permits this; that's the recommended way
+  to constrain a string field to a discrete vocabulary).
+- `capabilities/library/__init__.py` — multi-action verb-driven schema,
+  but per-action constraints sit in `properties.<field>` annotations
+  + handler-side guards, not in a top-level `allOf`.
+
+So the May 19 patch window (psyche + avatar) plugged the only two
+existing offenders.
+
+## Recommendation for upstream
+
+1. Land `scripts/lint_strict_tool_schemas.py` from this document under
+   the lingtai repo's `scripts/` directory.
+2. Wire it into `pyproject.toml#tool.pytest.ini_options` as a collected
+   test, or into the `pre-commit` config as a stage, or into the
+   GitHub Actions workflow before the unit-test job. Any of those is
+   sufficient — they catch the same class of bug.
+3. Document in `CONTRIBUTING.md` (or wherever intrinsic-author docs
+   live): "tool schemas must satisfy OpenAI strict-mode rules — no
+   top-level `allOf`/`anyOf`/`oneOf`/`enum`/`not`. Use a bare
+   `type: object` + `properties` + `required`, and enforce per-verb
+   constraints in the handler. The lint will fail your PR if you
+   forget."
+
+The cost of (1)+(2) is < 50 lines of code and one CI minute. The cost
+of *not* having it is what we just paid: a `gpt-5.5`-driven
+orchestrator silently AED-tripping on every turn it tries to use
+`psyche`, the operator chasing the symptom through three dead-end
+hypotheses (mailbox queue, heartbeat, agent state), and finally
+finding the schema-validator-400 in `agent.log` on careful read.
+
+## Why the schema-level constraint felt natural and was wrong
+
+A note for future intrinsic authors and reviewers, since "why was this
+ever there" is the question that comes up first:
+
+The `psyche` and `avatar` `allOf`/`if`/`then` blocks were genuinely
+expressing real constraints — `psyche(object="lingtai", action=…)`
+takes different valid `action` values than `psyche(object="pad", …)`,
+and `avatar(action="rules", …)` requires `rules_content` while every
+other action requires `name`. JSON Schema is supposed to be the right
+place to express that.
+
+The thing that's *new* — and is not obvious unless you've been bitten
+— is that **strict-mode tool schema is a strict subset of JSON
+Schema**. It deliberately excludes `oneOf`/`anyOf`/`allOf`/`enum`/`not`
+at the top level because those constructs allow an LLM to emit a tool
+call that satisfies one branch of a polymorphic schema but not
+another, and OpenAI's validator wants a tool call to either obviously
+match or obviously fail — no "valid under interpretation A, invalid
+under interpretation B". The branchy validators are still allowed
+*nested* inside a `properties.<field>` slot, where they constrain a
+single concrete field rather than the top-level shape.
+
+The migration is therefore always: lift the branchy constraint out of
+the schema, replace with a `type: object` + `properties` + `required`
+that admits the union of all valid shapes, and have the handler raise
+a structured error for the per-verb cases. The handler-side error
+message is also a better UX than a JSON-Schema validation diagnostic
+— it can name the specific verb and missing field rather than
+gesturing at "schema branch 2 of 4 failed".
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `lingtai_kernel/intrinsics/psyche/__init__.py` | Patched (this window) — comment block above the schema explains why |
+| `lingtai/core/avatar/__init__.py` | Patched (this window) — same comment block |
+| `scripts/lint_strict_tool_schemas.py` | New — embedded in this document, ready to land |
+| `tests/test_strict_tool_schemas.py` | New — embedded in this document, ready to land |

--- a/discussions/lingtai-preset-swap-silent-revert-patch.md
+++ b/discussions/lingtai-preset-swap-silent-revert-patch.md
@@ -1,0 +1,373 @@
+# Lingtai Preset Swap Silently Reverts — `api_compat` Lost + Cascading AED Bug
+
+**Date:** 2026-05-19
+**Repo:** upstream `lingtai` Python package (installed at
+`~/.lingtai-tui/runtime/venv/lib/python3.13/site-packages/`, **not** the TUI
+repo). All file paths in this document are inside that installed package,
+not this workspace.
+
+## TL;DR
+
+Two independent bugs in lingtai kernel combine into a single, very confusing
+user-visible failure:
+
+> "I tell my agent `system(action='refresh', preset='~/.../GLM5.1.json')`, the
+> tool returns success, the agent restarts cleanly, but the next moment it's
+> running on Qwen3.6_Plus again. Multiple retries — always reverts."
+
+The agent did switch. The new process ran 3 LLM calls successfully on the new
+preset. But every one of those 3 calls raised
+`'str' object has no attribute 'choices'`, AED tripped its threshold, and
+`preset_auto_fallback` silently rolled the agent back to its default preset.
+The user only sees "switched, then reverted".
+
+**Bug A (root cause):** `lingtai/cli.py` and `lingtai/agent.py` construct
+`LLMService` with a `provider_defaults` dict that omits `api_compat`. The
+custom-provider adapter factory in `lingtai/llm/_register.py:_custom` reads
+`api_compat` *from `provider_defaults`* (not from `manifest.llm`) and falls
+back to `"openai"`. A custom provider configured with
+`api_compat="anthropic"` (e.g. local GLM proxy speaking the Anthropic
+Messages API) gets silently routed to `OpenAIAdapter`, which accesses
+`raw.choices` on the response and explodes with
+`'str' object has no attribute 'choices'`.
+
+**Bug B (the second-order amplifier):** `lingtai_kernel/base_agent/turn.py:147`
+calls `agent._chat.has_pending_tool_calls()` instead of
+`agent._chat.interface.has_pending_tool_calls()`. `has_pending_tool_calls`
+lives on `ChatInterface`, not on `ChatSession`. When Bug A's error fires AED
+recovery, the persistence helper inside the recovery branch raises a second
+`AttributeError`, corrupting the AED counter logic and ensuring fallback
+triggers on the first round-trip.
+
+Either bug alone is bad. Together they make the symptom unrecognizable.
+
+---
+
+## Forensic timeline (one real reproduction)
+
+Agent: `baigu`, working dir `.lingtai/baigu`. Provider config in
+`init.json#manifest.llm` after switching to GLM5.1 preset:
+
+```json
+{
+  "api_compat": "anthropic",
+  "api_key_env": "CUSTOM_6_API_KEY",
+  "base_url": "http://127.0.0.1:34891",
+  "model": "GLM-5.1",
+  "provider": "custom"
+}
+```
+
+`init.json#manifest.preset.default = "~/.../Qwen3.6_Plus.json"` (the agent's
+fallback). Events excerpted from `logs/events.jsonl`:
+
+```
+08:28:46.128  preset_swap_started      preset=GLM5.1.json reason="切换长期配置"
+08:28:46.128  refresh_requested
+08:28:46.128  refresh_start                       ← _activate_preset has already
+                                                    persisted init.json
+08:28:46.218  refresh_deferred_relaunch           ← watcher subprocess spawned
+08:28:47.744  refresh_watcher_relaunch            ← new agent process launched
+08:28:48.261  refresh_start                       ← new process _setup_from_init
+08:28:48.266  capability_skipped       cap=library reason="Unknown capability"
+08:28:48.293  capability_skipped       cap=vision  reason="no vision support for
+                                                          provider 'custom'"
+08:28:48.311  refresh_complete
+08:28:48.825  llm_call                 model=GLM-5.1     ← preset DID switch
+08:28:48.977  aed_attempt   attempt=1  error="'str' object has no attribute 'choices'"
+08:28:48.977  llm_call                 model=GLM-5.1
+08:28:48.994  aed_attempt   attempt=2  error="'str' object has no attribute 'choices'"
+08:28:48.996  llm_call                 model=GLM-5.1
+08:28:49.010  aed_attempt   attempt=3  error="'str' object has no attribute 'choices'"
+08:28:49.010  preset_auto_fallback     reason="...choices..." failed_attempts=3
+08:28:49.011  refresh_start                       ← AUTO-FALLBACK fires refresh
+                                                    with preset=default
+08:28:50.450  refresh_start                       ← yet another process boots
+08:28:50.888  llm_call                 model=qwen3.6-plus  ← reverted
+```
+
+Net effect from the user's vantage point: 4.7s elapse between
+`preset_swap_started(GLM5.1)` and `llm_call(qwen3.6-plus)`. The user pings the
+agent half a minute later and gets a Qwen response. `init.json` on disk has
+`manifest.preset.active = "...Qwen3.6_Plus.json"`. The kernel did exactly
+what it was designed to do — it's the failed `'str' object` calls that look
+like a mystery.
+
+A separate isolation test reproducing `_activate_preset` against
+`baigu/init.json` confirmed the write path itself is sound — the file does
+get rewritten to GLM5.1. The reversion happens *because of* the LLM failure,
+not because the write was lost.
+
+---
+
+## Bug A — `api_compat` is silently dropped when LLMService is built
+
+### Root cause
+
+`lingtai/llm/_register.py:_custom` (factory for `provider == "custom"`):
+
+```python
+def _custom(*, model=None, defaults=None, **kw):
+    from .custom.adapter import create_custom_adapter
+    kw.pop("model", None)
+    compat = defaults.get("api_compat", "openai") if defaults else "openai"
+    return create_custom_adapter(api_compat=compat,
+                                 **{k: v for k, v in kw.items() if v is not None})
+```
+
+The factory consults `defaults["api_compat"]` and defaults to `"openai"` if
+absent. `defaults` here is the per-provider dict from
+`LLMService._provider_defaults`, **not** the `manifest.llm` block read from
+`init.json`. The two are different things and somebody has to bridge them.
+The bridging happens in two places, and **both bridges drop `api_compat`**:
+
+`lingtai/cli.py` (initial boot path), around line 95:
+
+```python
+max_rpm = m.get("max_rpm", 60)
+provider_key = llm["provider"].lower()
+per_provider: dict = {}
+if max_rpm > 0:
+    per_provider["max_rpm"] = max_rpm
+user_headers = llm.get("default_headers")
+if isinstance(user_headers, dict) and user_headers:
+    per_provider["default_headers"] = dict(user_headers)
+# ↑ only max_rpm and default_headers. api_compat is on llm but never copied.
+provider_defaults: dict | None = {provider_key: per_provider} if per_provider else None
+service = LLMService(
+    provider=llm["provider"], model=llm["model"],
+    api_key=api_key, base_url=llm.get("base_url"),
+    context_window=m.get("context_limit", 200_000),
+    provider_defaults=provider_defaults,
+)
+```
+
+`lingtai/agent.py` (`_setup_from_init` rebuild path), around line 1043:
+
+```python
+new_max_rpm = m.get("max_rpm", 60)
+new_provider_key = new_provider.lower()
+new_per_provider: dict = {}
+if new_max_rpm > 0:
+    new_per_provider["max_rpm"] = new_max_rpm
+new_user_headers = llm.get("default_headers")
+if isinstance(new_user_headers, dict) and new_user_headers:
+    new_per_provider["default_headers"] = dict(new_user_headers)
+# ↑ same omission — api_compat from manifest.llm is read nowhere here.
+new_provider_defaults: dict | None = (
+    {new_provider_key: new_per_provider} if new_per_provider else None
+)
+```
+
+When the test agent's preset is materialized into `manifest.llm` with
+`api_compat: "anthropic"`, the rebuilt `LLMService._provider_defaults["custom"]`
+contains only `{"max_rpm": 60}`. `_custom(defaults=...)` doesn't see
+`api_compat`, defaults to `"openai"`, and `create_custom_adapter` dispatches
+to `OpenAIAdapter`. The Anthropic Messages-shaped response (content blocks,
+no `.choices`) then surfaces inside `openai/adapter.py:241`
+(`choice = raw.choices[0]`) as `'str' object has no attribute 'choices'`.
+
+Subtle additional rule: `lingtai/llm/openai/defaults.py` declares
+`"api_compat": "openai"` and `lingtai/llm/anthropic/defaults.py` declares
+`"api_compat": "anthropic"`. These per-package defaults aren't relevant for
+`provider="custom"` — the custom adapter's dispatch is what matters here, and
+it has no per-package defaults file to consult; it leans entirely on the
+`api_compat` propagated through `provider_defaults`.
+
+### Why nobody noticed before
+
+- The built-in providers (`provider="anthropic"`, `provider="openai"`, etc.)
+  each have their own factory in `_register.py` that doesn't consult
+  `api_compat` at all — they're hardcoded to their wire protocol. The
+  silent-drop only bites `provider="custom"` with a non-default
+  `api_compat`.
+- The most common `provider="custom"` usage is OpenAI-compatible proxies
+  (vLLM, OpenRouter, opencode.ai's Zen passthrough). `api_compat="openai"`
+  is the silent fallback, so those work by accident.
+- Anthropic-compat custom providers are a niche: local GLM proxies, Bedrock
+  routed through a custom base_url, etc.
+
+### Fix
+
+`lingtai/cli.py`, after the `default_headers` block:
+
+```python
+user_headers = llm.get("default_headers")
+if isinstance(user_headers, dict) and user_headers:
+    per_provider["default_headers"] = dict(user_headers)
+# api_compat is consulted by the custom adapter factory
+# (lingtai/llm/_register.py:_custom) to dispatch between
+# OpenAI/Anthropic/Gemini wire protocols. Without this,
+# custom providers with api_compat="anthropic" silently fall
+# back to "openai" and the OpenAI adapter chokes on the
+# response shape (raw.choices vs response.content[]),
+# surfacing as `'str' object has no attribute 'choices'`
+# followed by preset_auto_fallback reverting the preset.
+api_compat = llm.get("api_compat")
+if api_compat:
+    per_provider["api_compat"] = api_compat
+```
+
+`lingtai/agent.py`, mirror change with `new_` prefix in the
+`_setup_from_init` rebuild block (around line 1043).
+
+That's the whole fix for Bug A.
+
+### Suggested follow-ups (out of scope for this patch)
+
+1. Move the `api_compat` lookup into the bridging step, but more
+   structurally — extract a single helper that converts `manifest.llm` into
+   `provider_defaults`, used by both `cli.py` and `agent.py`. Right now the
+   two sites duplicate the logic and drifted out of sync historically.
+2. Have `_custom` raise (not silently default) when `api_compat` is missing
+   but the provider name isn't in the known-OpenAI-compatible alias list.
+   The current silent default is the kind of leniency that hides this exact
+   class of bug.
+3. Consider populating a fixed safelist of `manifest.llm` keys into
+   `provider_defaults` rather than enumerating the ones we happen to care
+   about. Anything in `manifest.llm` that an adapter factory might consult
+   should flow through; an opt-in safelist (api_compat, timeout_ms,
+   default_headers, max_rpm, …) is safer than the current
+   enumerate-per-site approach.
+
+---
+
+## Bug B — `agent._chat.has_pending_tool_calls()` missing `.interface`
+
+### Root cause
+
+`lingtai_kernel/base_agent/turn.py:147` (inside
+`_persist_tool_results_on_continuation_failure`):
+
+```python
+if (
+    agent._chat is None
+    or not agent._chat.has_pending_tool_calls()   # ← AttributeError
+):
+    return
+agent._chat.commit_tool_results(tool_results)
+```
+
+`has_pending_tool_calls` is defined on `ChatInterface`
+(`lingtai_kernel/llm/interface.py`), not on `ChatSession`
+(`lingtai_kernel/llm/base.py`). The other four sites in turn.py and across
+the kernel that call this method all go through `.interface`:
+
+- `turn.py:179`  — `agent._chat.interface.has_pending_tool_calls()` ✓
+- `turn.py:593` — `iface = agent._chat.interface; iface.has_pending_tool_calls()` ✓
+- `base_agent/__init__.py:1003`  — `iface.has_pending_tool_calls()` ✓
+- `intrinsics/psyche/_molt.py`   — `iface_pre = agent._chat.interface` ✓
+
+So line 147 is a typo, not a design choice.
+
+It's only reached when a previous LLM call has dangling unanswered tool_calls
+AND the next call fails AND AED tries to persist the tool_results before
+retry. In quiet operation it never fires. In Bug A's failure mode it fires
+on every AED attempt.
+
+### Fix
+
+```python
+if (
+    agent._chat is None
+    or not agent._chat.interface.has_pending_tool_calls()
+):
+    return
+```
+
+Single-character intent fix. Optionally add a test that exercises the AED
+retry path on a session with pending tool_calls — it would have caught this
+on day one.
+
+### Why this matters even after Bug A is fixed
+
+Bug B isn't only "bad in combination with Bug A". Any transient LLM error
+(rate-limit, socket reset, upstream timeout) mid-tool-result-persist will
+trip the same `AttributeError`, AED will spend its budget on bogus retries,
+and the agent ends up in `STUCK` or auto-fallback for the wrong reason.
+
+---
+
+## Validation
+
+After patching both files, restart the agent on the GLM5.1 preset and watch
+events:
+
+```
+09:14:49  refresh_complete
+09:14:50  agent_state              idle → active (tc_wake)
+09:14:50  llm_call                 model=GLM-5.1
+09:15:05  llm_response                              ← 15s, anthropic adapter,
+                                                      no choices access, no AED
+09:15:05  tool_call                tool=email
+09:15:05  tool_result              status=ok
+09:15:05  llm_call                 model=GLM-5.1
+09:15:18  llm_response                              ← turn-2 also clean
+09:15:18  tool_call                tool=email (sent)
+09:15:18  mail_sent
+09:15:18  llm_call                 model=GLM-5.1
+09:15:28  llm_response                              ← turn-3
+09:15:28  diary
+09:15:28  agent_state              active → idle
+```
+
+`.agent.json` after the run:
+
+```json
+{
+  "state": "idle",
+  "started_at": "2026-05-19T01:14:49Z",
+  "llm": {
+    "model": "GLM-5.1",
+    "base_url": "http://127.0.0.1:34891",
+    "api_compat": "anthropic"
+  }
+}
+```
+
+Three full LLM round-trips with tool calling on the anthropic adapter, zero
+`aed_attempt`, zero `preset_auto_fallback`. The preset stays put.
+
+---
+
+## Adjacent issues observed but not addressed by this patch
+
+These showed up in the same investigation but are independent — flagging
+for follow-up:
+
+1. **`capability_skipped: library`** during refresh — the GLM5.1 preset
+   declares a `library` capability that the kernel's capability registry
+   doesn't know. Preset is older than the current capability set, or the
+   `library` umbrella was renamed/removed without a migration. Harmless at
+   runtime (cap is skipped), but every preset using `library` will warn on
+   every boot.
+2. **`capability_skipped: vision` with reason "no vision support for provider
+   'custom'"** — the vision capability's provider safelist doesn't include
+   `custom`. For custom providers that *do* support vision (most
+   OpenAI-compat proxies pass `image_url` through), this means the agent
+   silently has no vision tool. Either widen the safelist or make vision's
+   provider check key off `api_compat` instead of `provider`.
+3. **`agent.log` rotation across refresh** — the file handler points at the
+   pre-refresh path and the new process doesn't pick it up. New events go to
+   `events.jsonl` correctly but `agent.log` (the Python-level WARNING/ERROR
+   stream) ends up frozen at the moment of refresh. Made this
+   investigation harder than it should have been.
+4. **No watcher on a manually-launched agent** — after `_perform_refresh`
+   relaunches via its short-lived watcher script, the watcher exits and the
+   new agent has nobody monitoring it. A subsequent `kill -9` of the agent
+   leaves no autorestart. Probably intentional (the agent isn't a system
+   service), but worth a one-line note in the lifecycle docs because the
+   asymmetry surprised me during this investigation.
+
+---
+
+## Files touched by this patch
+
+| Path (inside installed lingtai package) | Lines | Change |
+|---|---|---|
+| `lingtai/cli.py` | ~99–104 → ~99–113 | Append `api_compat` to `per_provider` |
+| `lingtai/agent.py` | ~1043–1048 → ~1043–1056 | Mirror change for refresh path |
+| `lingtai_kernel/base_agent/turn.py` | 147 | Add `.interface` |
+
+Backups left at `*.bak-bug1-api-compat` and the pre-existing `.bak` for
+turn.py.

--- a/discussions/lingtai-vision-capability-fallback-patch.md
+++ b/discussions/lingtai-vision-capability-fallback-patch.md
@@ -1,0 +1,403 @@
+# Vision capability silently swallows custom-provider config — three layered bugs + one preset-design footgun
+
+**Date:** 2026-05-19
+**Repo:** upstream `lingtai` Python package + `lingtai_kernel`, both installed at
+`~/.lingtai-tui/runtime/venv/lib/python3.13/site-packages/`. Not in the
+`Lingtai-AI/lingtai` TUI repo itself.
+
+## TL;DR
+
+Trying to wire vision for an agent whose main LLM is a custom anthropic-compat
+proxy (`provider="custom"`, `api_compat="anthropic"`, e.g. JoyCode local
+proxy serving GLM-5.1) takes four turns of debugging across three files
+because four separate things go wrong in sequence:
+
+1. **Bug C-1** — `lingtai/capabilities/vision/__init__.py:setup()`'s fallback
+   path reads `defaults.get("api_compat")` against the outer
+   `_provider_defaults` dict, but that dict is shaped
+   `{provider_name: defaults_dict}` — the outer key is the provider name
+   ("custom"), not "api_compat". The lookup always returns `None` and the
+   fallback never sees the agent's real wire protocol.
+
+2. **Bug C-2** — Even after C-1 is fixed, only `api_compat == "openai"` has a
+   fallback branch. Anthropic-compat custom providers fall through to
+   `capability_skipped`. (Independent of whether the upstream actually
+   supports vision; failure should be at the API call, not at capability
+   registration.)
+
+3. **Bug C-3** — The fallback hard-binds vision to the main LLM's
+   `service._model` and `service._base_url`. There's no way for a user to
+   say "main LLM stays on text-only model X via proxy Y, but route vision
+   through vision-capable model Z via the same proxy" without forking the
+   `inherit` mechanism. The clean override channel — capability kwargs in
+   init.json — is silently ignored by the fallback path.
+
+4. **Footgun D** — `lingtai_kernel/presets.py:materialize_active_preset` does
+   a wholesale replace of `manifest.capabilities` from the preset every time
+   `_read_init` runs (i.e. every refresh, every boot). Users who edit
+   `init.json` directly to override a single capability for one agent
+   discover their edit silently vanishes on the next refresh. The preset has
+   no surface area for per-agent overrides.
+
+5. **Cherry on top — Bug G** — Once C/D are worked around (by editing the
+   preset directly with explicit vision config), `OpenAIVisionService.analyze_image`
+   in `lingtai/services/vision/openai.py` blindly accesses `raw.choices` on
+   the response. When the openai SDK returns a `str` (which it does silently
+   when the proxy hands back non-JSON for any reason — see the companion
+   JoyCodeProxy issue), the failure message is the mystifying
+   `'str' object has no attribute 'choices'`, with no hint that the
+   underlying HTTP body was actually HTML or a plain-text error.
+
+This is what made the original report ("GLM5.1 supports vision, why doesn't
+it work in lingtai") so hard to triangulate — every layer turned what was
+actually a clear failure into a misleading one.
+
+---
+
+## Reproduction (real path I walked, May 19 2026)
+
+Setup: agent `baigu` working on a financial trading workspace, originally
+on a `Qwen3.6_Plus.json` preset, switched to a new `GLM5.1.json` preset
+that I authored. `GLM5.1.json#manifest.llm` is
+
+```json
+{
+  "provider": "custom",
+  "api_compat": "anthropic",
+  "model": "GLM-5.1",
+  "api_key_env": "CUSTOM_6_API_KEY",
+  "base_url": "http://127.0.0.1:34891"
+}
+```
+
+(a local JoyCodeProxy speaking Anthropic Messages API on behalf of JoyCode's
+GLM-5.1 endpoint), and `GLM5.1.json#manifest.capabilities.vision` is the
+inherit sentinel:
+
+```json
+{"provider": "inherit"}
+```
+
+Every refresh produced `capability_skipped` events:
+
+```
+ts=…  capability=vision  requested_provider=custom
+       reason="no vision support for provider 'custom'"
+```
+
+### Bug C-1 — `defaults.get("api_compat")` reads the wrong dict layer
+
+`lingtai/capabilities/vision/__init__.py` lines ~100-130 (before fix):
+
+```python
+if provider not in PROVIDERS["providers"]:
+    # No dedicated VisionService for this provider. If the agent's
+    # main LLM is OpenAI-compatible … route vision through
+    # OpenAIVisionService using the LLM's own base_url.
+    api_compat = ""
+    defaults = getattr(getattr(agent, "service", None), "_provider_defaults", None)
+    if isinstance(defaults, dict):
+        api_compat = defaults.get("api_compat") or ""   # ← WRONG LAYER
+    if api_compat == "openai":
+        from ...services.vision.openai import OpenAIVisionService
+        …
+    else:
+        agent._log("capability_skipped", capability="vision",
+                   requested_provider=provider,
+                   reason=f"no vision support for provider {provider!r}")
+        return None
+```
+
+`LLMService._provider_defaults` is shaped
+`{provider_name: {api_compat: …, max_rpm: …, default_headers: …}}`. The
+outer key is the provider name (e.g. `"custom"`), not `"api_compat"`. So
+`defaults.get("api_compat")` always returns `None`, the openai branch is
+never taken, and every custom provider falls through to
+`capability_skipped` regardless of its actual `api_compat`.
+
+### Bug C-2 — Only the OpenAI branch exists
+
+Same code block — there's exactly one `if api_compat == "openai":` arm and
+no anthropic / gemini equivalents. `AnthropicVisionService` already exists
+under `lingtai/services/vision/anthropic.py`, it just isn't wired in. Same
+for `GeminiVisionService`. The fallback is effectively `openai-only`,
+masquerading as `api_compat-aware`.
+
+### Bug C-3 — Capability kwargs are ignored, agent service is the only source
+
+The fallback path reads:
+
+```python
+llm_base_url = getattr(agent.service, "_base_url", None)
+llm_model = getattr(agent.service, "_model", None) or "gpt-4o"
+```
+
+There's no `kwargs.get("base_url")` or `kwargs.get("model")` consulted
+first. So even if I write in `init.json#manifest.capabilities.vision`
+
+```json
+{
+  "provider": "custom",
+  "api_compat": "openai",
+  "model": "Kimi-K2.6",
+  "base_url": "http://127.0.0.1:34891/v1",
+  "api_key_env": "CUSTOM_6_API_KEY"
+}
+```
+
+the fallback substitutes the main LLM's model (GLM-5.1, the one I'm
+specifically trying NOT to use for vision because it isn't vision-capable
+on this proxy) and base_url. The capability kwargs are read by
+`_resolve_capabilities` and propagated correctly all the way to
+`setup_capability(**cap_kwargs)` — but the vision setup function doesn't
+look at them. The whole point of the explicit kwargs is to override the
+main LLM, and the fallback ignores them.
+
+### Fix — `vision/__init__.py:setup`
+
+```python
+if provider not in PROVIDERS["providers"]:
+    # Resolution order for api_compat / model / base_url:
+    #   1. capability kwargs (explicit user override in init.json)
+    #   2. main LLM via service._provider_defaults / ._base_url / ._model
+    # This lets the capability point at a different vision-capable
+    # model (e.g. Kimi-K2.6 on a multi-model proxy) while the main LLM
+    # stays on a text-only model (e.g. GLM-5.1).
+    api_compat = (kwargs.get("api_compat") or "").lower()
+    if not api_compat:
+        defaults = getattr(getattr(agent, "service", None), "_provider_defaults", None)
+        if isinstance(defaults, dict):
+            # _provider_defaults is dict[provider_name, defaults_dict];
+            # peek into the bucket for *this* provider, not the outer dict.
+            bucket = defaults.get((provider or "").lower())
+            if isinstance(bucket, dict):
+                api_compat = (bucket.get("api_compat") or "").lower()
+
+    cap_model    = kwargs.get("model")
+    cap_base_url = kwargs.get("base_url")
+    llm_base_url = cap_base_url or getattr(agent.service, "_base_url", None)
+    llm_model    = cap_model    or getattr(agent.service, "_model", None)
+
+    if api_compat == "openai":
+        from ...services.vision.openai import OpenAIVisionService
+        vision_service = OpenAIVisionService(
+            api_key=api_key,
+            model=llm_model or "gpt-4o",
+            base_url=llm_base_url,
+        )
+    elif api_compat == "anthropic":
+        from ...services.vision.anthropic import AnthropicVisionService
+        # NOTE: AnthropicVisionService.__init__ currently lacks a base_url
+        # parameter; needs an additive change there to fully support
+        # anthropic-compat custom proxies. See sibling section.
+        vision_service = AnthropicVisionService(
+            api_key=api_key,
+            model=llm_model or "claude-sonnet-4-20250514",
+            # base_url=llm_base_url,  # uncomment after the service signature is widened
+        )
+    else:
+        agent._log(
+            "capability_skipped",
+            capability="vision",
+            requested_provider=provider,
+            reason=f"no vision support for provider {provider!r} (api_compat={api_compat!r})",
+        )
+        return None
+```
+
+The reason-string change (adding `(api_compat=…)`) is operationally important
+on its own — without it I'd have spent another hour wondering whether
+`api_compat` was even being computed. The original message was
+indistinguishable between "provider not in safelist" and "fallback failed
+because api_compat was wrong" cases.
+
+### Sibling fix — `lingtai/services/vision/anthropic.py`
+
+Once Bug C-2 is fixed, anthropic-compat custom providers need a
+`base_url` parameter to be useful (the SDK defaults to api.anthropic.com,
+which is wrong for any local proxy). The existing `OpenAIVisionService`
+already takes `base_url`; mirror its signature:
+
+```python
+def __init__(
+    self,
+    *,
+    api_key: str,
+    model: str = "claude-sonnet-4-20250514",
+    base_url: str | None = None,   # ← new
+    max_tokens: int = 1024,
+) -> None:
+    import anthropic as _anthropic
+    client_kwargs: dict = {"api_key": api_key}
+    if base_url:
+        client_kwargs["base_url"] = base_url
+    self._client = _anthropic.Anthropic(**client_kwargs)
+    self._model = model
+    self._max_tokens = max_tokens
+```
+
+---
+
+## Bug D — `materialize_active_preset` wholesale-replaces capabilities
+
+`lingtai_kernel/presets.py:289` `materialize_active_preset` is called by
+`agent.py:_read_init` (line 854) on every refresh and boot. It substitutes
+`preset.manifest.llm` and `preset.manifest.capabilities` into the loaded
+`init.json` data wholesale (with the documented carve-out for
+`skills.paths`, which gets a merge).
+
+This means: **a user who edits `init.json` to override one capability for a
+single agent has their edit silently reverted on the next refresh.** The
+"carve-out for skills.paths" pattern shows the maintainers already noticed
+the wholesale-replace is too aggressive for at least one capability — but
+there is no general mechanism. Vision is exactly the kind of capability
+that benefits from per-agent override: same preset, different vision
+provider for different agents.
+
+This is most surprising because the rest of the lifecycle treats
+`init.json` as the source of truth. `_setup_from_init` reads it, validates
+it, runs capabilities from it. A user reasonably expects to be able to
+edit it. The hidden preset-replay step is invisible from the user's
+perspective.
+
+### Suggested fixes (escalating)
+
+1. **Minimum**: document the wholesale-replace behavior loudly. Right now
+   the docstring of `materialize_active_preset` describes it as "substitute
+   the active preset's llm + capabilities into init.json data" — true but
+   doesn't emphasize that this happens *every refresh*, *overwriting user
+   edits*. A `_log("preset_capabilities_overwritten", added=[…], removed=[…])`
+   event on every materialize would also help diagnostics enormously.
+
+2. **Better**: extend the `skills.paths` carve-out pattern. Add an
+   `init.json#manifest.capability_overrides` block that gets merged ON TOP
+   of preset-materialized capabilities. Vision changes for a single agent
+   live there, survive preset swaps.
+
+3. **Best**: structural — split the "preset capabilities" from the
+   "materialized capabilities" so that init.json never gets the preset's
+   capabilities written into it; instead `_read_init` returns a synthesized
+   manifest that holds preset capabilities ∪ init.json overrides, without
+   ever mutating the on-disk init.json. Refresh-time edits to init.json
+   would then have predictable, scoped effects.
+
+### Sibling small bug — `expand_inherit` drops `api_compat`
+
+`lingtai_kernel/presets.py:expand_inherit` (line 446) materializes
+`{provider: "inherit"}` capability configs by copying main_llm's
+`provider`, `api_key`, `api_key_env`, `base_url`. It does NOT copy
+`api_compat`. So a capability with `provider: "inherit"` that lands in a
+fallback branch still loses the anthropic/openai signal, even if the main
+LLM has it set correctly. Trivial one-line addition:
+
+```python
+kwargs["api_compat"] = main_llm.get("api_compat")
+```
+
+---
+
+## Bug G — `OpenAIVisionService.analyze_image` blindly trusts response shape
+
+`lingtai/services/vision/openai.py:analyze_image` ends with:
+
+```python
+raw = self._client.chat.completions.create(model=…, messages=…, max_tokens=…)
+if raw.choices:
+    return raw.choices[0].message.content or ""
+return ""
+```
+
+When the proxy on the other end is misconfigured (and there are many ways
+to misconfigure a local relay — see the companion JoyCodeProxy issue), the
+openai SDK can return a raw `str` instead of a `ChatCompletion`. This is
+the case if the response body is non-JSON, e.g. an HTML page from a
+catch-all SPA route. The SDK does not raise; it returns the body as
+string.
+
+The user-visible failure is
+
+```
+Vision analysis failed: 'str' object has no attribute 'choices'
+```
+
+…which is technically accurate but tells the user nothing. The body is
+HTML; that's the symptom that should surface. Suggested fix:
+
+```python
+raw = self._client.chat.completions.create(model=…, messages=…, max_tokens=…)
+if not hasattr(raw, "choices"):
+    # SDK returned raw body — almost always means the proxy/upstream
+    # served non-JSON (HTML SPA route, plain-text error, gateway page).
+    # Surface the first 200 chars so the user can see what they got.
+    snippet = repr(raw)[:200] if isinstance(raw, str) else f"<{type(raw).__name__}>"
+    raise RuntimeError(
+        f"vision upstream did not return a JSON ChatCompletion. "
+        f"Got {type(raw).__name__}: {snippet}. "
+        f"Common cause: base_url missing the '/v1' suffix on a local proxy, "
+        f"or the proxy returning an HTML dashboard for unknown routes."
+    )
+if raw.choices:
+    return raw.choices[0].message.content or ""
+return ""
+```
+
+Same pattern probably applies to AnthropicVisionService and the other
+provider-specific vision services.
+
+---
+
+## Cross-link
+
+The HTML-on-`/chat/completions` failure mode that surfaced as Bug G is
+caused by a separate bug in JoyCodeProxy
+([vibe-coding-labs/JoyCodeProxy](https://github.com/vibe-coding-labs/JoyCodeProxy)),
+whose SPA dashboard route catches `/chat/completions` when the openai SDK
+calls without a `/v1` prefix. I'm filing that separately. But even after
+that upstream is fixed, the lingtai-side error message stays misleading
+unless Bug G is also addressed — the next user who hits any non-JSON
+response on a different proxy will get the same `'str' has no attribute
+'choices'` mystery.
+
+---
+
+## Validation
+
+After applying the four-line patch in `vision/__init__.py` and updating
+the GLM5.1 preset to:
+
+```json
+"vision": {
+  "provider": "custom",
+  "api_compat": "openai",
+  "model": "Kimi-K2.6",
+  "api_key_env": "CUSTOM_6_API_KEY",
+  "base_url": "http://127.0.0.1:34891/v1"
+}
+```
+
+(JoyCodeProxy has Kimi-K2.6 as a vision-capable model; main LLM stays on
+GLM-5.1 for text), baigu's refresh produces:
+
+```
+refresh_complete   capabilities=[..., 'vision', ...]
+                   tools=[..., 'vision', ...]            ← was missing before
+```
+
+No more `capability_skipped: vision` events. End-to-end vision call on a
+608KB financial chart PNG returns a 102-char Chinese caption that
+correctly identifies the chart's subject, panels, and color-coded
+markers. `prompt_tokens=4113` confirms the image was actually processed
+by the upstream vision model (not silently dropped). Round-trip 26
+seconds.
+
+---
+
+## Files touched
+
+| Path | Lines | Change |
+|---|---|---|
+| `lingtai/capabilities/vision/__init__.py` | ~102-130 | Resolve api_compat from kwargs first; fall back to `_provider_defaults[provider]["api_compat"]`; honor kwargs `model` + `base_url`; add anthropic branch (commented pending sibling fix); enrich `capability_skipped` reason with `(api_compat=…)` |
+| `lingtai/services/vision/anthropic.py` | __init__ | Accept `base_url` (not yet applied — sibling fix; needed for the anthropic branch above to be useful) |
+| `lingtai_kernel/presets.py` | `expand_inherit` | Add `kwargs["api_compat"] = main_llm.get("api_compat")` |
+| `lingtai/services/vision/openai.py` | `analyze_image` | Raise with diagnostic context when `raw` isn't a `ChatCompletion` |
+| (design) `lingtai_kernel/presets.py` + `agent.py` | — | Add a per-agent override channel that survives `materialize_active_preset`, or at minimum log every wholesale-replace of capabilities |

--- a/portal/internal/fs/mail.go
+++ b/portal/internal/fs/mail.go
@@ -160,6 +160,18 @@ func readManifestAsIdentity(dir string) map[string]interface{} {
 	return manifest
 }
 
+func writeJSONAtomic(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
 // mailboxIDCollisionRetries is the per-folder attempt budget for
 // `prepareMailDirs`. The short ID has 16 bits of entropy in the
 // suffix, so a same-second send has a 1/65536 chance of colliding;
@@ -255,7 +267,7 @@ func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) 
 		return fmt.Errorf("marshal message: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(primaryDir, "message.json"), data, 0o644); err != nil {
+	if err := writeJSONAtomic(filepath.Join(primaryDir, "message.json"), data); err != nil {
 		return fmt.Errorf("write primary message: %w", err)
 	}
 
@@ -265,7 +277,7 @@ func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) 
 		return nil
 	}
 
-	if err := os.WriteFile(filepath.Join(sentDir, "message.json"), data, 0o644); err != nil {
+	if err := writeJSONAtomic(filepath.Join(sentDir, "message.json"), data); err != nil {
 		return fmt.Errorf("write sent message: %w", err)
 	}
 

--- a/portal/internal/fs/mail_test.go
+++ b/portal/internal/fs/mail_test.go
@@ -80,6 +80,9 @@ func TestWriteMail_ProducesShortMailboxID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read message.json: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(recipientDir, "mailbox", "inbox", name, "message.json.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("temporary primary message file leaked: %v", err)
+	}
 	var msg MailMessage
 	if err := json.Unmarshal(data, &msg); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -98,6 +101,9 @@ func TestWriteMail_ProducesShortMailboxID(t *testing.T) {
 	}
 	if len(sentEntries) != 1 || sentEntries[0].Name() != name {
 		t.Errorf("sent entries = %v, want [%q]", dirNames(sentEntries), name)
+	}
+	if _, err := os.Stat(filepath.Join(senderDir, "mailbox", "sent", name, "message.json.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("temporary sent message file leaked: %v", err)
 	}
 }
 

--- a/portal/web/package-lock.json
+++ b/portal/web/package-lock.json
@@ -267,21 +267,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -560,26 +560,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -587,9 +589,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +606,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -621,9 +623,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -638,9 +640,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -655,9 +657,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
-      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -672,9 +674,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -689,9 +691,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -706,9 +708,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -723,9 +725,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -740,9 +742,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
-      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -757,9 +759,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
-      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -774,9 +776,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
-      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -791,9 +793,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -801,16 +803,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -825,9 +829,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
-      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -849,9 +853,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1308,9 +1312,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2346,9 +2350,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2482,9 +2486,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2562,14 +2566,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
-      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.11"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2578,27 +2582,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.11",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
-      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2678,14 +2682,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2815,17 +2819,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
-      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.11",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2841,8 +2845,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -342,6 +342,8 @@
   "doctor.llm_no_base_url": "✗ No API endpoint (base_url) set for %s",
   "doctor.suggest_base_url": "→ Open preset editor and select a region (CN / INTL), then /refresh.",
   "doctor.llm_unknown": "✗ LLM error: %s",
+  "doctor.llm_empty_response": "✗ LLM responded but envelope is empty: %s",
+  "doctor.suggest_proxy_check": "→ The endpoint accepted your request but did not forward it upstream. Check the proxy/gateway logs (e.g. JoyCode), verify the model name and credentials are forwarded correctly, then /refresh.",
   "doctor.portal_ok": "✓ lingtai-portal on PATH",
   "doctor.portal_missing": "✗ lingtai-portal not found on PATH",
   "doctor.suggest_portal": "→ Run: brew link --overwrite lingtai-tui",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -337,6 +337,8 @@
   "doctor.llm_no_base_url": "✗ %s 未设端",
   "doctor.suggest_base_url": "→ 开预设编器选区域 (CN / INTL)，后 /refresh。",
   "doctor.llm_unknown": "✗ 天误：%s",
+  "doctor.llm_empty_response": "✗ 天应而无文：%s",
+  "doctor.suggest_proxy_check": "→ 端纳其请而不达上。察代之录（譬 JoyCode），验模名与凭无误，后 /refresh。",
   "doctor.portal_ok": "✓ lingtai-portal 在途",
   "doctor.portal_missing": "✗ lingtai-portal 不在途",
   "doctor.suggest_portal": "→ 行：brew link --overwrite lingtai-tui",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -337,6 +337,8 @@
   "doctor.llm_no_base_url": "✗ 未设置 %s 的 API 端点 (base_url)",
   "doctor.suggest_base_url": "→ 打开预设编辑器选择区域 (CN / INTL)，然后 /refresh。",
   "doctor.llm_unknown": "✗ LLM 错误：%s",
+  "doctor.llm_empty_response": "✗ LLM 响应包络为空：%s",
+  "doctor.suggest_proxy_check": "→ 端点接受了请求但未转发上游。检查代理/网关的日志（如 JoyCode），确认模型名和凭证正确转发，然后 /refresh。",
   "doctor.portal_ok": "✓ lingtai-portal 在 PATH 中",
   "doctor.portal_missing": "✗ lingtai-portal 不在 PATH 中",
   "doctor.suggest_portal": "→ 运行：brew link --overwrite lingtai-tui",

--- a/tui/internal/fs/mail.go
+++ b/tui/internal/fs/mail.go
@@ -234,6 +234,18 @@ func readManifestAsIdentity(dir string) map[string]interface{} {
 	return manifest
 }
 
+func writeJSONAtomic(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
 func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) error {
 	// Read sender's manifest as identity card (same as Python agents do)
 	identity := readManifestAsIdentity(senderDir)
@@ -278,7 +290,7 @@ func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) 
 		return fmt.Errorf("marshal message: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(primaryDir, "message.json"), data, 0o644); err != nil {
+	if err := writeJSONAtomic(filepath.Join(primaryDir, "message.json"), data); err != nil {
 		return fmt.Errorf("write primary message: %w", err)
 	}
 
@@ -288,7 +300,7 @@ func WriteMail(recipientDir, senderDir, fromAddr, toAddr, subject, body string) 
 		return nil
 	}
 
-	if err := os.WriteFile(filepath.Join(sentDir, "message.json"), data, 0o644); err != nil {
+	if err := writeJSONAtomic(filepath.Join(sentDir, "message.json"), data); err != nil {
 		return fmt.Errorf("write sent message: %w", err)
 	}
 

--- a/tui/internal/fs/mail_test.go
+++ b/tui/internal/fs/mail_test.go
@@ -396,6 +396,9 @@ func TestWriteMail_ProducesShortMailboxID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read message.json: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(recipientDir, "mailbox", "inbox", name, "message.json.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("temporary primary message file leaked: %v", err)
+	}
 	var msg MailMessage
 	if err := json.Unmarshal(data, &msg); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -417,6 +420,9 @@ func TestWriteMail_ProducesShortMailboxID(t *testing.T) {
 			got = append(got, e.Name())
 		}
 		t.Errorf("sent entries = %v, want [%q]", got, name)
+	}
+	if _, err := os.Stat(filepath.Join(senderDir, "mailbox", "sent", name, "message.json.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("temporary sent message file leaked: %v", err)
 	}
 }
 

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -185,7 +185,7 @@ func runDoctor(orchDir, globalDir string) doctorResultMsg {
 	}
 
 	// Phase 2: read init.json to get LLM config
-	provider, model, apiKey, baseURL, err := readLLMConfig(orchDir)
+	provider, model, apiKey, baseURL, apiCompat, err := readLLMConfig(orchDir)
 	if err != nil {
 		lines = append(lines, doctorLine{
 			Text: i18n.TF("doctor.config_error", err),
@@ -209,7 +209,7 @@ func runDoctor(orchDir, globalDir string) doctorResultMsg {
 	}
 
 	// Phase 3: live API check
-	status, detail := probeLLM(provider, model, apiKey, baseURL)
+	status, detail := probeLLM(provider, model, apiKey, baseURL, apiCompat)
 
 	switch status {
 	case probeOK:
@@ -259,6 +259,13 @@ func runDoctor(orchDir, globalDir string) doctorResultMsg {
 		})
 		lines = append(lines, doctorLine{
 			Text: i18n.T("doctor.suggest_setup"), Hint: true,
+		})
+	case probeEmptyResponse:
+		lines = append(lines, doctorLine{
+			Text: i18n.TF("doctor.llm_empty_response", detail),
+		})
+		lines = append(lines, doctorLine{
+			Text: i18n.T("doctor.suggest_proxy_check"), Hint: true,
 		})
 	default:
 		lines = append(lines, doctorLine{
@@ -330,32 +337,41 @@ func findLastAPIError(orchDir string) string {
 
 // --- Init.json / env resolution ---
 
-func readLLMConfig(orchDir string) (provider, model, apiKey, baseURL string, err error) {
+// readLLMConfig pulls the agent's LLM configuration from init.json. The
+// apiCompat return value carries manifest.llm.api_compat ("", "openai",
+// or "anthropic") — required by probeLLM to pick the right auth scheme
+// when provider="custom" points at a third-party gateway. Without this,
+// any anthropic-compatible custom endpoint (e.g. JoyCode's local proxy
+// on 127.0.0.1:34891) gets probed with `Authorization: Bearer <key>`,
+// silently falls into the 404 path that's mapped to probeOK, and masks
+// the real connectivity state.
+func readLLMConfig(orchDir string) (provider, model, apiKey, baseURL, apiCompat string, err error) {
 	initPath := filepath.Join(orchDir, "init.json")
 	data, err := os.ReadFile(initPath)
 	if err != nil {
-		return "", "", "", "", fmt.Errorf("cannot read init.json")
+		return "", "", "", "", "", fmt.Errorf("cannot read init.json")
 	}
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return "", "", "", "", fmt.Errorf("invalid init.json")
+		return "", "", "", "", "", fmt.Errorf("invalid init.json")
 	}
 
 	manifest, _ := raw["manifest"].(map[string]interface{})
 	if manifest == nil {
-		return "", "", "", "", fmt.Errorf("no manifest in init.json")
+		return "", "", "", "", "", fmt.Errorf("no manifest in init.json")
 	}
 
 	llm, _ := manifest["llm"].(map[string]interface{})
 	if llm == nil {
-		return "", "", "", "", fmt.Errorf("no manifest.llm in init.json")
+		return "", "", "", "", "", fmt.Errorf("no manifest.llm in init.json")
 	}
 
 	provider, _ = llm["provider"].(string)
 	model, _ = llm["model"].(string)
 	apiKey, _ = llm["api_key"].(string)
 	baseURL, _ = llm["base_url"].(string)
+	apiCompat, _ = llm["api_compat"].(string)
 
 	if apiKey == "" {
 		apiKeyEnv, _ := llm["api_key_env"].(string)
@@ -365,7 +381,7 @@ func readLLMConfig(orchDir string) (provider, model, apiKey, baseURL string, err
 		}
 	}
 
-	return provider, model, apiKey, baseURL, nil
+	return provider, model, apiKey, baseURL, apiCompat, nil
 }
 
 // lookupEnvKey resolves an environment variable name, checking os.Environ first,
@@ -419,14 +435,25 @@ const (
 	probeNetworkError
 	probeNoKey
 	probeUnknown
+	// probeEmptyResponse: the endpoint accepted a real POST /v1/messages
+	// (HTTP 200) but returned an empty content array and zero-token usage.
+	// This is the canonical failure signature of an anthropic-compatible
+	// reverse proxy (JoyCode's local 127.0.0.1:34891 proxy is the example
+	// motivating this status) that received the request, didn't actually
+	// forward to its upstream model, and replied with a structurally-valid
+	// but empty Message envelope. GET /v1/models cannot detect this — the
+	// proxy may not implement /v1/models at all (404 → existing probeOK
+	// charity branch), or may return a benign 200 — so we run a real
+	// minimal messages call as a second-stage probe.
+	probeEmptyResponse
 )
 
-func probeLLM(provider, model, apiKey, baseURL string) (probeStatus, string) {
+func probeLLM(provider, model, apiKey, baseURL, apiCompat string) (probeStatus, string) {
 	if apiKey == "" {
 		return probeNoKey, ""
 	}
 
-	url, headers := providerProbeConfig(provider, apiKey, baseURL)
+	url, headers := providerProbeConfig(provider, apiKey, baseURL, apiCompat)
 	if url == "" {
 		return probeUnknown, "unknown provider: " + provider
 	}
@@ -452,12 +479,14 @@ func probeLLM(provider, model, apiKey, baseURL string) (probeStatus, string) {
 	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 	body := string(bodyBytes)
 
+	var gotStatus probeStatus
+	var gotDetail string
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		return probeOK, ""
+		gotStatus, gotDetail = probeOK, ""
 	case resp.StatusCode == 404 || resp.StatusCode == 405:
 		// /v1/models not supported but server responded — connectivity and auth OK
-		return probeOK, ""
+		gotStatus, gotDetail = probeOK, ""
 	case resp.StatusCode == 401 || resp.StatusCode == 403:
 		return probeAuthError, fmt.Sprintf("%d %s", resp.StatusCode, extractErrorMessage(body))
 	case resp.StatusCode == 429:
@@ -467,9 +496,312 @@ func probeLLM(provider, model, apiKey, baseURL string) (probeStatus, string) {
 	default:
 		return probeUnknown, fmt.Sprintf("%d %s", resp.StatusCode, extractErrorMessage(body))
 	}
+
+	// Stage 2: real-call second-stage probe. The /v1/models check above
+	// tells us only that the host is reachable and credentials were not
+	// rejected outright. It cannot tell us whether the actual generation
+	// path (POST /v1/messages or POST /v1/chat/completions) forwards
+	// requests to a working upstream model — and that is exactly what
+	// fails for reverse-proxy gateways (e.g. JoyCode at 127.0.0.1:34891,
+	// or acui.shop / opencode.ai zen routes) when they reply HTTP 200
+	// with an empty envelope. So when the wire protocol is identifiable
+	// we send one max_tokens=1 generation and inspect the envelope. Cost
+	// is negligible (<$0.0001 on every commercial provider) and the
+	// diagnostic value is high — without this the doctor's first-stage
+	// probeOK silently masks the very failure mode the user is here to
+	// debug.
+	if gotStatus == probeOK {
+		switch classifyWire(provider, apiCompat) {
+		case wireAnthropic:
+			if msgStatus, msgDetail := probeAnthropicMessages(model, apiKey, baseURL); msgStatus != probeOK {
+				return msgStatus, msgDetail
+			}
+		case wireOpenAI:
+			if msgStatus, msgDetail := probeOpenAICompletions(model, apiKey, baseURL); msgStatus != probeOK {
+				return msgStatus, msgDetail
+			}
+		}
+	}
+	return gotStatus, gotDetail
 }
 
-func providerProbeConfig(provider, apiKey, baseURL string) (string, map[string]string) {
+// wireProtocol classifies a provider/api_compat pair into the wire
+// protocol used for the actual generation call. The classification is
+// what determines which second-stage envelope-inspection probe runs.
+type wireProtocol int
+
+const (
+	wireUnknown wireProtocol = iota
+	wireAnthropic
+	wireOpenAI
+)
+
+func classifyWire(provider, apiCompat string) wireProtocol {
+	switch provider {
+	case "anthropic", "minimax":
+		return wireAnthropic
+	case "openai", "openrouter", "deepseek", "kimi", "mimo", "zhipu", "codex":
+		return wireOpenAI
+	case "custom":
+		switch apiCompat {
+		case "anthropic":
+			return wireAnthropic
+		case "openai":
+			return wireOpenAI
+		default:
+			return wireUnknown
+		}
+	default:
+		switch apiCompat {
+		case "anthropic":
+			return wireAnthropic
+		case "openai":
+			return wireOpenAI
+		default:
+			return wireUnknown
+		}
+	}
+}
+
+// probeAnthropicMessages issues a single max_tokens=1 POST /v1/messages
+// and verifies the response envelope is non-empty. Returns probeOK when
+// the server returns a real Message with at least one content block (or
+// non-zero output_tokens); returns probeEmptyResponse when HTTP 200 is
+// paired with content:[] and zero-token usage — the canonical failure
+// signature of a reverse-proxy gateway that received the call but did
+// not actually forward it (JoyCode's local proxy is the motivating case).
+// Any non-200 / network failure is mapped to the same status taxonomy as
+// probeLLM's first-stage check so the doctor UI stays consistent.
+func probeAnthropicMessages(model, apiKey, baseURL string) (probeStatus, string) {
+	base := strings.TrimRight(baseURL, "/")
+	if base == "" {
+		base = "https://api.anthropic.com"
+	}
+	url := base + "/v1/messages"
+
+	probeModel := model
+	if probeModel == "" {
+		// Best-effort default; the gateway will surface a 400 if it dislikes
+		// the model name, which is itself a useful diagnostic outcome.
+		probeModel = "claude-3-5-haiku-20241022"
+	}
+
+	payload := map[string]interface{}{
+		"model":      probeModel,
+		"max_tokens": 1,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return probeUnknown, err.Error()
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return probeNetworkError, err.Error()
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	// Some gateways (notably proxies fronting Bearer-style upstreams) will
+	// also accept Authorization; sending both is harmless and improves
+	// compatibility with reverse proxies that forward only one.
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, apiKey) {
+			errMsg = "connection failed"
+		}
+		return probeNetworkError, errMsg
+	}
+	defer resp.Body.Close()
+	respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	respBody := string(respBytes)
+
+	switch {
+	case resp.StatusCode == 401 || resp.StatusCode == 403:
+		return probeAuthError, fmt.Sprintf("messages %d %s", resp.StatusCode, extractErrorMessage(respBody))
+	case resp.StatusCode == 429:
+		return probeRateLimit, "messages 429 rate limited"
+	case resp.StatusCode == 529 || resp.StatusCode == 503:
+		return probeOverloaded, fmt.Sprintf("messages %d overloaded", resp.StatusCode)
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		// Continue to envelope inspection below.
+	default:
+		return probeUnknown, fmt.Sprintf("messages %d %s", resp.StatusCode, extractErrorMessage(respBody))
+	}
+
+	var env struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+		StopReason string `json:"stop_reason"`
+	}
+	if err := json.Unmarshal(respBytes, &env); err != nil {
+		preview := respBody
+		if len(preview) > 100 {
+			preview = preview[:100] + "..."
+		}
+		return probeUnknown, "messages 200 but response not anthropic-shape: " + preview
+	}
+
+	hasContent := false
+	for _, c := range env.Content {
+		if strings.TrimSpace(c.Text) != "" || c.Type != "" {
+			hasContent = true
+			break
+		}
+	}
+	usageZero := env.Usage.InputTokens == 0 && env.Usage.OutputTokens == 0
+
+	if !hasContent && usageZero {
+		// JoyCode-style failure: gateway accepted the call, replied 200,
+		// but the envelope shows nothing was actually forwarded upstream.
+		return probeEmptyResponse, fmt.Sprintf(
+			"HTTP 200, content=[], usage 0/0 (model=%s); proxy/gateway likely did not forward to upstream",
+			probeModel,
+		)
+	}
+	return probeOK, ""
+}
+
+// probeOpenAICompletions is the OpenAI-protocol counterpart of
+// probeAnthropicMessages. It POSTs a single max_tokens=1 chat completion
+// to base_url + /v1/chat/completions (or just /chat/completions when the
+// base_url already ends in /v1) and inspects choices[].message.content
+// plus usage.completion_tokens. Returns probeEmptyResponse when the
+// response is HTTP 200 but the envelope is empty — the canonical failure
+// signature of OpenAI-compatible reverse proxies (acui.shop and the
+// opencode.ai zen routes are the motivating cases) that 200-but-nop the
+// generation. See probeAnthropicMessages for the broader rationale.
+func probeOpenAICompletions(model, apiKey, baseURL string) (probeStatus, string) {
+	base := strings.TrimRight(baseURL, "/")
+	if base == "" {
+		base = "https://api.openai.com/v1"
+	}
+	// Smart endpoint join: many OpenAI-compatible base_urls already end in
+	// /v1, others don't. Don't double-stack.
+	url := base + "/chat/completions"
+	if !strings.HasSuffix(base, "/v1") && !strings.Contains(base, "/v1/") {
+		url = base + "/v1/chat/completions"
+	}
+
+	probeModel := model
+	if probeModel == "" {
+		probeModel = "gpt-4o-mini"
+	}
+
+	payload := map[string]interface{}{
+		"model": probeModel,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "hi"},
+		},
+		"max_tokens": 1,
+		"stream":     false,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return probeUnknown, err.Error()
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return probeNetworkError, err.Error()
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, apiKey) {
+			errMsg = "connection failed"
+		}
+		return probeNetworkError, errMsg
+	}
+	defer resp.Body.Close()
+	respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+	respBody := string(respBytes)
+
+	switch {
+	case resp.StatusCode == 401 || resp.StatusCode == 403:
+		return probeAuthError, fmt.Sprintf("chat/completions %d %s", resp.StatusCode, extractErrorMessage(respBody))
+	case resp.StatusCode == 429:
+		return probeRateLimit, "chat/completions 429 rate limited"
+	case resp.StatusCode == 529 || resp.StatusCode == 503:
+		return probeOverloaded, fmt.Sprintf("chat/completions %d overloaded", resp.StatusCode)
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		// Continue to envelope inspection below.
+	default:
+		return probeUnknown, fmt.Sprintf("chat/completions %d %s", resp.StatusCode, extractErrorMessage(respBody))
+	}
+
+	var env struct {
+		Choices []struct {
+			Message struct {
+				Content   string        `json:"content"`
+				ToolCalls []interface{} `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(respBytes, &env); err != nil {
+		preview := respBody
+		if len(preview) > 100 {
+			preview = preview[:100] + "..."
+		}
+		return probeUnknown, "chat/completions 200 but response not openai-shape: " + preview
+	}
+
+	hasContent := false
+	for _, c := range env.Choices {
+		if strings.TrimSpace(c.Message.Content) != "" || len(c.Message.ToolCalls) > 0 {
+			hasContent = true
+			break
+		}
+	}
+	usageZero := env.Usage.PromptTokens == 0 && env.Usage.CompletionTokens == 0
+
+	if !hasContent && usageZero {
+		// acui.shop / opencode.ai-style failure: proxy returned 200 but
+		// nothing was actually generated upstream.
+		return probeEmptyResponse, fmt.Sprintf(
+			"HTTP 200, choices=[] (no content / no tool_calls), usage 0/0 (model=%s); proxy/gateway likely did not forward to upstream",
+			probeModel,
+		)
+	}
+	return probeOK, ""
+}
+
+// providerProbeConfig returns the URL and headers for a GET /v1/models
+// (or provider-equivalent) probe. apiCompat carries manifest.llm.api_compat
+// and is consulted whenever a provider entry is itself protocol-agnostic
+// (i.e. "custom" or unknown providers backed by a user-supplied baseURL):
+// the auth scheme then follows the wire protocol the user declared, not
+// a hardcoded default.
+//
+// Without this, anthropic-compatible third-party gateways — JoyCode's
+// local proxy at 127.0.0.1:34891 being a representative case — get hit
+// with `Authorization: Bearer <key>`, fall through to a 404 on /v1/models
+// (which the probe charitably maps to OK), and the user sees a green
+// /doctor while the actual agent fails to talk to the gateway.
+func providerProbeConfig(provider, apiKey, baseURL, apiCompat string) (string, map[string]string) {
 	switch provider {
 	case "anthropic":
 		base := "https://api.anthropic.com"
@@ -514,12 +846,24 @@ func providerProbeConfig(provider, apiKey, baseURL string) (string, map[string]s
 			return "", nil
 		}
 		base := strings.TrimRight(baseURL, "/")
+		if apiCompat == "anthropic" {
+			return base + "/v1/models", map[string]string{
+				"x-api-key":         apiKey,
+				"anthropic-version": "2023-06-01",
+			}
+		}
 		return base + "/v1/models", map[string]string{
 			"Authorization": "Bearer " + apiKey,
 		}
 	default:
 		if baseURL != "" {
 			base := strings.TrimRight(baseURL, "/")
+			if apiCompat == "anthropic" {
+				return base + "/v1/models", map[string]string{
+					"x-api-key":         apiKey,
+					"anthropic-version": "2023-06-01",
+				}
+			}
 			return base + "/v1/models", map[string]string{
 				"Authorization": "Bearer " + apiKey,
 			}

--- a/tui/internal/tui/login.go
+++ b/tui/internal/tui/login.go
@@ -92,7 +92,7 @@ func NewLoginModel(orchDir, globalDir string) LoginModel {
 	}
 
 	// 1. Read orchestrator's active provider/model.
-	provider, model, _, _, _ := readLLMConfig(orchDir)
+	provider, model, _, _, _, _ := readLLMConfig(orchDir)
 	m.activePreset = provider
 	m.activeModel = model
 


### PR DESCRIPTION
## Summary

Three logical changes by @JieKiYu cherry-picked from her PR #115, with her unrelated auto-launch-stopped-agents commit (627789e) intentionally **omitted** so the explicit do-not-auto-launch policy in `tui/main.go` is preserved.

### 1. `feat(doctor): two-stage probe + api_compat-aware auth` (1c4530d)

The `/doctor` connectivity probe previously sent `Authorization: Bearer <key>` to every `provider="custom"` endpoint on a GET `/v1/models` call and treated a 404 as `probeOK`. An anthropic-compatible custom proxy (JoyCode at `127.0.0.1:34891` is the motivating case) got probed with the wrong auth scheme, fell into the 404-charity branch, and the doctor reported green while the actual agent couldn't talk to the gateway.

This change:
- Widens `readLLMConfig` to also return `manifest.llm.api_compat`.
- Uses it on the stage-1 probe to pick `x-api-key + anthropic-version` vs `Authorization: Bearer` correctly for unknown / custom providers.
- Adds a new `probeEmptyResponse` status. After the stage-1 check passes, sends one `max_tokens=1` generation through the wire protocol the user declared (POST `/v1/messages` for anthropic, POST `/v1/chat/completions` for openai). HTTP 200 paired with `content=[]` / `choices=[]` AND zero-token usage is the canonical failure signature of a reverse-proxy gateway that received the call but did not forward it upstream. Cost: <\$0.0001 per `/doctor` invocation.
- `tui/i18n/{en,zh,wen}.json` get the new strings (`doctor.llm_empty_response`, `doctor.suggest_proxy_check`).
- `tui/internal/tui/login.go` follows the widened `readLLMConfig` signature (mechanical).

### 2. `fix: harden mailbox writes` (ba22cf9)

`tui/internal/fs/mail.go` + `portal/internal/fs/mail.go`: route `WriteMail`'s primary + sent message.json writes through a new `writeJSONAtomic` helper (tmp + rename, cleanup on failure). Tests assert the temporary file doesn't leak.

### 3. `docs(discussions): May 19 patch reports` (4ea33ba)

Five investigation reports against the lingtai Python package and the canonical `lingtai-skill` protocol. Two (preset-swap-silent-revert, strict-schema-scan) describe issues already fixed via merged kernel PRs #114-#117 today; the other three (vision, sentinel-ordering, covenant-distillation) remain open work. Filed here under `discussions/` per the existing patch-report convention.

## Explicitly omitted from JieKiYu's PR #115

`627789e` "local: auto-launch stopped agents on startup" was an unannounced commit that deletes the load-bearing `// Do NOT auto-relaunch stopped agents on TUI startup` comment block and replaces it with `autoLaunchStoppedAgents()`. That reverses an explicit prior policy decision (the existing comment explains the rationale: causes of stopped-at-rest are externally indistinguishable, and auto-revival overrides the user's last explicit `/suspend`). Maintainer call: the policy stays. I've left a note on PR #115 explaining.

## Credit

All code is @JieKiYu's work from PR #115. This branch just slices off the controversial commit so the rest can land.

## Test plan

- [x] `go test ./...` clean across all TUI internal packages
- [x] `go vet ./internal/tui/...` clean
- [x] `make build` clean
- [x] Portal `internal/fs` tests pass; root-level `embed.go` fails only because `web/dist` isn't built locally (unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)