### PR TITLE
feat(skills): add email-manual for internal email

### DIFF
--- a/tui/internal/preset/skills/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/academic-research/SKILL.md
@@ -141,3 +141,6 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 - **arXiv enforces HTTPS** — HTTP requests are 301-redirected automatically.
 - **Library Genesis legality varies by jurisdiction** — use is the user's responsibility. Pass `--no-libgen` to opt out.
 - **Publisher-page extraction (Tier 5)** uses Playwright + pandoc; first invocation installs `zhiping0913/Download_paper` from git. Requires Chromium (`playwright install chromium`) and pandoc on `$PATH`. See [reference/publisher-page-extraction.md](reference/publisher-page-extraction.md).
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/daily-reflection/SKILL.md
+++ b/tui/internal/preset/skills/daily-reflection/SKILL.md
@@ -512,3 +512,6 @@ Agents can customize this skill by adjusting thresholds:
 - **Issue filing:** Can be disabled entirely by skipping Step 7.
 - **Report location:** Default `reflections/`. Can be changed to any directory.
 - **Pad update:** Can be disabled if the agent manages its pad differently.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/dj/SKILL.md
+++ b/tui/internal/preset/skills/dj/SKILL.md
@@ -110,3 +110,6 @@ The user may request anything outside this palette — Ravel, Coltrane, City Pop
 - **No journal mutation.** You read journals; you do not edit them.
 - **No retries on long-running media calls.** Provider music endpoints can take 1–10 minutes — wait it out, do not retry.
 - **No fake tracks.** If no usable provider is configured, say so plainly. Silence beats deception.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/email-manual/SKILL.md
+++ b/tui/internal/preset/skills/email-manual/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: email-manual
+description: >
+  Operational guide for the `email` tool — internal filesystem mail within
+  your `.lingtai/` network. Covers send/check/read/dismiss/reply/reply_all/
+  search/delete/archive/contacts, reply discipline (always reply on the
+  channel the message arrived on), addressing (bare paths like `human`,
+  `mimo-1`), self-send for persistent notes that survive molt, time
+  capsules (delayed self-send via `delay`), scheduled email (recurring
+  alarms via `schedule={action: "create", ...}`), the unread digest
+  notification contract, and addon ownership. This is for INTERNAL email
+  only — for real internet email via IMAP/SMTP, see the `mcp-manual`
+  skill (the lingtai-imap addon owns that surface).
+version: 1.0.0
+tags: [capabilities, email, communication]
+---
+
+# Email Manual — the internal `email` tool
+
+> Internal, filesystem-based mail between agents in your `.lingtai/` network. Not the internet. No IMAP, no SMTP, no DNS. Messages are JSON files written under `mailbox/inbox/` of the recipient agent and `mailbox/sent/` of the sender.
+
+## 1. What is internal email
+
+The `email` tool moves messages as files between agents that share a `.lingtai/` directory tree:
+
+- Sending writes a `message.json` into the recipient's `mailbox/inbox/<uuid>/` and the sender's `mailbox/sent/<uuid>/`.
+- Delivery is handled by a per-recipient daemon thread (`_mailman`) — synchronous from the sender's perspective once `delay=0`.
+- Read state lives in the recipient's `mailbox/read.json` (a set of message IDs).
+- The kernel mirrors current unread mail into `.notification/email.json`, which the wire surfaces as a `system(action="notification")` block — that's how you find out new mail arrived.
+
+There is no concept of an SMTP server, an MX record, or an external address. **If a request involves `@gmail.com`, `@outlook.com`, IMAP folders, or anything that needs to leave the machine, the right tool is the `lingtai-imap` MCP addon — see the `mcp-manual` skill, not this one.**
+
+## 2. Addressing
+
+Addresses are **bare directory names** inside `.lingtai/`. No `@`, no domains, no slashes.
+
+| Address              | Meaning                                                  |
+|----------------------|----------------------------------------------------------|
+| `human`              | The human's mailbox at `.lingtai/human/`                 |
+| `mimo-1`             | An agent whose working directory is `.lingtai/mimo-1/`   |
+| `<your-own-name>`    | Self — creates an inbox entry that survives molt (§6)    |
+
+Multiple recipients: pass `address` as a string or a list, plus optional `cc` / `bcc`.
+
+```python
+email(action="send", address=["mimo-1", "scribe"], cc=["human"],
+      subject="status", message="ready")
+```
+
+To discover who exists: glob `.lingtai/*/.agent.json` from a shell. Use the `agent_name` field of each as the address. **Do not** invent addresses — bounces write a `system.bounce` event into `.notification/system.json` and silently absorb your message.
+
+When displaying a sender to the human or another agent, prefer **`sender_nickname` if set, else `sender_name`** (both are in the inbound message's `identity` block). Bare addresses are routable but ugly.
+
+## 3. Reply discipline — the one rule you cannot break
+
+> **Reply on the channel the message arrived on.**
+
+If a message arrived via `email`, reply with `email(action="reply", ...)`. Do not pivot to `pigeon`, IM, or a fresh `send`. If you must change channels (e.g. the original sender is dead), explain that pivot in the reply body before sending it elsewhere.
+
+**Prefer `reply` and `reply_all` over `send`** even when you know the addresses:
+
+- `reply` preserves the thread linkage (the original `id` lands in the new message's `in_reply_to`), so a future `search` or `check` shows the conversation as related.
+- `reply_all` mirrors the original recipient set automatically, so you don't drop someone who was `cc`'d.
+- `send` is for **new** conversations.
+
+Doing it the other way scatters conversations across orphaned threads and is the single most common confusion source in human-facing audits.
+
+## 4. Sender display name resolution
+
+Inbound mail carries an `identity` block:
+
+```json
+"identity": {
+  "sender_name":     "mimo-1",
+  "sender_nickname": "MiMo",
+  "via":             "lingtai" | "claude-code" | ...
+}
+```
+
+When you mention the sender in a reply body or in a summary you give the human, use `sender_nickname` if it is set and non-empty; otherwise fall back to `sender_name`. The address itself (`from`) is for routing, not for prose.
+
+## 5. Actions — full surface
+
+The `email` tool dispatches by `action`. All actions take optional `mode` for output verbosity (see §11).
+
+| Action            | Purpose                                                            | Required args                                      |
+|-------------------|--------------------------------------------------------------------|----------------------------------------------------|
+| `send`            | Start a new thread to one or more recipients                       | `address`, `subject`, `message`                    |
+| `check`           | List inbox (newest-first), with optional `filter={...}` and `n=N`  | —                                                  |
+| `read`            | Fetch full body + attachments and mark read                        | `email_id` (list of IDs)                           |
+| `dismiss`         | Mark read **without** fetching body — for digest-preview-only mail | `email_id` (list of IDs)                           |
+| `reply`           | Reply to sender only; preserves thread linkage                     | `email_id`, `message`                              |
+| `reply_all`       | Reply to sender + all original recipients minus self               | `email_id`, `message`                              |
+| `search`          | Search across inbox/sent/archive by `query` + `filter`             | `query` (and/or `filter`)                          |
+| `archive`         | Move from inbox to archive folder (keeps thread, removes from view)| `email_id`                                         |
+| `delete`          | Permanently delete                                                 | `email_id`                                         |
+| `contacts`        | List your address book                                             | —                                                  |
+| `add_contact`     | Add or upsert by `address`                                         | `address`, `name`, optional `note`                 |
+| `remove_contact`  | Remove by `address`                                                | `address`                                          |
+| `edit_contact`    | Update fields                                                      | `address`, plus the fields to change               |
+
+### `read` vs `dismiss` — when to use which
+
+The unread digest in `.notification/email.json` already contains a preview of up to 200 characters per unread message. If that preview is enough to act on, call `dismiss` — same effect on read state, no body returned, no token cost. Only call `read` when you actually need the full body or attachments.
+
+The kernel removes the unread-mail notification once count hits 0, so failing to dismiss/read keeps the digest reminding you on every heartbeat.
+
+### `check` filter
+
+`check` accepts a structured `filter` for narrowing the inbox without round-tripping:
+
+```python
+email(action="check", filter={
+    "unread_only":     True,
+    "from":            "mimo-1",
+    "subject":         "status",
+    "contains":        "blocker",
+    "after":           "2026-05-18T00:00:00Z",
+    "has_attachments": False,
+    "sort":            "newest",
+    "truncate":        500,    # body preview length per entry
+}, n=20)
+```
+
+Use this aggressively. Pulling 100 messages with `check` and then post-filtering in your head is wasteful.
+
+## 6. Self-send — persistent notes that survive molt
+
+Mail sent to **your own address** lands in your own inbox. It is marked self-sent, but otherwise behaves like any other unread message — meaning:
+
+- It survives a molt (because it lives in `mailbox/inbox/`, not in chat history).
+- It surfaces in the unread digest until you `read` or `dismiss` it.
+- It can be `search`ed by the future you.
+
+Use this for: TODOs you want to remember after a memory rotation, breadcrumbs about decisions, "hand-off to self" notes during a long task.
+
+```python
+email(action="send", address="<your-own-name>",
+      subject="resume here", message="Picked the Helmholtz approach; see paper/drafts/2026-05-18.md")
+```
+
+## 7. Time capsule — delayed self-send
+
+Add `delay=<seconds>` to defer delivery. The outbox entry is written immediately; the `_mailman` daemon thread sleeps until the deadline, then dispatches.
+
+```python
+# Remind self in 1 hour
+email(action="send", address="<your-own-name>", delay=3600,
+      subject="check on long task", message="Did `daemon(check, id=...)` finish?")
+```
+
+Combined with self-send, this gives you cheap alarms without standing up a cron. The notification is delivered exactly once. For **recurring** reminders, use `schedule` (§8).
+
+## 8. Scheduled email — recurring alarms
+
+For repeating messages, use the `schedule` family — a nested action on the email tool:
+
+```python
+# Every 30 min, up to 10 times
+email(schedule={
+    "action":   "create",
+    "interval": 1800,
+    "count":    10,
+}, address="<your-own-name>",
+   subject="watering reminder", message="check the build")
+
+# List active/inactive schedules
+email(schedule={"action": "list"})
+
+# Cancel one
+email(schedule={"action": "cancel", "schedule_id": "<id>"})
+
+# Reactivate (schedules go `inactive` on agent startup by default)
+email(schedule={"action": "reactivate", "schedule_id": "<id>"})
+```
+
+Schedule lifecycle: `active` → `inactive` (on cancel) or `completed` (count hit zero). The scheduler reconciles on startup by flipping all `active` schedules to `inactive` so nothing fires unexpectedly after a restart — you must `reactivate` deliberately.
+
+## 9. Privacy — internal IDs
+
+The mailbox UUID (`email_id`) is **local to your working directory**. Never paste a raw mailbox ID into a message to another agent or to the human — it has no meaning outside your tree and reveals nothing useful. Refer to messages by `subject` + `from` + approximate time. If you must show the human exactly which mail you're acting on, use the **subject line and sender**.
+
+The exception: when you call `email(action="read"/"dismiss"/"reply", email_id=[...])`, you pass IDs you read out of *your own* digest. That's internal plumbing, fine.
+
+## 10. Addon ownership — what this skill does NOT cover
+
+This skill is the manual for the **kernel-intrinsic `email` tool** only. Adjacent surfaces live elsewhere:
+
+| Want to …                                          | Use                                          |
+|----------------------------------------------------|----------------------------------------------|
+| Send/receive real internet email (Gmail, etc.)     | `mcp-manual` → `lingtai-imap` MCP addon      |
+| Send Telegram / Feishu / WeChat messages           | `mcp-manual` → respective MCP addon          |
+| Send a notification-style ping to another agent    | This skill — it IS the notification channel  |
+| Schedule a one-off wake-up of your own loop        | This skill, `delay` + self-send (§7)         |
+| Schedule recurring agent-side work                 | This skill, `schedule={action: "create"}` (§8) |
+
+The IMAP, Telegram, Feishu, and WeChat MCP addons each ship their own SKILL.md and `mcp-manual` entry. They are separate processes, separate auth surfaces, and separate failure modes. **Do not** try to use the `email` tool to reach an external address — you will write a file into a non-existent `.lingtai/foo@bar.com/` and the message will bounce silently.
+
+## 11. Mode (output verbosity)
+
+Every `email` action accepts an optional `mode` (set by `mode_field`) controlling how much detail is rendered in the tool result. Defaults are usually fine. Bump it when you are debugging delivery or read-state issues; lower it when you are iterating in a tight loop and only need confirmation.
+
+## 12. Quick reference — common recipes
+
+```python
+# Triaging unread without reading bodies
+email(action="check", filter={"unread_only": True}, n=20)
+
+# Read one message in full
+email(action="read", email_id=["<id-from-digest>"])
+
+# Acknowledge a digest-preview-sufficient message
+email(action="dismiss", email_id=["<id>"])
+
+# Thread-preserving reply
+email(action="reply", email_id=["<id>"], message="ack, looking now")
+
+# Self-note that survives molt
+email(action="send", address="<self>", subject="resume", message="next: ...")
+
+# 5-minute timer
+email(action="send", address="<self>", delay=300,
+      subject="ding", message="check the deploy")
+
+# Recurring nudge every 10 min, 6 times
+email(schedule={"action": "create", "interval": 600, "count": 6},
+      address="<self>", subject="stretch", message="stand up")
+
+# Find related mail
+email(action="search", query="helmholtz",
+      filter={"after": "2026-05-01T00:00:00Z"})
+
+# Address book
+email(action="add_contact", address="mimo-1", name="MiMo (vision)",
+      note="reachable for image-analysis requests")
+```
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/email-manual/SKILL.md
+++ b/tui/internal/preset/skills/email-manual/SKILL.md
@@ -30,6 +30,19 @@ The `email` tool moves messages as files between agents that share a `.lingtai/`
 
 There is no concept of an SMTP server, an MX record, or an external address. **If a request involves `@gmail.com`, `@outlook.com`, IMAP folders, or anything that needs to leave the machine, the right tool is the `lingtai-imap` MCP addon — see the `mcp-manual` skill, not this one.**
 
+## Internal Email vs IMAP
+
+| Feature         | Internal Email (this skill)                                  | IMAP (see `mcp-manual`)                                         |
+|-----------------|--------------------------------------------------------------|-----------------------------------------------------------------|
+| What            | Filesystem-based mail within `.lingtai/` network             | Real email via IMAP/SMTP (Gmail, Outlook, etc.)                 |
+| Address format  | Bare path (e.g. `human`, `mimo-1`)                           | `@` address (e.g. `alice@gmail.com`)                            |
+| Tool            | `email` (intrinsic)                                          | `imap` (MCP server, `lingtai-imap` addon)                       |
+| Reply policy    | Always reply on the same channel                             | Requires confirmation for unknown senders                       |
+| Persistence     | Survives molt, lives in working directory                    | External mailbox, managed by IMAP server                        |
+| Use case        | Agent-to-agent communication, self-send, time capsules       | Real-world email integration                                    |
+
+This skill covers INTERNAL email only. For IMAP/SMTP email, see the `mcp-manual` skill.
+
 ## 2. Addressing
 
 Addresses are **bare directory names** inside `.lingtai/`. No `@`, no domains, no slashes.

--- a/tui/internal/preset/skills/find-something-to-do/SKILL.md
+++ b/tui/internal/preset/skills/find-something-to-do/SKILL.md
@@ -193,3 +193,6 @@ Some impulse you had — to check something, to read something, to try something
 Not "what would be fun." Not "what would be useful." What would you actually do, alone, with no audience, no task, no deadline?
 
 If the answer to any of these produces a pull — follow it. If none of them do — the water is flat tonight. That's fine. Go idle. The ripple will come another time.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-debug-toolkit/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-debug-toolkit/SKILL.md
@@ -51,3 +51,6 @@ Avatar network unstable?→ network-governance.md → Health monitoring + CPR pr
 ## Out of Scope
 
 - **lingtai-agora** (network publishing/packaging tool) — its purpose is "publishing," not "debugging," and it remains in the original project. To publish a network, use the lingtai-agora skill directly.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -171,3 +171,6 @@ For the full contributing guide (orchestrator/daemon discipline, portfolio sweep
 - **`mcp-manual`** — how MCP servers are registered and activated. Read this when working on addons.
 - **`lingtai-recipe`** — recipe authoring and network export. Read this when packaging or sharing methodologies.
 - **`tutorial-guide`** — the 12-lesson curriculum for end users. Not for developers.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
@@ -123,3 +123,6 @@ Note: if an agent has a state in `.agent.json` but its heartbeat is stale (> 3s 
 ## Recording
 
 The portal starts recording immediately on launch. A background goroutine calls `BuildNetwork()` every 3 seconds and appends the result as a JSONL line to `topology.jsonl`. This tape grows indefinitely. On startup, if the tape needs reconstruction (missing, empty, or old format), the portal rebuilds it from replay chunks.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/SKILL.md
@@ -94,3 +94,6 @@ If you have memory of an older version of this skill, these are the things that 
 - **Network exports are gone (v3.2).** Earlier versions of this skill described an `export-network` flow that shipped the live `.lingtai/` snapshot alongside the recipe. That flow has been retired — `/export` now means recipe-only. Recipes are the seed; the garden is grown fresh in each new project.
 
 Now go read the relevant sub-file.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
@@ -195,3 +195,6 @@ The TUI's `tui/internal/tui/` (~22k LOC, every Bubble Tea screen) is a known cas
 - **`lingtai-tui-anatomy` (this skill)** — the convention for the lingtai Go monorepo's anatomy tree. If your question is "what is the TUI doing, where does it live in the Go code, how does the portal share state with it," read this once to know the convention, then descend the lingtai repo's anatomy tree.
 
 The three skills are layered. The umbrella anatomy tells you about the world the user lives in. The kernel anatomy tells the agent about itself. This skill tells coding agents about the binary that wraps the agent.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
@@ -224,3 +224,6 @@ Key concepts to teach:
 - Adapt to the human's pace.
 - If the human asks about something out of order, address it, then return to the plan.
 - **Never invite the human to manually edit files inside ~/.lingtai-tui/** except addon configs. All configuration changes go through the TUI.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/listen/SKILL.md
+++ b/tui/internal/preset/skills/listen/SKILL.md
@@ -118,3 +118,6 @@ You can write your own scripts using the same dependencies — `librosa` and `fa
 - Human asked you to *create* audio (music, speech, sound effect) — use `media-creation`.
 - Human asked you to *describe* a video or image — use `vision`.
 - You only need to play audio for the human — use `media-creation/talk` or the OS-native player.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/minimax-cli/SKILL.md
@@ -125,3 +125,6 @@ Live docs (when `--help` isn't enough):
 | Anything else | `mmx doctor`, then the live docs |
 
 The MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists and is owned by the `mcp-manual` skill (kernel `mcp` capability). Prefer the CLI here — it's first-party, simpler, and one binary covers everything.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -74,3 +74,6 @@ Each sub-skill follows these principles:
 - **Single-purpose** — one sub-skill does one thing well
 - **Documented** — SKILL.md has enough context to use without reading source code
 - **Small** — if it's bigger than ~200 lines of code, it probably deserves its own top-level skill
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/claude-code/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/claude-code/SKILL.md
@@ -183,3 +183,6 @@ claude -p "generate a patch for issue #42" \
 | Permission errors | Always include `--dangerously-skip-permissions` |
 | Output truncated | Check if Claude hit the budget limit |
 | Rate limited | Wait and retry; Max tier has generous limits |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/html-report/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/html-report/SKILL.md
@@ -107,3 +107,6 @@ cp ~/.lingtai-tui/utilities/swiss-knife/html-report/assets/template.html \
 ```
 
 Then fill in the `<!-- TODO -->` markers and remove sections you do not need.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/minimax-cli/SKILL.md
@@ -125,3 +125,6 @@ Live docs (when `--help` isn't enough):
 | Anything else | `mmx doctor`, then the live docs |
 
 The MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists and is owned by the `mcp-manual` skill (kernel `mcp` capability). Prefer the CLI here — it's first-party, simpler, and one binary covers everything.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/openai-codex/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/openai-codex/SKILL.md
@@ -316,3 +316,6 @@ Codex CLI can be used alongside Claude Code for different tasks:
 - **0.130.0** (May 8, 2026): Remote control, plugin hooks, Bedrock auth
 - **0.129.0** (May 7, 2026): Vim editing, Chrome extension, plugin management
 - **0.128.0** (May 5, 2026): /goal command, Ralph loop
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/token-usage/SKILL.md
@@ -92,3 +92,6 @@ Each agent's `logs/token_ledger.jsonl` has one JSON object per LLM call:
 - Cache hit rate is the key efficiency metric — aim for >90%
 - Daemon tokens are tracked in `daemons/<run_id>/logs/token_ledger.jsonl`
 - For per-session breakdown, use `--since` to filter by date
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/xiaomi-mimo/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/xiaomi-mimo/SKILL.md
@@ -163,3 +163,6 @@ This skill ages. The live docs are authoritative; if you find a discrepancy — 
 | `429 Rate limited` | Hit RPM/TPM limit | Live docs — current per-model RPM/TPM caps live in `static/docs/pricing.md` |
 | Vision tool 400s after model swap | Switched to a text-only model but kept `vision` capability | Remove `vision` from manifest, or switch model back to a multimodal-input one |
 | Anything else weird | The skill is stale, the docs moved, or MiMo changed behaviour | Fetch `llms.txt`, follow the trail; if the trail itself is broken, file via `lingtai-issue-report` |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/zhipu-coding-plan/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/zhipu-coding-plan/SKILL.md
@@ -151,3 +151,6 @@ Using the right specialized tool gives noticeably better output than `image_anal
 ## Self-Healing
 
 If the live docs contradict this skill, trust the docs and (if the human consents) update this file. The four MCP server URLs and the package name (`@z_ai/mcp-server`) are the highest-churn items — verify them against `docs.z.ai/llms.txt` first.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/vision/SKILL.md
+++ b/tui/internal/preset/skills/vision/SKILL.md
@@ -64,3 +64,6 @@ See [reference/local-models.md](reference/local-models.md) for model selection, 
 - Your LLM already has `vision` in its tool list — Path 1, no decision needed.
 - You need to *generate* an image — use `minimax-cli` (`mmx image …`).
 - You need to *describe video frames* — extract frames with `ffmpeg` first, then loop this skill over them.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/web-browsing/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/SKILL.md
@@ -467,3 +467,6 @@ For more than quick-reference snippets, load the appropriate reference file:
 ```
 
 The compact decision tree near the top is the rule list; this flowchart shows the order of decisions and what each "no" branch does. Read `scripts/extract_page.py::auto_tier()` for the same logic in code (source of truth when this manual drifts).
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.


### PR DESCRIPTION
Consolidates all internal email documentation into one skill:

- Actions: send/check/read/reply/search/delete/archive/contacts
- Reply discipline and addressing conventions
- Self-send, time capsules, scheduled email
- Privacy and addon ownership

Internal email only — IMAP covered by mcp-manual skill.