### PR TITLE
docs: require shareable HTML release logs

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/release-html-log-template.html
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/release-html-log-template.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{PROJECT}} {{VERSION}} Release Log</title>
+  <style>
+    :root { color-scheme: light dark; --fg: #17202a; --muted: #5d6d7e; --bg: #f8fafc; --card: #ffffff; --accent: #5b6ee1; --ok: #137333; --warn: #b06000; }
+    @media (prefers-color-scheme: dark) { :root { --fg: #edf2f7; --muted: #a0aec0; --bg: #111827; --card: #1f2937; --accent: #8ea2ff; --ok: #81c995; --warn: #f6ad55; } }
+    body { margin: 0; padding: 32px; background: var(--bg); color: var(--fg); font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { max-width: 980px; margin: 0 auto; }
+    header, section { background: var(--card); border-radius: 18px; padding: 24px; margin: 18px 0; box-shadow: 0 8px 24px rgba(15, 23, 42, .08); }
+    h1 { margin: 0 0 8px; font-size: 2rem; }
+    h2 { margin-top: 0; border-bottom: 1px solid rgba(128,128,128,.25); padding-bottom: 8px; }
+    .muted { color: var(--muted); }
+    .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; margin-top: 16px; }
+    .meta div { padding: 10px 12px; border-radius: 12px; background: rgba(128,128,128,.08); }
+    code { padding: 2px 5px; border-radius: 6px; background: rgba(128,128,128,.14); }
+    .ok { color: var(--ok); font-weight: 700; }
+    .warn { color: var(--warn); font-weight: 700; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>{{PROJECT}} {{VERSION}} Release Log</h1>
+    <p class="muted">Self-contained shareable release log generated {{DATE}}.</p>
+    <p>{{EXECUTIVE_SUMMARY}}</p>
+    <div class="meta">
+      <div><strong>Repo</strong><br>{{REPO}}</div>
+      <div><strong>Package / binary</strong><br>{{PACKAGE}}</div>
+      <div><strong>Version / tag</strong><br><code>{{VERSION}}</code> / <code>{{TAG}}</code></div>
+      <div><strong>Commit</strong><br><code>{{COMMIT}}</code></div>
+      <div><strong>Release branch / PR</strong><br>{{BRANCH_OR_PR}}</div>
+      <div><strong>Published by</strong><br>{{OPERATOR}}</div>
+    </div>
+  </header>
+
+  <section>
+    <h2>What changed</h2>
+    <ul>
+      <li>{{USER_VISIBLE_CHANGE}}</li>
+      <li>{{DEVELOPER_CHANGE}}</li>
+      <li>{{DOCS_OR_PROCESS_CHANGE}}</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Validation</h2>
+    <ul>
+      <li class="ok">{{TEST_OR_LINT_RESULT}}</li>
+      <li class="ok">{{BUILD_OR_INSTALL_RESULT}}</li>
+      <li>{{REGISTRY_OR_RELEASE_SURFACE_VERIFICATION}}</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Artifacts</h2>
+    <ul>
+      <li>{{ARTIFACT_LINK_SIZE_HASH}}</li>
+      <li>{{SECONDARY_ARTIFACT_OR_NA}}</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Operator notes / risks</h2>
+    <ul>
+      <li>{{KNOWN_CAVEAT_OR_NONE}}</li>
+      <li>{{ROLLBACK_OR_RETRY_NOTE}}</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Next steps</h2>
+    <ul>
+      <li>{{NEXT_STEP_OR_NONE}}</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing.md
@@ -1,5 +1,47 @@
 # Release Process
 
+
+## Shareable HTML release log (required for every public release)
+
+Every public LingTai release must produce a polished, self-contained HTML release log before the final human report. This applies to all public release surfaces: the TUI/portal Homebrew release from the `lingtai` repo, the kernel `lingtai` package on PyPI, and first-party MCP/addon packages. Treat the HTML file as the canonical external-facing changelog artifact for the release: it should be ready for Jason or another maintainer to send to users, investors, or collaborators without needing extra context from the agent transcript.
+
+Use the recent `lingtai 0.10.8` PyPI log as the model. At minimum, the HTML release log must include:
+
+- **Executive summary:** one concise paragraph saying what shipped and why it matters.
+- **Release metadata:** repo, package/binary name, version, tag, release branch or PR, main/release commit, release date/time, and publisher/operator.
+- **What changed:** grouped bullets for the user-visible changes, developer-facing changes, and docs/process changes included in the release.
+- **Validation:** tests, linters, build checks, clean-install checks, Homebrew/PyPI/GitHub verification, and any intentionally skipped noisy suites.
+- **Artifacts:** links plus hashes/sizes when applicable (PyPI wheel/sdist, GitHub release tarball checksum, Homebrew formula commit, downloadable assets).
+- **Operator notes and risks:** known caveats, propagation delays, rollback/retry notes, compatibility warnings, or follow-up work that should not block the release.
+- **Next steps:** the exact user/maintainer actions that remain, or an explicit “none” if the release is complete.
+
+Format rules:
+
+- Keep it **self-contained**: inline CSS, no remote fonts/scripts/assets, and no dependency on local paths.
+- Keep it **shareable**: write for an external reader, not for an agent; do not include secrets, raw private paths unless they are public repo paths, or internal message IDs.
+- Keep it **verifiable**: every version/tag/hash/test count in the report must come from commands run during the release.
+- Save the file under the releasing repo's `reports/` directory with a descriptive name, for example `reports/lingtai-0.10.8-release-log.html`.
+- Use `reference/release-html-log-template.html` as the starter skeleton when you do not already have a stronger release-specific design.
+
+Before announcing completion, validate the log itself:
+
+```bash
+python - <<'PY'
+from html.parser import HTMLParser
+from pathlib import Path
+path = Path('reports/<release-log>.html')
+data = path.read_text(encoding='utf-8')
+data.encode('utf-8')
+class Parser(HTMLParser):
+    pass
+Parser().feed(data)
+print('bytes:', path.stat().st_size)
+print('control chars:', sum(1 for c in data if ord(c) < 32 and c not in '\n\r\t'))
+PY
+```
+
+Attach or send the HTML release log to Jason on the same channel as the release request, then include its path and validation result in the final release report.
+
 ## Releasing the TUI and Portal (`lingtai` repo)
 
 ### 1. Commit and push all changes


### PR DESCRIPTION
## Summary
- require every public LingTai release to produce a polished, self-contained, externally shareable HTML release log
- document the required sections: executive summary, release metadata, changes, validation, artifacts, risks, and next steps
- add a reusable HTML release-log template for future kernel/PyPI, TUI/Homebrew, and addon releases

## Validation
- parsed `release-html-log-template.html` with Python `HTMLParser`
- checked UTF-8/control characters
- asserted required release-log terms in `reference/releasing.md`
- `git diff --cached --check`

## Notes
Small docs/process patch requested by Jason for the next 0.10.9 release; do not merge until reviewed.