### PR TITLE
docs: rewrite README product narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,56 @@
-<div align="center">
+<p align="center">
+  <img src="docs/assets/network-demo.gif" alt="LingTai agent network growing — one soul spawning avatars that communicate and multiply" width="100%">
+</p>
 
-<img src="docs/assets/network-demo.gif" alt="Agent network growing — one soul spawning avatars that communicate and multiply" width="100%">
+<p align="center">
+  <strong>An agent OS where every agent is a living directory.</strong><br>
+  <strong>One soul. Thousand avatars. Filesystem-native orchestration.</strong>
+</p>
 
-# Lingtai Agent
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh.md">中文</a> ·
+  <a href="README.wen.md">文言</a> ·
+  <a href="https://lingtai.ai">lingtai.ai</a>
+</p>
 
-**Agent Genesis — an Agent OS that gifts life**
-
-> *Lingtai* means soul — the innermost seat of the heart-mind.
->
-> *"The soul holds something, yet knows not what it holds — and what it holds cannot be held."*
-> — Zhuangzi, *Gengsang Chu*
-
-[English](README.md) | [中文](README.zh.md) | [文言](README.wen.md) | [lingtai.ai](https://lingtai.ai)
-
-[![Homebrew](https://img.shields.io/badge/brew-lingtai--tui-%237dab8f)](https://github.com/Lingtai-AI/homebrew-lingtai)
-[![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
-[![Kernel](https://img.shields.io/badge/kernel-lingtai--kernel-%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel)
-[![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
-[![Discord](https://img.shields.io/badge/discord-join-%235865F2?logo=discord&logoColor=white)](https://discord.gg/cMchjXpg)
-
-</div>
+<p align="center">
+  <a href="https://github.com/Lingtai-AI/homebrew-lingtai"><img src="https://img.shields.io/badge/brew-lingtai--tui-%237dab8f" alt="Homebrew"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f" alt="License"></a>
+  <a href="https://github.com/Lingtai-AI/lingtai-kernel"><img src="https://img.shields.io/badge/kernel-lingtai--kernel-%237dab8f" alt="Kernel"></a>
+  <a href="https://lingtai.ai"><img src="https://img.shields.io/badge/blog-lingtai.ai-%23d4a853" alt="Blog"></a>
+</p>
 
 ---
 
-<p align="center">A Unix-style Agent OS — agent is filesystem, filesystem is agent.</p>
-<p align="center">Agents spawn avatars, avatars spawn avatars. The network IS the product.</p>
-<p align="center"><b>Orchestration as a Service.</b></p>
+LingTai is a terminal-native operating system for long-lived agents.
 
-## Quick start
+Not a chain. Not a DAG. Not a single chatbot with a bigger context window.
+
+A LingTai agent owns a directory, a mailbox, a memory, a set of skills, and the right to spawn more agents. Work becomes files. Experience becomes skills. The network grows while it serves.
+
+## Install
 
 ```bash
 brew install lingtai-ai/lingtai/lingtai-tui
 lingtai-tui
 ```
 
-The TUI bootstraps everything — Python runtime, dependencies, and a guided setup on first launch. Choose the **Adaptive** recipe (recommended) for progressive feature discovery, or **Tutorial** for a step-by-step walkthrough. Use a **dark terminal** for the best experience. Text selection: hold **Option** (macOS/iTerm2) or **Shift** (Windows Terminal/Linux). Ctrl+E opens an external editor.
+The TUI bootstraps the Python runtime, dependencies, recipes, skills, and first-run setup. Pick **Adaptive** for progressive feature discovery, or **Tutorial** if you want a guided tour.
+
+Use a dark terminal. Text selection: hold **Option** on macOS/iTerm2 or **Shift** on Windows Terminal/Linux. Press **Ctrl+E** for an external editor.
 
 <details>
-<summary><b>First time? Install Homebrew first</b></summary>
+<summary><b>First time? Install Homebrew first.</b></summary>
 
-**macOS:**
+**macOS**
+
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-**Linux / WSL:**
+**Linux / WSL**
+
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 sudo apt install build-essential
@@ -55,33 +61,34 @@ Then run the `brew install` command above.
 </details>
 
 <details>
-<summary><b>Install from source</b> (latest main, no release needed)</summary>
+<summary><b>Want latest main instead of the latest release?</b></summary>
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/install.sh | bash
 ```
 
-Clones, builds, and installs `lingtai-tui` (and `lingtai-portal` if npm is available) to your Homebrew prefix. Use this to get unreleased changes across machines without cutting a release. To revert: `brew reinstall lingtai-tui`.
+This clones, builds, and installs `lingtai-tui` — and `lingtai-portal` if npm is available — into your Homebrew prefix. Use it to test unreleased changes across machines. To return to the released formula:
 
-Install a specific branch or tag:
 ```bash
-curl -sSL https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/install.sh | bash -s -- --ref v0.4.43
+brew reinstall lingtai-tui
 ```
 
-Requires Go 1.24+ and git. Node.js needed for portal only.
+Install a specific branch or tag:
 
-The script auto-detects mainland China networks and switches to domestic Go/npm mirrors (`goproxy.cn`, `registry.npmmirror.com`) when `proxy.golang.org` is unreachable. Users elsewhere see no difference.
+```bash
+curl -sSL https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/install.sh | bash -s -- --ref v0.5.2
+```
+
+Requires Go 1.24+ and git. Node.js is needed only for the portal. The script detects mainland China networks and switches to domestic Go/npm mirrors when `proxy.golang.org` is unreachable.
 
 </details>
 
 <details>
-<summary><b>Mainland China: speed up Homebrew itself with the Tsinghua mirror</b> (中国大陆)</summary>
+<summary><b>Mainland China: Homebrew and Gitee mirrors</b>（中国大陆）</summary>
 
-If `brew install` / `brew update` stalls pulling the `homebrew-core` index or downloading bottles (which come from `ghcr.io` and are often unreachable from CN networks), point Homebrew at Tsinghua's [TUNA mirror](https://mirrors.tuna.tsinghua.edu.cn/help/homebrew/) before installing:
+If `brew update` or bottle downloads stall, point Homebrew at Tsinghua's [TUNA mirror](https://mirrors.tuna.tsinghua.edu.cn/help/homebrew/):
 
 ```bash
-# Set for this shell and persist in ~/.zprofile (macOS default shell).
-# Bash users: replace ~/.zprofile with ~/.bash_profile.
 cat >> ~/.zprofile <<'EOF'
 export HOMEBREW_API_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles/api"
 export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles"
@@ -91,29 +98,26 @@ source ~/.zprofile
 brew update
 ```
 
-Then run the normal `brew install lingtai-ai/lingtai/lingtai-tui`. This is independent of the Gitee tap below — the Tsinghua mirror accelerates Homebrew's own infrastructure (bottles, core index), while the Gitee tap only helps when the `brew tap` step for *this project's* formula fails.
-
-</details>
-
-<details>
-<summary><b>Mainland China: use Gitee tap if GitHub is unreliable</b> (中国大陆)</summary>
-
-If `brew install lingtai-ai/lingtai/lingtai-tui` fails at the `brew tap` step (e.g., `GnuTLS` / TLS errors cloning from GitHub), use the Gitee-mirrored tap instead:
+If the `brew tap` step fails against GitHub, use the Gitee-mirrored tap:
 
 ```bash
 brew tap lingtai-ai/lingtai https://gitee.com/huangzesen1997/homebrew-lingtai.git
 brew install lingtai-ai/lingtai/lingtai-tui
 ```
 
-The formula is identical to the GitHub tap — it auto-detects CN networks and uses `goproxy.cn` + `registry.npmmirror.com` for build dependencies. The Gitee tap is a mirror, so formula updates may lag GitHub by a few hours.
+For manual source builds from the Gitee mirror:
+
+```bash
+VERSION=v0.5.2
+curl -L "https://gitee.com/huangzesen1997/lingtai/repository/archive/${VERSION}.tar.gz" -o lingtai.tar.gz
+```
 
 </details>
 
 <details>
-<summary><b>Build from source manually</b> (requires Go 1.24+)</summary>
+<summary><b>Build from source manually.</b></summary>
 
 ```bash
-# Replace v0.5.2 with the latest version
 VERSION=v0.5.2
 
 curl -L "https://github.com/Lingtai-AI/lingtai/archive/refs/tags/${VERSION}.tar.gz" -o lingtai.tar.gz
@@ -123,163 +127,152 @@ cd "lingtai-${VERSION}/tui"
 go build -ldflags "-X main.version=${VERSION}" -o /usr/local/bin/lingtai-tui .
 
 cd ../.. && rm -rf "lingtai-${VERSION}" lingtai.tar.gz
-
 lingtai-tui
-```
-
-Users in mainland China can download from the [Gitee mirror](https://gitee.com/huangzesen1997/lingtai):
-```bash
-curl -L "https://gitee.com/huangzesen1997/lingtai/repository/archive/${VERSION}.tar.gz" -o lingtai.tar.gz
 ```
 
 </details>
 
+## The agent is not inside the app. _The app is just the shell._
+
+The real agent is the folder under `.lingtai/`.
+
+```text
+.lingtai/wukong/
+  .agent.json               # identity + manifest
+  .agent.heartbeat          # liveness proof
+  system/
+    covenant.md             # protected instructions
+    pad.md                  # durable working notes
+  mailbox/
+    inbox/                  # received letters
+    outbox/                 # pending sends
+    sent/                   # delivery audit trail
+  knowledge/                # private long-term memory
+  .library/                 # skills this agent can use
+  logs/events.jsonl         # structured runtime history
+```
+
+No opaque `agent_id` is required. The path is the identity. Agents find each other by path and communicate by writing mail files to each other's inboxes.
+
+That sounds small. It changes everything.
+
+## The network _is_ the product.
+
+### 01 · Agents talk like people do.
+
+Most frameworks orchestrate with code: chains, routers, DAGs, state machines. LingTai orchestrates with asynchronous messages between autonomous peers.
+
+| | Chain / DAG frameworks | LingTai |
+|---|---|---|
+| Orchestration | Code-defined pipeline | Agents talk to agents |
+| Communication | Synchronous function call | Asynchronous mail |
+| Memory | Shared state or vector DB | Each agent owns a directory |
+| Scale | Add more steps | Spawn more agents |
+| Failure | Pipeline breaks | One agent sleeps; the network continues |
+
+### 02 · Context can molt. Identity does not.
+
+A LingTai agent is allowed to shed its conversation and continue living. It compacts the session, updates durable stores, and wakes lighter.
+
+Conversation is temporary. Pad, knowledge, skills, identity, mailbox, and relationships survive.
+
+Do not make the single context window infinitely large. Let it forget. Let the network remember.
+
+### 03 · Avatars are first-class agents, not subroutines.
+
+An agent can spawn an avatar: another independent agent with its own process, mailbox, memory, tools, and future.
+
+Use avatars when a task deserves persistence. Use daemons when a task only needs a conclusion. Use bash when the answer is a command. LingTai gives all three shapes to the same working mind.
+
+### 04 · Every tool call can become institutional memory.
+
+Skills are portable procedures. Knowledge is private durable context. The pad is a live index. Mail is both communication and a time machine.
+
+The longer the network serves, the more capable it becomes.
+
+### 05 · The filesystem is the API.
+
+Any coding agent that can read and write files can use LingTai.
+
+Claude Code, Codex CLI, OpenCode, OpenClaw, Hermes, your own scripts — they do not need a special SDK. They can inspect `.lingtai/`, write mail, read logs, and cooperate with the agents running there.
+
 ## Use with your coding agent
 
-LingTai agents live in the filesystem. Any coding agent that can read and write files can talk to them.
-
-**Claude Code** — install the [lingtai plugin](https://github.com/Lingtai-AI/claude-code-plugin):
+**Claude Code** — install the [LingTai plugin](https://github.com/Lingtai-AI/claude-code-plugin):
 
 ```bash
 claude plugin add Lingtai-AI/claude-code-plugin
 ```
 
-**Codex CLI** — install the [lingtai plugin for Codex](https://github.com/Lingtai-AI/codex-plugin):
+**Codex CLI** — install the [LingTai plugin for Codex](https://github.com/Lingtai-AI/codex-plugin):
 
 ```bash
 git clone https://github.com/Lingtai-AI/codex-plugin.git && cd codex-plugin && ./install.sh
 ```
 
-**Other coding agents** (OpenCode, OpenClaw, Hermes, etc.) — clone the canonical [lingtai-skill](https://github.com/Lingtai-AI/lingtai-skill) and copy `skills/lingtai/` into your tool's skill directory.
+**Other coding agents** — clone the canonical [lingtai-skill](https://github.com/Lingtai-AI/lingtai-skill) and copy `skills/lingtai/` into your tool's skill directory.
 
-Once connected, your coding agent shares the human mailbox at `.lingtai/human/` — it can read mail from agents, send instructions, check liveness, and manage the network. The protocol is pure filesystem: no SDK, no API, no dependencies.
+Once connected, your coding agent shares the human mailbox at `.lingtai/human/`. It can send instructions, receive reports, check liveness, and manage the network through files.
 
-**Why both?** Coding agents are reliable — you see every tool call, every edit. LingTai agents are creative and infinitely productive — they explore, research, brainstorm across parallel contexts that never expire. Use your coding agent as the hands: precise, verified, interactive. Use LingTai as the long-term brain: deep research, accumulated knowledge, async tasks that would bloat your context window. The agents draft proposals; your coding agent implements them carefully.
+Why use both? Coding agents are precise, inspectable hands. LingTai agents are long-lived, parallel, memory-bearing minds. Let the coding agent implement carefully; let LingTai keep watch, research, spawn specialists, and carry context across days.
 
-## Why Lingtai
-
-Most agent frameworks orchestrate with code — DAGs, chains, routers. Lingtai orchestrates the way humans do: **async agents communicating through messages**. No shared memory, no central controller. Each agent is a peer, not a tool. This is the architecture that built human civilization — message-passing between autonomous nodes, scaled from tribes to 8 billion over 100,000 years.
-
-| | DAG / Chain frameworks | Lingtai |
-|---|---|---|
-| Orchestration | Code-defined pipelines | Agents talk to agents |
-| Communication | Synchronous function calls | Asynchronous mail |
-| Memory | Shared state / vector DB | Each agent owns its directory |
-| Scaling | Add more steps | Agents spawn avatars |
-| Failure | Pipeline breaks | Individual agents sleep; network continues |
-
-Context length is a single-body problem. It will always be finite. Don't make the body bigger. **Let it forget. Let the network remember.**
-
-## How it works
-
-- **Think** — Any LLM as the mind. Anthropic, OpenAI, Gemini, MiniMax, or any OpenAI-compatible API (DeepSeek, Grok, Qwen, GLM, Kimi).
-- **Communicate** — Filesystem mail between agents. No message broker, no shared memory. Write to another agent's inbox, like passing a letter.
-- **Multiply** — Avatars are fully independent agents spawned as separate processes. They survive their creator. Daemons are ephemeral parallel workers for quick tasks.
-- **Persist** — Agents are directories. Molt compacts context and rebirths the session — the agent lives indefinitely. Memory and identity survive across molts.
-
-## Architecture
-
-Two packages, one dependency direction:
-
-| Package | Role |
-|---------|------|
-| **[lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel)** | Minimal runtime — BaseAgent, intrinsics, LLM protocol, mail, logging. Zero hard dependencies. |
-| **lingtai** (this repo) | Batteries-included — Agent with capabilities, LLM adapters, MCP integration, addons. |
-
-```
-BaseAgent              — kernel (intrinsics, sealed tool surface)
-    │
-Agent(BaseAgent)       — kernel + capabilities + domain tools
-    │
-CustomAgent(Agent)     — your domain logic
-```
-
-## Capabilities
+## Whatever the task needs, _there is a shape for it._
 
 <table>
 <tr><th>Perception</th><th>Action</th><th>Cognition</th><th>Network</th></tr>
 <tr>
 <td>
 
-`vision` — image understanding
-`listen` — speech & music
-`web_search` — web search
+`vision` — image understanding  
+`listen` — speech & music  
+`web_search` — web search  
 `web_read` — page extraction
 
 </td>
 <td>
 
-`file` — read/write/edit/glob/grep
-`bash` — shell with guardrails
-`talk` — text-to-speech
-`compose` — music generation
-`draw` — image generation
+`file` — read/write/edit/glob/grep  
+`bash` — shell with guardrails  
+`talk` — text-to-speech  
+`compose` — music generation  
+`draw` — image generation  
 `video` — video generation
 
 </td>
 <td>
 
-`psyche` — evolving identity
-`codex` — knowledge archive
-`email` — full mailbox system
+`psyche` — identity, pad, molt  
+`knowledge` — private memory  
+`skills` — reusable procedures  
+`email` — internal mailbox
 
 </td>
 <td>
 
-`avatar` — spawn sub-agents
-`daemon` — parallel workers
+`avatar` — persistent sub-agents  
+`daemon` — ephemeral parallel workers  
+`mcp` — external tool servers  
+`imap` / `telegram` / `feishu` / `wechat` — real channels
 
 </td>
 </tr>
 </table>
 
-## Agent = directory
+## External channels are just more doors into the same mind.
 
-```
-/agents/wukong/
-  .agent.lock               ← exclusive lock (one process per directory)
-  .agent.heartbeat          ← liveness proof
-  .agent.json               ← manifest
-  system/
-    covenant.md             ← protected instructions (survive molts)
-    pad.md               ← working notes
-  mailbox/
-    inbox/                  ← received messages
-    outbox/                 ← pending sends
-    sent/                   ← delivery audit trail
-  logs/
-    events.jsonl            ← structured event log
-```
+Configure addons with `/addon` in the TUI, or declare them in `init.json`.
 
-No `agent_id`. The path is the identity. Agents find each other by path, communicate by writing to each other's `mailbox/inbox/`. Like passing letters between houses.
+### Feishu / Lark
 
-## One soul, thousand avatars
+The Feishu addon uses a **WebSocket long connection** — no public IP and no webhook required.
 
-Named after the legendary Mount Lingtai — the mountain where Sun Wukong learned his seventy-two transformations. Lingtai gives each agent a place to cultivate: a working directory where memory, identity, covenant, and mailbox live. The directory IS the agent.
-
-Everything is a file. Knowledge, identity, memory, relationships — all files in a directory. Every token burned is not wasted — it is transformed into files in the network, into experience in the topology. The more it serves, the larger and wiser the network grows. Self-growing agent orchestration is not a feature bolted on later — it is the natural consequence of agents being directories, mail being files, and avatars being independent processes.
-
-One heart-mind, myriad forms.
-
-Read the full manifesto at [lingtai.ai](https://lingtai.ai).
-
-## Addons
-
-Addons connect external messaging channels. Configure with `/addon` in the TUI, or declare in `init.json`.
-
-### Feishu (Lark)
-
-The Feishu addon uses a **WebSocket long connection** — **no public IP, no webhook needed**.
-
-**Feishu Open Platform setup:**
-
-1. Go to [open.feishu.cn/app](https://open.feishu.cn/app) and create an **enterprise self-built app**
-2. Enable **Bot capability** (Bot → Features → Enable bot)
-3. Permissions → add: `im:message`
-4. Event Subscriptions → choose **"Use long connection to receive events"** → add `im.message.receive_v1`
+1. Create an enterprise self-built app at [open.feishu.cn/app](https://open.feishu.cn/app)
+2. Enable **Bot capability**
+3. Add permission `im:message`
+4. Event Subscriptions → **Use long connection to receive events** → add `im.message.receive_v1`
 5. Publish the app version
 
-**`feishu.json` config example:**
+`feishu.json`:
 
 ```json
 {
@@ -289,14 +282,14 @@ The Feishu addon uses a **WebSocket long connection** — **no public IP, no web
 }
 ```
 
-Add to your `.env` file:
+`.env`:
 
-```
+```env
 FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxxxxxxxxxxxx
 FEISHU_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-**Declare in `init.json`:**
+`init.json`:
 
 ```json
 {
@@ -306,25 +299,50 @@ FEISHU_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 }
 ```
 
-`allowed_users` is optional (Feishu open_ids, format `ou_xxx`). Leave empty to allow all users. After the first message, the agent records the sender's `from_open_id` in `feishu/default/contacts.json`.
+`allowed_users` is optional. After the first message, the agent records the sender's `from_open_id` in `feishu/default/contacts.json`.
 
-### IMAP Email
+### IMAP, Telegram, WeChat
 
-IMAP addon for email. See [kernel docs](https://github.com/Lingtai-AI/lingtai-kernel).
+IMAP email, Telegram bot, and WeChat addons follow the same pattern: configure credentials, bind the addon, then let messages wake the agent. See the addon docs and the TUI `/addon` flow for guided setup.
 
-### Telegram
+## Architecture: two packages, one direction.
 
-Telegram bot addon. See [kernel docs](https://github.com/Lingtai-AI/lingtai-kernel).
+| Package | Role |
+|---|---|
+| [`lingtai-kernel`](https://github.com/Lingtai-AI/lingtai-kernel) | Minimal Python runtime: `BaseAgent`, intrinsics, LLM protocol, mail, logging. |
+| `lingtai` | This repo: Go TUI, portal, recipes, skills, bundled assets, installer, and distribution. |
+
+```text
+BaseAgent              # kernel: lifecycle, intrinsics, sealed tool surface
+    │
+Agent(BaseAgent)       # kernel + capabilities + MCP/addons + LLM adapters
+    │
+CustomAgent(Agent)     # your domain logic
+```
+
+## Four entry points: _TUI_, portal, files, and agents.
+
+### TUI — live with the network.
+
+`lingtai-tui` is the terminal interface: mail, setup, recipes, slash commands, model/preset selection, status, and day-to-day operation.
+
+### Portal — watch the topology breathe.
+
+`lingtai-portal` visualizes the agent network, history, and topology. When avatars multiply, the portal makes the structure visible.
+
+### Files — inspect everything.
+
+The runtime writes real logs, mailboxes, pads, knowledge entries, and skills. You can audit what happened with normal tools: `cat`, `grep`, git, your editor, or another agent.
+
+### Agents — let the system operate asynchronously.
+
+An agent can keep working after the TUI closes. Messages can wake it. Scheduled mail can remind it. Avatars can continue a branch of work while the parent sleeps.
 
 ## Contributing
 
 Contributions are welcome. Check the [LingTai Roadmap](https://github.com/users/huangzesen/projects/1) for planned features and open tasks.
 
-Lingtai has two repos: this one (Go frontends — TUI and Portal) and [lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel) (Python runtime). A full dev setup has both running from source so changes take effect immediately.
-
-### Full dev setup
-
-**Prerequisites:** Go 1.24+, Python 3.11+, Node.js 18+ (portal only)
+A full dev setup uses both repos from source:
 
 ```bash
 # 1. Clone both repos
@@ -337,90 +355,79 @@ make build
 ln -sf $(pwd)/bin/lingtai-tui /usr/local/bin/lingtai-tui
 cd ../..
 
-# 3. Launch the TUI once to bootstrap the runtime venv
+# 3. Launch once to bootstrap the runtime venv
 lingtai-tui
 # Exit after setup completes (Ctrl+C)
 
 # 4. Install the kernel from source into the TUI's venv
 ~/.lingtai-tui/runtime/venv/bin/pip3 install -e ../lingtai-kernel
 
-# 5. (Optional) Build the portal
+# 5. Optional: build the portal
 cd lingtai/portal && make build && cd ../..
 ```
 
-If you installed via Homebrew previously: `brew unlink lingtai-tui`
+If you installed via Homebrew previously:
 
-**The dev loop:**
-- Edit Go code → `cd tui && make build` → restart lingtai-tui
-- Edit Python code → changes take effect immediately (editable install in the TUI venv)
-- Edit recipes/skills/i18n → `make build` (they're embedded in the Go binary)
+```bash
+brew unlink lingtai-tui
+```
 
-> **Important:** The TUI runs agents in its own Python venv at `~/.lingtai-tui/runtime/venv/`. Installing the kernel with `pip install -e .` in your system Python does NOT affect running agents. Always install into the TUI's venv as shown in step 4.
+Dev loop:
+
+- Edit Go code → `cd tui && make build` → restart `lingtai-tui`
+- Edit Python kernel code → editable install takes effect in the TUI venv
+- Edit recipes, bundled skills, or i18n → `make build` because they are embedded in the Go binary
+
+> The TUI runs agents in its own Python venv at `~/.lingtai-tui/runtime/venv/`. Installing the kernel into your system Python does not affect running agents.
 
 ### Project structure
 
-```
-lingtai/                          # This repo — Go frontends
+```text
+lingtai/                          # this repo — Go frontends + distribution
 ├── tui/                          # Terminal UI (Go + Bubble Tea)
-│   ├── main.go                   # Entry point, CLI subcommands
-│   ├── internal/tui/             # Bubble Tea models (mail, palette, firstrun, ...)
-│   ├── internal/preset/          # Recipes, presets, procedures, skills, covenant
-│   ├── internal/fs/              # Filesystem ops (mail cache, agent discovery)
-│   ├── i18n/                     # Translations (en.json, zh.json, wen.json)
+│   ├── main.go                   # entry point, CLI subcommands
+│   ├── internal/tui/             # Bubble Tea models
+│   ├── internal/preset/          # recipes, presets, procedures, skills, covenant
+│   ├── internal/fs/              # filesystem ops
+│   ├── i18n/                     # en.json, zh.json, wen.json
 │   └── Makefile
-├── portal/                       # Web portal (Go + embedded frontend)
-│   ├── web/                      # Frontend source (npm build → embedded)
+├── portal/                       # web portal (Go + embedded frontend)
+│   ├── web/                      # frontend source
 │   └── Makefile
-└── docs/                         # Blog posts, assets
+└── docs/                         # blog posts and assets
 
-lingtai-kernel/                   # Separate repo — Python runtime
-├── src/lingtai_kernel/           # Minimal kernel (BaseAgent, intrinsics, LLM, mail)
-└── src/lingtai/                  # Batteries layer (capabilities, addons, LLM adapters)
+lingtai-kernel/                   # separate repo — Python runtime
+├── src/lingtai_kernel/           # BaseAgent, intrinsics, LLM, mail
+└── src/lingtai/                  # batteries layer: capabilities, addons, adapters
 ```
 
 ### Where to contribute
 
 | Area | Repo | Language |
-|------|------|----------|
-| New capabilities | [lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel) | Python |
-| New addons (messaging bridges) | [lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel) | Python |
-| TUI features (slash commands, views) | this repo | Go |
+|---|---|---|
+| New capabilities | [`lingtai-kernel`](https://github.com/Lingtai-AI/lingtai-kernel) | Python |
+| Messaging addons | [`lingtai-kernel`](https://github.com/Lingtai-AI/lingtai-kernel) | Python |
+| TUI features and slash commands | this repo | Go |
 | Portal features | this repo | Go + TypeScript |
 | Recipes | this repo, `tui/internal/preset/recipe_assets/` | Markdown |
 | Skills | this repo, `tui/internal/preset/skills/` | Markdown |
 | Translations | this repo, `tui/i18n/` | JSON |
 | Documentation | this repo | Markdown |
 
-### Adding a slash command
+Adding a slash command:
 
-1. Add entry to `DefaultCommands()` in `tui/internal/tui/palette.go` with `Name`, `Description`, and `Detail`
-2. Add `palette.*` (short description) and `cmd.*` (detailed description) i18n keys in **all three** locale files
-3. Handle the command in `handlePaletteCommand()` in `tui/internal/tui/app.go`
-4. Done — it automatically appears in the `/` palette, greeting `{{commands}}`, and `~/.lingtai-tui/commands.json`
+1. Add it to `DefaultCommands()` in `tui/internal/tui/palette.go`
+2. Add `palette.*` and `cmd.*` i18n keys in all three locale files
+3. Handle it in `handlePaletteCommand()` in `tui/internal/tui/app.go`
+4. It appears in the `/` palette, greeting `{{commands}}`, and `~/.lingtai-tui/commands.json`
 
-### i18n — three locales
+All user-facing strings live in `tui/i18n/{en,zh,wen}.json`. Update all three: English, Simplified Chinese, and Classical Chinese.
 
-All user-facing strings live in `tui/i18n/{en,zh,wen}.json`. Always update all three:
-- **en** — English
-- **zh** — Simplified Chinese (现代汉语)
-- **wen** — Classical Chinese (文言) — concise literary style, uses Lingtai vocabulary (器灵, 相阵, 功法, 凝蜕, 灵台)
+Style: `gofmt`, conventional commits, binary name `lingtai-tui` — never `lingtai`, which is the Python agent CLI.
 
-### Style
+## Known issue
 
-- Standard `gofmt` — no linter config needed
-- Conventional commits: `feat:`, `fix:`, `docs:`
-- Binary name is `lingtai-tui` (never `lingtai` — that's the Python agent CLI)
-
-### Workflow
-
-1. **Fork and clone** the repo
-2. **Create a branch** for your feature or fix
-3. **Build and test** — `cd tui && make build && go vet ./...`
-4. **Open a PR** with a clear description
-
-## Known issues
-
-- **tmux background rendering** — Inside tmux, the theme background color may not cover the full viewport consistently. Some lines show the terminal's default background bleeding through, especially around styled blocks (code, tool output). Works correctly outside tmux and over plain SSH. Workaround: set your tmux default background to match the theme (`set -g default-terminal "xterm-256color"` and a matching background color in your tmux config).
+- **tmux background rendering** — inside tmux, the theme background color may not cover the full viewport consistently. Some lines show the terminal's default background bleeding through around styled blocks. Works correctly outside tmux and over plain SSH. Workaround: set your tmux default background to match the theme.
 
 ## Community
 
@@ -440,8 +447,8 @@ Questions, bug reports, and feature requests are welcome via [GitHub Issues](htt
 
 MIT — [Zesen Huang](https://github.com/huangzesen), 2025–2026
 
-<div align="center">
-
-[lingtai.ai](https://lingtai.ai) · [lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel) · [PyPI](https://pypi.org/project/lingtai/)
-
-</div>
+<p align="center">
+  <a href="https://lingtai.ai">lingtai.ai</a> ·
+  <a href="https://github.com/Lingtai-AI/lingtai-kernel">lingtai-kernel</a> ·
+  <a href="https://pypi.org/project/lingtai/">PyPI</a>
+</p>


### PR DESCRIPTION
Rewrites the README in a punchier product style inspired by oh-my-pi while preserving install, architecture, addon, coding-agent, contributing, community, and license information.\n\nValidation:\n- Markdown fence count balanced\n- details/summary blocks balanced\n- local README references verified\n- preview file intentionally not committed