### PR TITLE
fix: lock API key edits for existing presets

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -437,6 +437,7 @@
   "preset_editor.field_api_key": "API key",
   "preset_editor.api_key_unset": "(not set — paste here)",
   "preset_editor.api_key_codex_readonly": "OAuth credential \u2014 manage on the preset picker page.",
+  "preset_editor.api_key_locked": "API key is locked for existing presets. Create a new preset to use a different key.",
   "preset_editor.field_edit": "edit",
   "preset_editor.field_streaming": "streaming",
   "preset_editor.field_karma": "karma",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -432,6 +432,7 @@
   "preset_editor.field_api_key": "API 钥",
   "preset_editor.api_key_unset": "（未设——粘于此）",
   "preset_editor.api_key_codex_readonly": "OAuth 凭据——于择预页管之。",
+  "preset_editor.api_key_locked": "已立之预，钥不可更。欲换钥者，另立新预。",
   "preset_editor.field_edit": "编辑",
   "preset_editor.field_streaming": "流式输出",
   "preset_editor.field_karma": "因果",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -432,6 +432,7 @@
   "preset_editor.field_api_key": "API 密钥",
   "preset_editor.api_key_unset": "（未设置——在此粘贴）",
   "preset_editor.api_key_codex_readonly": "OAuth 凭据 — 于预设选择页管理。",
+  "preset_editor.api_key_locked": "已存在的预设不可改 API 密钥。如需更换，请新建一个预设。",
   "preset_editor.field_edit": "编辑",
   "preset_editor.field_streaming": "流式输出",
   "preset_editor.field_karma": "因果",

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -292,9 +292,19 @@ type PresetEditorModel struct {
 	// matching env var is already populated. apiKey is the live edit
 	// buffer; apiKeySet flips true when the user types into it (so we
 	// know to emit it on commit even if the new value is empty/cleared).
+	//
+	// apiKeyLocked is set at construction when the preset opens with a
+	// key already stored for its api_key_env slot. Editing an existing
+	// preset's saved key from inside this editor was confusing — users
+	// expected the row to show what was there, not silently overwrite
+	// it. When locked, the inline-edit entry on the api_key row is a
+	// no-op (the codex/OAuth branch already behaves this way for a
+	// different reason). Newly created presets with no stored key
+	// remain freely editable so initial setup still works.
 	existingKeys map[string]string
 	apiKey       string
 	apiKeySet    bool
+	apiKeyLocked bool
 
 	// Status
 	saveErr string
@@ -359,6 +369,7 @@ func NewPresetEditorModelWithBuiltinFlag(p preset.Preset, lang string, existingK
 		existingKeys:   existingKeys,
 		globalDir:      globalDir,
 		apiKey:         apiKey,
+		apiKeyLocked:   apiKey != "",
 	}
 }
 
@@ -577,6 +588,14 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 		// page. API key field is read-only; no-op here.
 		if asString(m.llmMap()["provider"]) == "codex" && m.globalDir != "" {
 			m.saveErr = i18n.T("preset_editor.api_key_codex_readonly")
+			return *m, nil
+		}
+		// Preset opened with a key already stored for its api_key_env.
+		// Editing here was confusing — the row shows a masked value but
+		// pressing Enter blanked the buffer and silently overwrote the
+		// stored key on commit. Lock the row instead.
+		if m.apiKeyLocked {
+			m.saveErr = i18n.T("preset_editor.api_key_locked")
 			return *m, nil
 		}
 		// Edit the live key buffer, not the env-var-name. We start

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/anthropics/lingtai-tui/i18n"
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
 
@@ -97,6 +98,67 @@ func TestPresetEditorShortTerminalDoesNotWrapRowsPastHeight(t *testing.T) {
 		if got := renderedLineCount(view); got > size.height {
 			t.Fatalf("%dx%d view must fit terminal height, got %d lines; view:\n%s", size.width, size.height, got, view)
 		}
+	}
+}
+
+// TestPresetEditorAPIKeyLockedWhenAlreadyStored verifies that opening the
+// editor on a preset whose api_key_env slot already holds a value blocks
+// inline edit of the api_key row. Users were confused when the masked row
+// silently overwrote the stored key on commit. New presets (empty
+// existingKeys) must still be editable — covered by the next test.
+func TestPresetEditorAPIKeyLockedWhenAlreadyStored(t *testing.T) {
+	keys := map[string]string{"MINIMAX_API_KEY": "sk-existing-value"}
+	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", keys, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	if !m.apiKeyLocked {
+		t.Fatalf("expected apiKeyLocked=true when preset opens with stored key")
+	}
+
+	// Walk cursor to feAPIKey (index 9 in editorFieldOrder).
+	for i := 0; i < 9; i++ {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	if editorFieldOrder[m.cursor] != feAPIKey {
+		t.Fatalf("expected cursor on feAPIKey, got %v", editorFieldOrder[m.cursor])
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if m.mode != emBrowse {
+		t.Fatalf("expected to stay in browse mode after Enter on locked api_key, got mode=%v", m.mode)
+	}
+	if m.saveErr == "" {
+		t.Fatalf("expected a saveErr message explaining the lock; got empty")
+	}
+	want := i18n.T("preset_editor.api_key_locked")
+	if m.saveErr != want {
+		t.Fatalf("expected lock message %q; got %q", want, m.saveErr)
+	}
+}
+
+// TestPresetEditorAPIKeyEditableWhenNoStoredKey is the inverse: a preset
+// with no stored key (typical for first-run flow on a fresh template)
+// must still allow inline edit so initial setup works.
+func TestPresetEditorAPIKeyEditableWhenNoStoredKey(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	if m.apiKeyLocked {
+		t.Fatalf("expected apiKeyLocked=false when no stored key")
+	}
+
+	for i := 0; i < 9; i++ {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	if editorFieldOrder[m.cursor] != feAPIKey {
+		t.Fatalf("expected cursor on feAPIKey, got %v", editorFieldOrder[m.cursor])
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if m.mode != emInline {
+		t.Fatalf("expected emInline after Enter on editable api_key, got mode=%v", m.mode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- lock the API key row when a preset opens with an already-stored key
- keep API key entry editable for fresh presets without a stored key
- add localized lock message plus focused preset editor regressions

## Tests
- cd tui && go test ./internal/tui/ -run 'PresetEditor' -v
- cd tui && go test ./internal/tui/ ./internal/preset/
- git diff origin/main...HEAD --check

Reported by Jason: users should not be allowed to change API keys for already-created presets because it is confusing.