### PR TITLE
feat: surface Rust sidecar diagnostics

### DIFF
--- a/tui/ANATOMY.md
+++ b/tui/ANATOMY.md
@@ -6,11 +6,12 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 
 ## Components
 
-- **`main.go:28-975`** — single-file `package main`. The version stamp (`main.go:29`, set via `-ldflags`), welcome/help text, and interactive entry (`main.go:31-360`). After parsing subcommands, it runs global migrations, checks invariants (init.json all-or-nothing, exactly-one-orchestrator), handles upgrade prompts and first-run wizard routing, then launches Bubble Tea.
-- **`main.go:31-91`** — subcommand dispatch. Each subcommand returns early; the fallthrough path starts the interactive TUI.
+- **`main.go:33-1087`** — single-file `package main`. The version stamp (`main.go:31`, set via `-ldflags`), welcome/help text, Rust toolchain startup guidance (`main.go:670-734`), and interactive entry (`main.go:33-93`). After parsing subcommands, it runs global migrations, checks invariants (init.json all-or-nothing, exactly-one-orchestrator), handles upgrade prompts and first-run wizard routing, then launches Bubble Tea.
+- **`main.go:35-93`** — subcommand dispatch. Each subcommand returns early; the fallthrough path starts the interactive TUI.
 - **`upgrade.go`** — startup TUI binary upgrade flow: detects newer Homebrew releases, asks about other running TUI windows, puts affected agents to sleep, stops old TUI processes, runs `brew upgrade`, and asks the user to relaunch.
-- **`main.go:763-837`** — `cleanMain`: suspend agents in `.lingtai/` (10s timeout), then `os.RemoveAll`.
-- **`main.go:839-887`** — `postmanMain`: parse `--port`, collect watch directories, call `postman.Run`.
+- **`main.go:670-734`** — `maybePromptRustToolchain` / `markRustPromptSeen`: one-time optional Rust/Cargo startup prompt. Only prompts on an interactive TTY when the managed runtime is on the Python file-search fallback and no `cargo` is on PATH. Writes the `~/.lingtai-tui/runtime/rust-toolchain-prompted` marker on decline/install/skip — including when the probe errors or reports an unsupported runtime — so the Python probe never re-spawns on every launch.
+- **`main.go:826-900`** — `cleanMain`: suspend agents in `.lingtai/` (10s timeout), then `os.RemoveAll`.
+- **`main.go:902-950`** — `postmanMain`: parse `--port`, collect watch directories, call `postman.Run`.
 - **`purge_unix.go:17-122`** — `purgeMain` (unix): `ps aux | grep "lingtai run"`, SIGTERM → SIGKILL survivors. Build tag `!windows`.
 - **`purge_windows.go`** — `purgeMain` (windows): equivalent via Windows process enumeration.
 - **`list_unix.go:15-161`** — `listMain` (unix): enumerate running agents with uptime, phantom detection (`.lingtai/` deleted but process still running). Build tag `!windows`.
@@ -23,17 +24,17 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 - **`Makefile:1-23`** — build, dev (fast local), cross-compile (darwin/linux × arm64/amd64), clean. Version stamp via `-ldflags "-X main.version=$(VERSION)"` where `VERSION` is `git describe --tags --always`.
 - **`i18n/i18n.go:10`** — `//go:embed en.json zh.json wen.json`. The only embed target in the root `tui/` package; all other embeds are in `internal/preset/`.
 - **`tui/internal/`** — all substantive packages (tui screens, preset engine, migration system, filesystem readers, process launcher, headless JSON CLI surface, postman, timemachine, lock shims).
-- **`tui/internal/headless/`** — JSON-emitting non-interactive surface. `RunPresets` (lists templates/saved presets as JSON), `RunSpawn` (creates a project + launches an agent), and `ExitError` (structured error codes). Wired from `main.go` via `bootstrapMain` (`main.go:895`), `presetsMain` (`main.go:905`), and `spawnMain` (`main.go:929`). For agents and scripts that drive `lingtai-tui` without the Bubble Tea UI.
+- **`tui/internal/headless/`** — JSON-emitting non-interactive surface. `RunPresets` (lists templates/saved presets as JSON), `RunSpawn` (creates a project + launches an agent), and `ExitError` (structured error codes). Wired from `main.go` via `bootstrapMain` (`main.go:952`), `presetsMain` (`main.go:1017`), and `spawnMain` (`main.go:1041`). For agents and scripts that drive `lingtai-tui` without the Bubble Tea UI.
 
 ## Connections
 
 - **Called from:** the shell (`lingtai-tui`), Homebrew tap (`lingtai-ai/lingtai/lingtai-tui`), `install.sh`.
 - **Calls out:** `tui/internal/tui` (Bubble Tea app), `tui/internal/migrate` (per-project migrations), `tui/internal/globalmigrate` (per-machine migrations), `tui/internal/preset` (bootstrap + utility skill population), `tui/internal/process` (agent launch), `tui/internal/config` (global config, venv, upgrade checks), `tui/internal/postman` (mail relay daemon), `tui/internal/timemachine` (git history daemon).
-- **Bootstrap sequence** (`main.go:277-295`): on every launch, the TUI runs `config.MigrateLegacyLanguage` → `config.NeedsVenv` (for setup banner) → `config.EnsureRuntime` (create/repair venv if needed, then always run the non-blocking `CheckUpgrade`) → `config.EnsureAddons` → `preset.Bootstrap` → `tui.ExportCommandsJSON`. `CheckUpgrade` auto-upgrades the `lingtai` meta-package from PyPI, which bundles `lingtai-kernel` + all addon MCPs. See `tui/internal/config/ANATOMY.md`.
-- **`lingtai-tui doctor` subcommand** (`main.go:911-964`): runs `config.RunDoctorUpdate` with both `ForceTUI=true` and `ForcePython=true`, then refreshes presets, utility skills, and `commands.json`. Designed to be usable when the TUI cannot start (broken venv, missing migrations) — it never touches `.lingtai/`. Exit nonzero only on unrecoverable failures.
-- **Version flow:** `Makefile:4` injects `git describe` into `main.go:29`. On startup, `main.go:131` calls `tui.SetTUIVersion(version)`, which stores it for `/doctor` drift detection.
-- **TUI binary upgrade:** `main.go:100-107` delegates newer-release handling to `upgrade.go`, which detects other running TUI binaries before running Homebrew; with confirmation, it puts agents in their projects to sleep, stops those TUI processes, upgrades, then asks the user to relaunch.
-- **i18n loading:** `i18n/i18n.go` embeds the three locale JSONs; `main.go:249` sets the active locale from `tuiCfg.Language`.
+- **Bootstrap sequence** (`main.go:228-273`): on every launch, the TUI runs `config.MigrateLegacyLanguage` → `config.NeedsVenv` (for setup banner) → `config.EnsureRuntime` (create/repair venv if needed, then always run the non-blocking `CheckUpgrade`) → `config.EnsureAddons` → `preset.Bootstrap` → `tui.ExportCommandsJSON` → `maybePromptRustToolchain` (one-time optional Rust/Cargo prompt only when file search is on Python fallback and no cargo is on PATH). `CheckUpgrade` auto-upgrades the `lingtai` meta-package from PyPI, which bundles `lingtai-kernel` + all addon MCPs. See `tui/internal/config/ANATOMY.md`.
+- **`lingtai-tui doctor` subcommand** (`main.go:962-1002`): runs `config.RunDoctorUpdate` (`main.go:974`) with both `ForceTUI=true` and `ForcePython=true`, then refreshes presets, utility skills, and `commands.json`. The report includes native file-search sidecar / Rust toolchain diagnostics (`config.checkFileSearchNative`). Designed to be usable when the TUI cannot start (broken venv, missing migrations) — it never touches `.lingtai/`. Exit nonzero only on unrecoverable failures.
+- **Version flow:** `Makefile:4` injects `git describe` into `main.go:31`. On startup, `main.go:112` calls `tui.SetTUIVersion(version)`, which stores it for `/doctor` drift detection.
+- **TUI binary upgrade:** `main.go:102-105` delegates newer-release handling to `upgrade.go` (`handleTUIUpgrade`), which detects other running TUI binaries before running Homebrew; with confirmation, it puts agents in their projects to sleep, stops those TUI processes, upgrades, then asks the user to relaunch.
+- **i18n loading:** `i18n/i18n.go` embeds the three locale JSONs; `main.go:230` sets the active locale from `tuiCfg.Language`.
 
 ## Composition
 
@@ -58,8 +59,8 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 
 - **Writes:** `tui/bin/lingtai-tui` (build artifact). Subcommands write signal files (`.suspend`) and can remove `.lingtai/` (`cleanMain`).
 - **Reads:** `~/.lingtai-tui/` (global config, venv, presets), `<project>/.lingtai/` (agent state), `~/.lingtai-tui/config.json` (TUI preferences).
-- **Version stamp:** `main.go:29` — set at build time, never changes at runtime.
-- **Upgrade sentinels:** `~/.lingtai-tui/.firstrun` (one-time welcome), `~/.lingtai-tui/.last_agent_check` (periodic agent count reminder).
+- **Version stamp:** `main.go:31` — set at build time, never changes at runtime.
+- **Upgrade sentinels:** `~/.lingtai-tui/.firstrun` (one-time welcome), `~/.lingtai-tui/.last_agent_check` (periodic agent count reminder), `~/.lingtai-tui/runtime/rust-toolchain-prompted` (one-time startup Rust prompt dismissal/install marker).
 
 ## Notes
 
@@ -67,5 +68,5 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 - **`main.go` is intentionally flat** — every subcommand's `*Main()` function is defined inline in `main.go` or platform-specific `*_unix.go`/`*_windows.go` files. Don't refactor subcommands into `internal/` packages; the flat `main.go` is the contract.
 - **Platform shims follow the `//go:build !windows` pattern.** Unix is the primary target; Windows files mirror the same function signatures. Every subcommand (`purge`, `list`, `suspend`) plus `countRunningAgents` and TUI-process upgrade helpers have paired platform files.
 - **The platform split** covers: `purge`, `list`, `suspend`, `agent_count`, and `tui_process`. The `timemachine` and `postman` subcommands live in `internal/` and share no platform-specific `main.go` surface.
-- **Version stamping:** `Makefile:4` uses `git describe --tags --always`. Dev builds get `-X main.version=dev`. The upgrade check in `main.go:79-82` skips dev builds (those containing `-` in the version string).
+- **Version stamping:** `Makefile:4` uses `git describe --tags --always`. Dev builds get `-X main.version=dev`. The upgrade check in `main.go:97-101` skips dev builds (those containing `-` in the version string).
 - **MCP packages are dependencies of `lingtai`.** The `lingtai` PyPI package bundles `lingtai-kernel` + all addon MCPs. `config.CheckUpgrade` on every launch upgrades everything. Users never install MCP packages individually.

--- a/tui/internal/config/ANATOMY.md
+++ b/tui/internal/config/ANATOMY.md
@@ -9,9 +9,10 @@ This package manages the TUI's bootstrap sequence — the steps that run before 
 - **`venv.go:59-166`** — `EnsureVenv`: creates the runtime venv at `~/.lingtai-tui/runtime/venv/`. Uses `uv` if available (can auto-download Python 3.13), falls back to system Python. Verifies Python 3.11+, installs `lingtai`, symlinks CLI into PATH.
 - **`venv.go:300-309`** — `CheckUpgrade`: thin wrapper over `UpgradePythonRuntime(globalDir, false, ...)` that returns `true` only when a real upgrade was verified post-install. Used by `EnsureRuntime`, where any failure is silent so the TUI can still launch. It no longer reports success when the underlying pip command fails.
 - **`venv.go:311-350`** — `EnsureRuntime` / `EnsureRuntimeQuiet`: startup helpers that ensure the managed Python runtime exists, then always run the non-blocking `CheckUpgrade` path after a successful ensure. This avoids the old intermittent skip where a newly-created/repaired venv would not check PyPI until the next launch.
-- **`venv.go:424-454`** — `RunDoctorUpdate`: the forced check-and-update routine called by `/doctor` and `lingtai-tui doctor`. Verifies the TUI binary against the latest GitHub release (brew-upgrades when needed), repairs a missing/broken runtime venv, then runs `UpgradePythonRuntime(force=true)`. All command stdout/stderr is captured after command completion and surfaced; nothing is silently swallowed.
-- **`venv.go:604-673`** — `UpgradePythonRuntime`: compares installed `lingtai` to PyPI, runs `uv pip install --upgrade lingtai -p <venv>` (or `pip install --upgrade lingtai`), then re-imports to verify the new version. Reports `DoctorFail` on any command error or post-install version mismatch.
-- **`venv.go:352-421`** — `DoctorOptions` / `CommandRunner`: dependency-injection seams so tests stub brew/pip/python without dialing the network. Production callers leave them nil and get real `exec.Command` + `http.Client`.
+- **`venv.go:430-461`** — `RunDoctorUpdate`: the forced check-and-update routine called by `/doctor` and `lingtai-tui doctor`. Verifies the TUI binary against the latest GitHub release (brew-upgrades when needed), repairs a missing/broken runtime venv, then runs `UpgradePythonRuntime(force=true)`, then reports native file-search sidecar/Rust availability via `checkFileSearchNative`. All command stdout/stderr is captured after command completion and surfaced; nothing is silently swallowed.
+- **`venv.go:742-825`** — `UpgradePythonRuntime`: compares installed `lingtai` to PyPI, runs `uv pip install --upgrade lingtai -p <venv>` (or `pip install --upgrade lingtai`), then re-imports to verify the new version. Reports `DoctorFail` on any command error or post-install version mismatch.
+- **`venv.go:388-428`** — `DoctorOptions` / `CommandRunner`: dependency-injection seams so tests stub brew/pip/python without dialing the network. Production callers leave them nil and get real `exec.Command` + `http.Client`.
+- **`venv.go:551-652`** — `checkFileSearchNative` / `FileSearchStatus` / `timeoutCommandRunner` / `FileSearchNativeStatus`: asks the managed Python runtime which file-search backend it will use (`RustFileIOBackend` sidecar vs Python fallback) and reports both packaged sidecar status and local Cargo availability for `/doctor` / startup guidance. The probe runs through a `timeoutCommandRunner` (3s default) so startup and `/doctor` cannot hang on a slow or broken managed Python runtime. A `ModuleNotFoundError` for `lingtai.services.file_io_sidecar` (a runtime that predates the Rust sidecar release) is reported as `FileSearchStatus{Unsupported: true}` rather than an error; `checkFileSearchNative` then emits a single `DoctorInfo` line ("does not expose Rust sidecar diagnostics yet; upgrade the lingtai Python package…") and the report stays healthy.
 - **`venv.go:283-313`** — `EnsureAddons`: reads `init.json`'s `addons` map, verifies each addon is importable as `lingtai.addons.<name>`. Error surfaces which addon is missing and suggests `pip install --upgrade lingtai`.
 - **`venv.go:241-254`** — `CheckTUIUpgrade`: compares running TUI binary version against latest GitHub release. Returns tag if upgrade available. Used by the startup-time prompt in `main.go`.
 - **`venv.go:47-57`** — `NeedsVenv`: returns true if no venv exists or `lingtai` is not importable.
@@ -23,15 +24,16 @@ This package manages the TUI's bootstrap sequence — the steps that run before 
 
 ## Connections
 
-- **Called from:** `tui/main.go:277-289`, `tui/internal/tui/firstrun.go:597-604`, and `tui/internal/headless/spawn.go:77-83` — startup/first-run/headless bootstrap paths.
+- **Called from:** `tui/main.go:228-273`, `tui/internal/tui/firstrun.go:597-604`, and `tui/internal/headless/spawn.go:77-83` — startup/first-run/headless bootstrap paths.
 - **Calls out:** PyPI API (`pypi.org/pypi/lingtai/json`), GitHub API (`api.github.com/repos/Lingtai-AI/lingtai/releases/latest`), `uv` / `pip` CLI.
-- **Bootstrap sequence** (in `main.go:277-295`):
+- **Bootstrap sequence** (in `main.go:228-273`):
   1. `config.MigrateLegacyLanguage(globalDir)` — one-shot language migration
   2. `config.NeedsVenv(globalDir)` — check if a setup banner should be printed
   3. `config.EnsureRuntime(globalDir)` — create/repair venv if needed, then always auto-check/upgrade the `lingtai` PyPI package
   4. `config.EnsureAddons(python, agentDir)` — verify addon importability
   5. `preset.Bootstrap(globalDir)` — copy preset resources
   6. `tui.ExportCommandsJSON(globalDir)` — export slash commands
+  7. `maybePromptRustToolchain(globalDir)` — one-time optional Rust/Cargo prompt when native file search is unavailable and Cargo is missing
 
 ## Composition
 
@@ -40,7 +42,7 @@ This package manages the TUI's bootstrap sequence — the steps that run before 
 
 ## State
 
-- **Writes:** `~/.lingtai-tui/runtime/venv/` (Python venv), `~/.lingtai-tui/config.json` (API keys), `~/.lingtai-tui/tui_config.json` (TUI prefs), `~/.lingtai-tui/.env` (env file for agents).
+- **Writes:** `~/.lingtai-tui/runtime/venv/` (Python venv), `~/.lingtai-tui/runtime/rust-toolchain-prompted` (one-time Rust prompt marker), `~/.lingtai-tui/config.json` (API keys), `~/.lingtai-tui/tui_config.json` (TUI prefs), `~/.lingtai-tui/.env` (env file for agents).
 - **Reads:** `init.json` (addon declarations), PyPI/GitHub APIs (version checks).
 
 ## Notes

--- a/tui/internal/config/venv.go
+++ b/tui/internal/config/venv.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -455,6 +456,7 @@ func RunDoctorUpdate(globalDir string, opts DoctorOptions) DoctorReport {
 
 	report.checkTUI(opts)
 	report.checkPythonRuntime(globalDir, opts)
+	report.checkFileSearchNative(globalDir, opts)
 	return report
 }
 
@@ -544,6 +546,108 @@ func (r *DoctorReport) checkPythonRuntime(globalDir string, opts DoctorOptions) 
 	if !upgrade.Healthy {
 		r.Healthy = false
 	}
+}
+
+func (r *DoctorReport) checkFileSearchNative(globalDir string, opts DoctorOptions) {
+	python := VenvPython(RuntimeVenvDir(globalDir))
+	if _, err := opts.Stat(python); err != nil {
+		r.add(DoctorWarn, "File search native backend: skipped because Python runtime is missing: %v", err)
+		return
+	}
+	status, err := FileSearchNativeStatus(globalDir, opts.Runner)
+	if err != nil {
+		r.add(DoctorWarn, "File search native backend: could not inspect runtime sidecar status: %v", err)
+		return
+	}
+	if status.Unsupported {
+		r.add(DoctorInfo, "File search native backend: installed Python runtime does not expose Rust sidecar diagnostics yet; upgrade the lingtai Python package after the Rust sidecar release to enable this check")
+		return
+	}
+	if status.SidecarPath != "" {
+		r.add(DoctorOK, "File search native backend: Rust sidecar available (%s)", status.SidecarPath)
+	} else if status.Backend == "RustFileIOBackend" {
+		r.add(DoctorOK, "File search native backend: Rust backend active")
+	} else {
+		r.add(DoctorWarn, "File search native backend: Python fallback active; no packaged Rust sidecar was found")
+	}
+	if cargo, err := opts.LookPath("cargo"); err == nil && cargo != "" {
+		r.add(DoctorOK, "Rust toolchain: cargo found at %s", cargo)
+	} else if status.SidecarPath != "" || status.Backend == "RustFileIOBackend" {
+		r.add(DoctorInfo, "Rust toolchain: cargo not found, but bundled sidecar is already available at runtime")
+	} else {
+		r.add(DoctorWarn, "Rust toolchain: cargo not found; install Rust from https://rustup.rs or install a platform wheel with the bundled sidecar to enable accelerated glob/grep")
+	}
+}
+
+type FileSearchStatus struct {
+	Backend     string
+	SidecarPath string
+	Unsupported bool
+}
+
+type timeoutCommandRunner struct {
+	timeout time.Duration
+}
+
+func (r timeoutCommandRunner) Run(name string, args ...string) CommandResult {
+	timeout := r.timeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return CommandResult{Stdout: stdout.String(), Stderr: stderr.String(), Err: fmt.Errorf("timed out after %s", timeout)}
+	}
+	return CommandResult{Stdout: stdout.String(), Stderr: stderr.String(), Err: err}
+}
+
+// FileSearchNativeStatus asks the managed Python runtime which file-search
+// backend it will use. The probe is intentionally Python-side because the
+// sidecar resolver lives in the `lingtai` package installed inside that venv.
+// Production calls use a short timeout so startup and /doctor cannot hang on a
+// slow or broken managed Python runtime; tests may pass a runner.
+func FileSearchNativeStatus(globalDir string, runner CommandRunner) (FileSearchStatus, error) {
+	if runner == nil {
+		runner = timeoutCommandRunner{timeout: 3 * time.Second}
+	}
+	python := VenvPython(RuntimeVenvDir(globalDir))
+	script := `
+import tempfile
+from lingtai.services.file_io_sidecar import default_file_io_service, resolve_sidecar_binary
+binary = resolve_sidecar_binary()
+service = default_file_io_service(tempfile.gettempdir(), backend="auto")
+backend = type(getattr(service, "_backend", service)).__name__
+print("BACKEND " + backend)
+print("SIDECAR " + (str(binary) if binary else ""))
+`
+	res := runner.Run(python, "-c", script)
+	if res.Err != nil {
+		stderr := strings.TrimSpace(res.Stderr)
+		if strings.Contains(stderr, "ModuleNotFoundError") && strings.Contains(stderr, "file_io_sidecar") {
+			return FileSearchStatus{Unsupported: true}, nil
+		}
+		return FileSearchStatus{}, fmt.Errorf("probe failed: %v: %s", res.Err, stderr)
+	}
+	status := FileSearchStatus{}
+	for _, line := range strings.Split(res.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "BACKEND "):
+			status.Backend = strings.TrimSpace(strings.TrimPrefix(line, "BACKEND "))
+		case strings.HasPrefix(line, "SIDECAR "):
+			status.SidecarPath = strings.TrimSpace(strings.TrimPrefix(line, "SIDECAR "))
+		}
+	}
+	if status.Backend == "" {
+		return FileSearchStatus{}, fmt.Errorf("probe returned no backend line: %q", strings.TrimSpace(res.Stdout))
+	}
+	return status, nil
 }
 
 type latestRelease struct {
@@ -763,10 +867,10 @@ func pythonLingtaiVersion(runner CommandRunner, python string) (string, error) {
 
 // isEditableLingtaiInstall reports whether the lingtai distribution in the
 // given Python interpreter was installed in editable mode (pip/uv -e ...).
-// Detection follows PEP 610: the install records a ``direct_url.json`` file
+// Detection follows PEP 610: the install records a direct_url.json file
 // inside the package's .dist-info/ directory; editable installs set
-// ``dir_info.editable: true``. The second return is the editable source path
-// (e.g. ``file:///Users/.../lingtai-kernel``) if available, for the log line.
+// dir_info.editable: true. The second return is the editable source path
+// (e.g. file:///Users/.../lingtai-kernel) if available, for the log line.
 // Returns (false, "") on any error so a missing or malformed direct_url is
 // treated as "regular wheel install" — the conservative default that lets the
 // upgrade proceed.

--- a/tui/internal/config/venv_doctor_test.go
+++ b/tui/internal/config/venv_doctor_test.go
@@ -12,15 +12,33 @@ import (
 )
 
 type fakeRunner struct {
-	versions       []string
-	failPip        bool
-	editableSource string // when non-empty, the editable-detect probe reports EDITABLE <source>
-	calls          []string
+	versions          []string
+	failPip           bool
+	editableSource    string // when non-empty, the editable-detect probe reports EDITABLE <source>
+	fileSearchStdout  string // when non-empty, returned for the file_io_sidecar probe
+	fileSearchErr     bool
+	fileSearchMissing bool // when true, the probe fails with ModuleNotFoundError for file_io_sidecar
+	calls             []string
 }
 
 func (r *fakeRunner) Run(name string, args ...string) CommandResult {
 	call := name + " " + strings.Join(args, " ")
 	r.calls = append(r.calls, call)
+	if strings.Contains(call, "file_io_sidecar") {
+		if r.fileSearchMissing {
+			return CommandResult{
+				Err:    errors.New("exit status 1"),
+				Stderr: "Traceback (most recent call last):\n  File \"<string>\", line 2, in <module>\nModuleNotFoundError: No module named 'lingtai.services.file_io_sidecar'",
+			}
+		}
+		if r.fileSearchErr {
+			return CommandResult{Err: errors.New("exit status 1"), Stderr: "probe failed"}
+		}
+		if r.fileSearchStdout != "" {
+			return CommandResult{Stdout: r.fileSearchStdout}
+		}
+		return CommandResult{Stdout: "BACKEND RustFileIOBackend\nSIDECAR /tmp/lingtai-search-sidecar\n"}
+	}
 	if strings.Contains(call, "direct_url.json") {
 		// Editable-install probe (isEditableLingtaiInstall). Default response
 		// is "WHEEL" — matching the conservative no-skip default for existing
@@ -487,6 +505,117 @@ func TestRunDoctorUpdateReportsTUISymlinkCaveat(t *testing.T) {
 	}
 	if !containsLine(report.Lines, "executable is a symlink") {
 		t.Fatalf("expected symlink caveat: %+v", report.Lines)
+	}
+}
+
+func TestFileSearchNativeStatusParsesProbe(t *testing.T) {
+	runner := &fakeRunner{fileSearchStdout: "BACKEND LocalFileIOBackend\nSIDECAR \n"}
+	status, err := FileSearchNativeStatus(t.TempDir(), runner)
+	if err != nil {
+		t.Fatalf("FileSearchNativeStatus err = %v", err)
+	}
+	if status.Backend != "LocalFileIOBackend" || status.SidecarPath != "" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if !containsCall(runner.calls, "file_io_sidecar") {
+		t.Fatalf("expected Python file_io_sidecar probe, got %#v", runner.calls)
+	}
+}
+
+func TestRunDoctorUpdateReportsFileSearchFallbackAndMissingCargo(t *testing.T) {
+	runner := &fakeRunner{
+		versions:         []string{"0.9.7", "0.9.7"},
+		fileSearchStdout: "BACKEND LocalFileIOBackend\nSIDECAR \n",
+	}
+	report := RunDoctorUpdate(t.TempDir(), DoctorOptions{
+		CurrentTUIVersion: "v0.8.1",
+		ForcePython:       false,
+		HTTPClient:        testVersionClient(t, "0.9.7", "v0.8.1"),
+		Runner:            runner,
+		LookPath:          func(string) (string, error) { return "", errors.New("not found") },
+		Executable:        func() (string, error) { return "/opt/homebrew/bin/lingtai-tui", nil },
+		Readlink:          func(string) (string, error) { return "", os.ErrInvalid },
+		Stat:              statAllExist,
+	})
+	if !report.Healthy {
+		t.Fatalf("file-search fallback is a warning, not a failed doctor report: %+v", report.Lines)
+	}
+	if !containsLine(report.Lines, "Python fallback active") {
+		t.Fatalf("expected Python fallback warning: %+v", report.Lines)
+	}
+	if !containsLine(report.Lines, "cargo not found") {
+		t.Fatalf("expected missing cargo warning: %+v", report.Lines)
+	}
+}
+
+func TestRunDoctorUpdateReportsBundledSidecarWithoutCargo(t *testing.T) {
+	runner := &fakeRunner{
+		versions:         []string{"0.9.7", "0.9.7"},
+		fileSearchStdout: "BACKEND RustFileIOBackend\nSIDECAR /opt/lingtai/bin/lingtai-search-sidecar\n",
+	}
+	report := RunDoctorUpdate(t.TempDir(), DoctorOptions{
+		CurrentTUIVersion: "v0.8.1",
+		ForcePython:       false,
+		HTTPClient:        testVersionClient(t, "0.9.7", "v0.8.1"),
+		Runner:            runner,
+		LookPath:          func(string) (string, error) { return "", errors.New("not found") },
+		Executable:        func() (string, error) { return "/opt/homebrew/bin/lingtai-tui", nil },
+		Readlink:          func(string) (string, error) { return "", os.ErrInvalid },
+		Stat:              statAllExist,
+	})
+	if !report.Healthy {
+		t.Fatalf("expected healthy report: %+v", report.Lines)
+	}
+	if !containsLine(report.Lines, "Rust sidecar available") {
+		t.Fatalf("expected sidecar OK line: %+v", report.Lines)
+	}
+	if !containsLine(report.Lines, "bundled sidecar is already available") {
+		t.Fatalf("expected no-cargo-but-sidecar info line: %+v", report.Lines)
+	}
+}
+
+func TestFileSearchNativeStatusReportsUnsupportedOnModuleMissing(t *testing.T) {
+	runner := &fakeRunner{fileSearchMissing: true}
+	status, err := FileSearchNativeStatus(t.TempDir(), runner)
+	if err != nil {
+		t.Fatalf("ModuleNotFoundError should be treated as Unsupported, not an error: %v", err)
+	}
+	if !status.Unsupported {
+		t.Fatalf("expected Unsupported=true on missing file_io_sidecar module: %+v", status)
+	}
+	if !containsCall(runner.calls, "file_io_sidecar") {
+		t.Fatalf("expected Python file_io_sidecar probe, got %#v", runner.calls)
+	}
+}
+
+func TestRunDoctorUpdateReportsUnsupportedRuntimeInfo(t *testing.T) {
+	runner := &fakeRunner{
+		versions:          []string{"0.9.7", "0.9.7"},
+		fileSearchMissing: true,
+	}
+	report := RunDoctorUpdate(t.TempDir(), DoctorOptions{
+		CurrentTUIVersion: "v0.8.1",
+		ForcePython:       false,
+		HTTPClient:        testVersionClient(t, "0.9.7", "v0.8.1"),
+		Runner:            runner,
+		LookPath:          func(string) (string, error) { return "", errors.New("not found") },
+		Executable:        func() (string, error) { return "/opt/homebrew/bin/lingtai-tui", nil },
+		Readlink:          func(string) (string, error) { return "", os.ErrInvalid },
+		Stat:              statAllExist,
+	})
+	if !report.Healthy {
+		t.Fatalf("an unsupported runtime is informational, not a failed doctor report: %+v", report.Lines)
+	}
+	if !containsLine(report.Lines, "does not expose Rust sidecar diagnostics yet") {
+		t.Fatalf("expected unsupported-runtime info line: %+v", report.Lines)
+	}
+	// The unsupported path must short-circuit: no generic "could not inspect"
+	// warning and no "Python fallback" / cargo guidance.
+	if containsLine(report.Lines, "could not inspect runtime sidecar status") {
+		t.Fatalf("unsupported runtime should not emit the generic probe-error warning: %+v", report.Lines)
+	}
+	if containsLine(report.Lines, "Python fallback active") {
+		t.Fatalf("unsupported runtime should short-circuit before the fallback/cargo lines: %+v", report.Lines)
 	}
 }
 

--- a/tui/main.go
+++ b/tui/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -269,6 +270,7 @@ func main() {
 			os.Exit(1)
 		}
 		tui.ExportCommandsJSON(globalDir)
+		maybePromptRustToolchain(globalDir)
 
 		// Recipe reconciliation: if the project carries a recipe bundle at
 		// its root (.recipe/) and the contents differ from the last-applied
@@ -663,6 +665,79 @@ func printHelp() {
 	} else {
 		fmt.Printf("  Working dir:   (no .lingtai/ in %s)\n", cwd)
 	}
+}
+
+func maybePromptRustToolchain(globalDir string) {
+	if os.Getenv("LINGTAI_SKIP_RUST_PROMPT") == "1" {
+		return
+	}
+	if info, err := os.Stdin.Stat(); err != nil || (info.Mode()&os.ModeCharDevice) == 0 {
+		return
+	}
+
+	promptPath := filepath.Join(globalDir, "runtime", "rust-toolchain-prompted")
+	if _, err := os.Stat(promptPath); err == nil {
+		return
+	}
+
+	status, err := config.FileSearchNativeStatus(globalDir, nil)
+	if err != nil {
+		// The probe failed (slow/broken/old runtime). Mark the prompt seen so
+		// we don't re-spawn the Python probe on every startup forever.
+		markRustPromptSeen(promptPath, "probe-error\n")
+		return
+	}
+	if status.Unsupported {
+		// Installed runtime predates the Rust sidecar diagnostics. Nothing the
+		// user can act on here, and the probe will keep failing until they
+		// upgrade lingtai — so record it once and stop prompting.
+		markRustPromptSeen(promptPath, "unsupported-runtime\n")
+		return
+	}
+	if status.SidecarPath != "" || status.Backend == "RustFileIOBackend" {
+		return
+	}
+	if cargo, err := exec.LookPath("cargo"); err == nil && cargo != "" {
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("LingTai is using the pure-Python file search fallback; Rust/Cargo is not installed.")
+	fmt.Println("Rust is optional, but installing it lets source installs build the accelerated glob/grep sidecar.")
+	fmt.Print("Install Rust now via rustup.rs? [y/N] ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		markRustPromptSeen(promptPath, "declined\n")
+		return
+	}
+
+	if runtime.GOOS == "windows" {
+		fmt.Println("Please install Rust from https://rustup.rs, then reinstall/upgrade the LingTai Python runtime if you need the native sidecar.")
+		markRustPromptSeen(promptPath, "manual-windows\n")
+		return
+	}
+
+	installCmd := "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal"
+	fmt.Printf("Running: %s\n", installCmd)
+	cmd := exec.Command("sh", "-c", installCmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Rust installer failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, "You can install manually from https://rustup.rs and then reinstall/upgrade the LingTai Python runtime.")
+		return
+	}
+	fmt.Println("Rust installed. Open a new shell if cargo is not on PATH yet; reinstall/upgrade the LingTai Python runtime to rebuild the native sidecar if this install currently falls back to Python.")
+	markRustPromptSeen(promptPath, "installed\n")
+}
+
+func markRustPromptSeen(path, content string) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, []byte(content), 0o644)
 }
 
 func printWelcomeInfo() {


### PR DESCRIPTION
## Summary
- add `/doctor` diagnostics for the packaged Rust file-search sidecar and local Cargo/Rust availability
- add a one-time startup prompt when file search falls back to Python and Cargo is missing
- document the new startup/doctor flow in TUI anatomy files

## Validation
- `go test ./internal/config`
- `go test ./...`
- `git diff --check`

Do not merge until Jason explicitly approves.