### PR TITLE
docs(claude-md): reconcile rule 4 with worktree single-line carve-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ When a human gives conceptual, corrective, or ambiguous feedback — especially 
 1. **Pause coding.** Restate the intended contract and wait for confirmation when scope is ambiguous.
 2. **Classify findings.** Label each concern: confirmed defect, edge risk, future refactor, or documentation/process issue. Do not treat all concerns as immediate code changes.
 3. **Name the smallest change.** Identify the minimal fix. Do not expand into a broader refactor because nearby code is related.
-4. **No direct edits for self-initiated improvements.** All changes go through issue → branch → PR → merge. Direct edits are for explicitly requested emergency fixes only.
+4. **No direct edits for self-initiated improvements.** Self-initiated code changes go through issue → branch → PR → merge. Direct edits are for explicitly requested emergency fixes only. (The "Always work in a worktree" section below carves out single-line fixes and doc tweaks — those exceptions still apply.)
 5. **Stop after stop.** When a human says to stop coding, stop immediately. Switch to clarification or reporting only.
 
 ## Always work in a worktree, never directly in the main checkout


### PR DESCRIPTION
## Summary

Rule 4 of the "Clarify human intent before coding" section said *all* changes must go through issue → branch → PR → merge. But the "Always work in a worktree" section below it explicitly carves out an exception: "Single-line fixes and doc tweaks can stay in the main checkout." Two rules in the same file disagreed on what to do for a one-line doc edit — an AI agent reading top-to-bottom had to guess which one wins.

Reword rule 4 to acknowledge the carve-out.

## Test plan
- [x] Diff confirms only the one line changes