### PR TITLE
fix(preset): pass MiniMax API key to capabilities

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -704,9 +704,11 @@ func skillsDefault() map[string]interface{} {
 	}
 }
 
-
 func minimaxPreset() Preset {
-	mm := map[string]interface{}{"provider": "minimax"}
+	mm := map[string]interface{}{
+		"provider":    "minimax",
+		"api_key_env": "MINIMAX_API_KEY",
+	}
 	return Preset{
 		Name:        "minimax",
 		Description: PresetDescription{Summary: "MiniMax M2.7 — full multimodal capabilities"},

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -191,7 +191,6 @@ func TestGenerateInitJSONWritesPresetBlock(t *testing.T) {
 	}
 }
 
-
 func TestAutoEnvVarName(t *testing.T) {
 	pp := func(provider, baseURL string) Preset {
 		return Preset{Manifest: map[string]interface{}{
@@ -280,5 +279,26 @@ func TestAutoEnvVarName(t *testing.T) {
 				t.Errorf("AutoEnvVarName: got %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+func TestMiniMaxPresetCapabilitiesUseApiKeyEnv(t *testing.T) {
+	p := minimaxPreset()
+	manifest := p.Manifest
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest.capabilities missing or wrong type: %T", manifest["capabilities"])
+	}
+	for _, name := range []string{"web_search", "vision"} {
+		capCfg, ok := caps[name].(map[string]interface{})
+		if !ok {
+			t.Fatalf("capability %s missing or wrong type: %T", name, caps[name])
+		}
+		if provider, _ := capCfg["provider"].(string); provider != "minimax" {
+			t.Errorf("%s.provider = %v, want minimax", name, capCfg["provider"])
+		}
+		if env, _ := capCfg["api_key_env"].(string); env != "MINIMAX_API_KEY" {
+			t.Errorf("%s.api_key_env = %v, want MINIMAX_API_KEY", name, capCfg["api_key_env"])
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add `api_key_env: MINIMAX_API_KEY` to the built-in MiniMax `web_search` and `vision` capability configs
- add a regression test so both capability configs keep the MiniMax provider and key env

## Why
The MiniMax LLM block already had `api_key_env`, but the capability maps were explicit `provider: minimax` configs without their own `api_key_env`. Explicit provider configs do not inherit credentials from the LLM, so MiniMax web search started with `api_key=None` and failed during agent startup.

This makes the built-in preset match the shipped init templates/examples, which already pass `MINIMAX_API_KEY` to MiniMax capabilities.

## Tests
- `(cd tui && go test ./internal/preset)`
