### PR TITLE
fix(doctor): treat OAuth providers (codex) as Warn, not probeNoKey

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -339,6 +339,8 @@
   "doctor.llm_overloaded": "✗ LLM provider overloaded: %s",
   "doctor.llm_network": "✗ LLM unreachable: %s",
   "doctor.llm_no_key": "✗ API key not set",
+  "doctor.llm_oauth": "⚠ OAuth provider — credentials managed by the CLI, not probed here",
+  "doctor.suggest_oauth": "→ Verify login externally (e.g. `codex login`); if the CLI works, ignore this notice.",
   "doctor.llm_no_base_url": "✗ No API endpoint (base_url) set for %s",
   "doctor.suggest_base_url": "→ Open preset editor and select a region (CN / INTL), then /refresh.",
   "doctor.llm_unknown": "✗ LLM error: %s",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -334,6 +334,8 @@
   "doctor.llm_overloaded": "✗ 天过载：%s",
   "doctor.llm_network": "✗ 天不达：%s",
   "doctor.llm_no_key": "✗ 未设密钥",
+  "doctor.llm_oauth": "⚠ OAuth 之主 — 凭由 CLI 自掌，此不探。",
+  "doctor.suggest_oauth": "→ 于外验登（如 `codex login`）；CLI 既通，则此可置。",
   "doctor.llm_no_base_url": "✗ %s 未设端",
   "doctor.suggest_base_url": "→ 开预设编器选区域 (CN / INTL)，后 /refresh。",
   "doctor.llm_unknown": "✗ 天误：%s",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -334,6 +334,8 @@
   "doctor.llm_overloaded": "✗ LLM 过载：%s",
   "doctor.llm_network": "✗ LLM 不可达：%s",
   "doctor.llm_no_key": "✗ 未设置 API 密钥",
+  "doctor.llm_oauth": "⚠ OAuth 提供方 — 凭证由 CLI 管理，此处不做探测",
+  "doctor.suggest_oauth": "→ 在外部确认登录（如 `codex login`）；若 CLI 可用，可忽略此提示。",
   "doctor.llm_no_base_url": "✗ 未设置 %s 的 API 端点 (base_url)",
   "doctor.suggest_base_url": "→ 打开预设编辑器选择区域 (CN / INTL)，然后 /refresh。",
   "doctor.llm_unknown": "✗ LLM 错误：%s",

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -260,6 +260,13 @@ func runDoctor(orchDir, globalDir string) doctorResultMsg {
 		lines = append(lines, doctorLine{
 			Text: i18n.T("doctor.suggest_setup"), Hint: true,
 		})
+	case probeOAuth:
+		lines = append(lines, doctorLine{
+			Text: i18n.T("doctor.llm_oauth"), Warn: true,
+		})
+		lines = append(lines, doctorLine{
+			Text: i18n.T("doctor.suggest_oauth"), Hint: true,
+		})
 	case probeEmptyResponse:
 		lines = append(lines, doctorLine{
 			Text: i18n.TF("doctor.llm_empty_response", detail),
@@ -446,9 +453,27 @@ const (
 	// charity branch), or may return a benign 200 — so we run a real
 	// minimal messages call as a second-stage probe.
 	probeEmptyResponse
+	// probeOAuth: provider uses OAuth/session-based auth (e.g. codex /
+	// codex_oauth via ChatGPT subscription), not an API key. The doctor
+	// cannot probe these from this process — the CLI subprocess owns the
+	// credential. Surface as a Warn-level note rather than the bogus
+	// "API key not set" alarm that probeNoKey would produce.
+	probeOAuth
 )
 
+// oauthProviders enumerates LLM providers whose credentials live outside
+// the LingTai config (no api_key / api_key_env). The doctor cannot probe
+// these directly; the spawned CLI handles its own auth (e.g. `codex`
+// reads ~/.codex/auth.json from a prior `codex login`).
+var oauthProviders = map[string]bool{
+	"codex":       true,
+	"codex_oauth": true,
+}
+
 func probeLLM(provider, model, apiKey, baseURL, apiCompat string) (probeStatus, string) {
+	if oauthProviders[provider] {
+		return probeOAuth, ""
+	}
 	if apiKey == "" {
 		return probeNoKey, ""
 	}


### PR DESCRIPTION
## Summary

The codex preset intentionally carries no API key (`api_key: null`, `api_key_env: \"\"`) because authentication lives in `~/.codex/auth.json` from a prior `codex login`. The doctor probe at `doctor.go:452` checks `apiKey == ""` first and short-circuits to `probeNoKey`, displaying **\"✗ API key not set\"** to every codex-OAuth user who runs `/doctor`. False alarm — the agent is perfectly healthy.

This PR adds a `probeOAuth` status that fires *before* the `apiKey == \"\"` check for providers in a small allowlist (`{codex, codex_oauth}`). It renders as a Warn-level line:

> ⚠ OAuth provider — credentials managed by the CLI, not probed here
> → Verify login externally (e.g. \`codex login\`); if the CLI works, ignore this notice.

i18n added in en / zh / wen per the three-locale rule.

## Test plan
- [x] `make build` succeeds
- [x] `go test ./internal/tui/...` passes
- [x] JSON syntax validated for all three i18n files
- [ ] Manual: run `/doctor` on a codex-OAuth agent, confirm Warn line replaces "API key not set"