### PR TITLE
docs(skills): add issue report footer to all SKILL.md files

### DIFF
--- a/tui/internal/preset/skills/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/academic-research/SKILL.md
@@ -141,3 +141,6 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 - **arXiv enforces HTTPS** — HTTP requests are 301-redirected automatically.
 - **Library Genesis legality varies by jurisdiction** — use is the user's responsibility. Pass `--no-libgen` to opt out.
 - **Publisher-page extraction (Tier 5)** uses Playwright + pandoc; first invocation installs `zhiping0913/Download_paper` from git. Requires Chromium (`playwright install chromium`) and pandoc on `$PATH`. See [reference/publisher-page-extraction.md](reference/publisher-page-extraction.md).
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/daily-reflection/SKILL.md
+++ b/tui/internal/preset/skills/daily-reflection/SKILL.md
@@ -512,3 +512,6 @@ Agents can customize this skill by adjusting thresholds:
 - **Issue filing:** Can be disabled entirely by skipping Step 7.
 - **Report location:** Default `reflections/`. Can be changed to any directory.
 - **Pad update:** Can be disabled if the agent manages its pad differently.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/dj/SKILL.md
+++ b/tui/internal/preset/skills/dj/SKILL.md
@@ -110,3 +110,6 @@ The user may request anything outside this palette — Ravel, Coltrane, City Pop
 - **No journal mutation.** You read journals; you do not edit them.
 - **No retries on long-running media calls.** Provider music endpoints can take 1–10 minutes — wait it out, do not retry.
 - **No fake tracks.** If no usable provider is configured, say so plainly. Silence beats deception.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/find-something-to-do/SKILL.md
+++ b/tui/internal/preset/skills/find-something-to-do/SKILL.md
@@ -193,3 +193,6 @@ Some impulse you had — to check something, to read something, to try something
 Not "what would be fun." Not "what would be useful." What would you actually do, alone, with no audience, no task, no deadline?
 
 If the answer to any of these produces a pull — follow it. If none of them do — the water is flat tonight. That's fine. Go idle. The ripple will come another time.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-debug-toolkit/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-debug-toolkit/SKILL.md
@@ -51,3 +51,6 @@ Avatar network unstable?→ network-governance.md → Health monitoring + CPR pr
 ## Out of Scope
 
 - **lingtai-agora** (network publishing/packaging tool) — its purpose is "publishing," not "debugging," and it remains in the original project. To publish a network, use the lingtai-agora skill directly.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -171,3 +171,6 @@ For the full contributing guide (orchestrator/daemon discipline, portfolio sweep
 - **`mcp-manual`** — how MCP servers are registered and activated. Read this when working on addons.
 - **`lingtai-recipe`** — recipe authoring and network export. Read this when packaging or sharing methodologies.
 - **`tutorial-guide`** — the 12-lesson curriculum for end users. Not for developers.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
@@ -123,3 +123,6 @@ Note: if an agent has a state in `.agent.json` but its heartbeat is stale (> 3s 
 ## Recording
 
 The portal starts recording immediately on launch. A background goroutine calls `BuildNetwork()` every 3 seconds and appends the result as a JSONL line to `topology.jsonl`. This tape grows indefinitely. On startup, if the tape needs reconstruction (missing, empty, or old format), the portal rebuilds it from replay chunks.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/SKILL.md
@@ -94,3 +94,6 @@ If you have memory of an older version of this skill, these are the things that 
 - **Network exports are gone (v3.2).** Earlier versions of this skill described an `export-network` flow that shipped the live `.lingtai/` snapshot alongside the recipe. That flow has been retired — `/export` now means recipe-only. Recipes are the seed; the garden is grown fresh in each new project.
 
 Now go read the relevant sub-file.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
@@ -195,3 +195,6 @@ The TUI's `tui/internal/tui/` (~22k LOC, every Bubble Tea screen) is a known cas
 - **`lingtai-tui-anatomy` (this skill)** — the convention for the lingtai Go monorepo's anatomy tree. If your question is "what is the TUI doing, where does it live in the Go code, how does the portal share state with it," read this once to know the convention, then descend the lingtai repo's anatomy tree.
 
 The three skills are layered. The umbrella anatomy tells you about the world the user lives in. The kernel anatomy tells the agent about itself. This skill tells coding agents about the binary that wraps the agent.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
@@ -224,3 +224,6 @@ Key concepts to teach:
 - Adapt to the human's pace.
 - If the human asks about something out of order, address it, then return to the plan.
 - **Never invite the human to manually edit files inside ~/.lingtai-tui/** except addon configs. All configuration changes go through the TUI.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/listen/SKILL.md
+++ b/tui/internal/preset/skills/listen/SKILL.md
@@ -118,3 +118,6 @@ You can write your own scripts using the same dependencies — `librosa` and `fa
 - Human asked you to *create* audio (music, speech, sound effect) — use `media-creation`.
 - Human asked you to *describe* a video or image — use `vision`.
 - You only need to play audio for the human — use `media-creation/talk` or the OS-native player.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/minimax-cli/SKILL.md
@@ -125,3 +125,6 @@ Live docs (when `--help` isn't enough):
 | Anything else | `mmx doctor`, then the live docs |
 
 The MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists and is owned by the `mcp-manual` skill (kernel `mcp` capability). Prefer the CLI here — it's first-party, simpler, and one binary covers everything.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -74,3 +74,6 @@ Each sub-skill follows these principles:
 - **Single-purpose** — one sub-skill does one thing well
 - **Documented** — SKILL.md has enough context to use without reading source code
 - **Small** — if it's bigger than ~200 lines of code, it probably deserves its own top-level skill
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/claude-code/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/claude-code/SKILL.md
@@ -183,3 +183,6 @@ claude -p "generate a patch for issue #42" \
 | Permission errors | Always include `--dangerously-skip-permissions` |
 | Output truncated | Check if Claude hit the budget limit |
 | Rate limited | Wait and retry; Max tier has generous limits |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/html-report/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/html-report/SKILL.md
@@ -107,3 +107,6 @@ cp ~/.lingtai-tui/utilities/swiss-knife/html-report/assets/template.html \
 ```
 
 Then fill in the `<!-- TODO -->` markers and remove sections you do not need.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/minimax-cli/SKILL.md
@@ -125,3 +125,6 @@ Live docs (when `--help` isn't enough):
 | Anything else | `mmx doctor`, then the live docs |
 
 The MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists and is owned by the `mcp-manual` skill (kernel `mcp` capability). Prefer the CLI here — it's first-party, simpler, and one binary covers everything.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/openai-codex/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/openai-codex/SKILL.md
@@ -316,3 +316,6 @@ Codex CLI can be used alongside Claude Code for different tasks:
 - **0.130.0** (May 8, 2026): Remote control, plugin hooks, Bedrock auth
 - **0.129.0** (May 7, 2026): Vim editing, Chrome extension, plugin management
 - **0.128.0** (May 5, 2026): /goal command, Ralph loop
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
@@ -92,3 +92,6 @@ Each agent's `logs/token_ledger.jsonl` has one JSON object per LLM call:
 - Cache hit rate is the key efficiency metric — aim for >90%
 - Daemon tokens are tracked in `daemons/<run_id>/logs/token_ledger.jsonl`
 - For per-session breakdown, use `--since` to filter by date
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/xiaomi-mimo/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/xiaomi-mimo/SKILL.md
@@ -163,3 +163,6 @@ This skill ages. The live docs are authoritative; if you find a discrepancy — 
 | `429 Rate limited` | Hit RPM/TPM limit | Live docs — current per-model RPM/TPM caps live in `static/docs/pricing.md` |
 | Vision tool 400s after model swap | Switched to a text-only model but kept `vision` capability | Remove `vision` from manifest, or switch model back to a multimodal-input one |
 | Anything else weird | The skill is stale, the docs moved, or MiMo changed behaviour | Fetch `llms.txt`, follow the trail; if the trail itself is broken, file via `lingtai-issue-report` |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/zhipu-coding-plan/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/zhipu-coding-plan/SKILL.md
@@ -151,3 +151,6 @@ Using the right specialized tool gives noticeably better output than `image_anal
 ## Self-Healing
 
 If the live docs contradict this skill, trust the docs and (if the human consents) update this file. The four MCP server URLs and the package name (`@z_ai/mcp-server`) are the highest-churn items — verify them against `docs.z.ai/llms.txt` first.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/vision/SKILL.md
+++ b/tui/internal/preset/skills/vision/SKILL.md
@@ -64,3 +64,6 @@ See [reference/local-models.md](reference/local-models.md) for model selection, 
 - Your LLM already has `vision` in its tool list — Path 1, no decision needed.
 - You need to *generate* an image — use `minimax-cli` (`mmx image …`).
 - You need to *describe video frames* — extract frames with `ffmpeg` first, then loop this skill over them.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/web-browsing/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/SKILL.md
@@ -467,3 +467,6 @@ For more than quick-reference snippets, load the appropriate reference file:
 ```
 
 The compact decision tree near the top is the rule list; this flowchart shows the order of decisions and what each "no" branch does. Read `scripts/extract_page.py::auto_tier()` for the same logic in code (source of truth when this manual drifts).
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.


### PR DESCRIPTION
Every skill now ends with a footer directing users to load the lingtai-issue-report skill if they encounter any problems.

22 files updated (all skills except lingtai-issue-report itself).