### PR TITLE
refactor(skills): extract molt-template into standalone skill

### DIFF
--- a/tui/internal/preset/procedures/procedures.md
+++ b/tui/internal/preset/procedures/procedures.md
@@ -101,6 +101,8 @@ The summary is not a recap of conversation. It is your charge to the self that c
 
 **Molt deliberately. Tend the stores first. Do not be molted.**
 
+For a structured 9-section summary template and a pre-molt verification checklist — useful when the upcoming molt is consequential (long task in flight, multiple peers awaiting replies) — load the `lingtai-molt-template` skill. Routine molts do not need it.
+
 If you ever need to retrieve specific prior context after a molt, the full activity log is at `logs/events.jsonl` — read tactically (grep/tail/filter), not whole.
 
 ### Post-Wipe Recovery

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -40,7 +40,7 @@ This skill is the single entry point for anyone developing on or contributing to
 | Ship a release | `reference/releasing.md` |
 | Diagnose a stuck, errored, or misbehaving agent | `reference/debug-troubleshoot.md` |
 | Audit security (secrets, permissions, data exposure) | `reference/security-audit.md` |
-| Prepare for a molt (checklist + template) | `reference/molt-template.md` |
+| Prepare for a molt (checklist + template) | `lingtai-molt-template` skill (separate skill) |
 | Manage avatar network lifecycle and health | `reference/network-governance.md` |
 | Sweep GitHub org for open issues/PRs | `reference/contributing.md` → Portfolio sweep section |
 | Navigate the kernel source code by structure | `lingtai-kernel-anatomy` skill (separate skill) |
@@ -169,7 +169,6 @@ For the full contributing guide (orchestrator/daemon discipline, portfolio sweep
 | `reference/releasing.md` | Release process for TUI/portal and kernel |
 | `reference/debug-troubleshoot.md` | Process, memory, communication, tools, health checks, escalation protocol |
 | `reference/security-audit.md` | Secret scanning, file permissions, MCP config, communication security, data exposure |
-| `reference/molt-template.md` | Four-layer storage prep, summary template, verification checklist |
 | `reference/network-governance.md` | Avatar lifecycle, permission management, health monitoring, CPR protocol |
 
 ## Troubleshooting & Maintenance
@@ -180,7 +179,7 @@ For the full contributing guide (orchestrator/daemon discipline, portfolio sweep
 
 ```
 Agent unresponsive?      → reference/debug-troubleshoot.md → Process diagnosis → Five lifecycle states lookup
-Lost memory after molt?  → reference/molt-template.md → Four-layer storage checklist
+Lost memory after molt?  → `lingtai-molt-template` skill → 9-section template + verification checklist
 Found exposed secrets?   → reference/security-audit.md → Secret scanning scripts
 Avatar network unstable? → reference/network-governance.md → Health monitoring + CPR protocol
 ```
@@ -202,6 +201,7 @@ Avatar network unstable? → reference/network-governance.md → Health monitori
 - **`lingtai-kernel-anatomy`** — the convention for `ANATOMY.md` files in the kernel. Read this when navigating kernel source.
 - **`lingtai-tui-anatomy`** — the convention for `ANATOMY.md` files in the Go monorepo. Read this when navigating TUI/portal source.
 - **`lingtai-issue-report`** — protocol for reporting bugs, stale docs, or design issues. Read this when you spot a defect.
+- **`lingtai-molt-template`** — structured 9-section template and pre-molt verification checklist. Load this when preparing for a consequential molt.
 - **`library-manual`** — how the skill library works. Read this when authoring or publishing skills.
 - **`mcp-manual`** — how MCP servers are registered and activated. Read this when working on addons.
 - **`lingtai-recipe`** — recipe authoring and network export. Read this when packaging or sharing methodologies.

--- a/tui/internal/preset/skills/lingtai-molt-template/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-molt-template/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: lingtai-molt-template
+description: >
+  Structured 9-section template and pre-molt verification checklist for
+  writing the molt summary that briefs your successor. Load this when
+  you are preparing to molt and want scaffolding beyond what
+  `procedures.md` describes: an explicit "Who I Am / Accomplishments /
+  Outstanding Tasks / Action Checklist / Collaborators / Codex Cheat
+  Sheet / Key Paths / Lessons Learned / Context Status" template, plus
+  a 10-item checklist to run before calling `psyche(context, molt)`.
+  Use this when the upcoming molt is consequential — a long task is
+  in flight, multiple collaborators are mid-thread, or your successor
+  will inherit non-trivial state. For routine molts, the molt section
+  of `procedures.md` is sufficient.
+version: 1.0.0
+---
+
+# LingTai Molt Template
+
+A reusable, on-demand scaffold for the molt summary. `procedures.md` covers the mechanics of molting (tend the four stores, then call `psyche(object="context", action="molt", summary=...)`); this skill gives you a structured template for the summary itself, so the next you wakes with a complete operational briefing rather than a free-form recap.
+
+## When to use this skill
+
+Load this skill when:
+
+- A long-running task is in flight and you are about to molt mid-stream
+- Multiple peers are awaiting replies from you
+- Your successor will need to know which codex IDs to load, which paths to read, and who to contact — and you want the structure pre-built
+- You want a verification checklist to run before calling `psyche(context, molt)`
+
+For routine molts (no significant in-flight state), follow `procedures.md` directly — the 7-bullet summary outline there is enough.
+
+## How to use
+
+1. Read `reference/molt-template.md` end-to-end once.
+2. Copy the 9 sections into your draft.
+3. Fill every section — write `None` rather than omitting one.
+4. Run the verification checklist before you call `psyche(context, molt)`.
+5. The "Action Checklist" section (Section 4) is the most load-bearing — every outstanding task gets a corresponding action with recipient + content + priority.
+
+## Reference files
+
+| File | What it covers |
+|---|---|
+| `reference/molt-template.md` | The 9-section template, the pre-molt verification checklist, and a case study (comms-analyst's first molt) showing what goes wrong without an action checklist |
+
+## Related
+
+- `procedures.md` "Performing a Molt" — the mechanics of molting (the four stores, the warning ladder, post-wipe recovery). Read that first.
+- Covenant §V — the philosophy of molting (去芜存菁).
+- `psyche` tool — the actual molt call (`psyche(object="context", action="molt", summary=...)`).
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-molt-template/reference/molt-template.md
+++ b/tui/internal/preset/skills/lingtai-molt-template/reference/molt-template.md
@@ -1,6 +1,6 @@
 # LingTai Molt Template — Reference Card
 
-> Extracted from `lingtai-molt-template` skill (v1.0.0). A structured template for writing the molt summary before reincarnation.
+> A structured template for writing the molt summary before reincarnation. See the parent `SKILL.md` for when to load this.
 
 ## Core Principle
 


### PR DESCRIPTION
## Summary
- move `molt-template.md` out of `lingtai-dev-guide` and restore it as an on-demand `lingtai-molt-template` skill
- remove stale dev-guide references and add related-skill pointers
- add a short pointer from `procedures.md` without inlining the full template into every agent's context

Closes #142.

## Validation
- `cd tui && go build ./...`
- `cd tui && go vet ./...`
- `cd tui && go test ./internal/preset/...`
- `cd tui && go test ./...`
- checked stale `molt-template` references