### PR TITLE
Add WhatsApp MCP wiring

### DIFF
--- a/portal/internal/migrate/m028_addons_to_mcp.go
+++ b/portal/internal/migrate/m028_addons_to_mcp.go
@@ -74,6 +74,7 @@ var addonSpecs = map[string]addonSpec{
 	"telegram": {module: "lingtai_telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
 	"feishu":   {module: "lingtai_feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
 	"wechat":   {module: "lingtai_wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
+	"whatsapp": {module: "lingtai_whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
 }
 
 func convertAddonsInInitFile(initPath, agentDir, globalDir string) {

--- a/tui/internal/migrate/m028_addons_to_mcp.go
+++ b/tui/internal/migrate/m028_addons_to_mcp.go
@@ -91,6 +91,7 @@ var addonSpecs = map[string]addonSpec{
 	"telegram": {module: "lingtai_telegram", envVarName: "LINGTAI_TELEGRAM_CONFIG", defaultRel: ".secrets/telegram.json"},
 	"feishu":   {module: "lingtai_feishu", envVarName: "LINGTAI_FEISHU_CONFIG", defaultRel: ".secrets/feishu.json"},
 	"wechat":   {module: "lingtai_wechat", envVarName: "LINGTAI_WECHAT_CONFIG", defaultRel: ".secrets/wechat/config.json"},
+	"whatsapp": {module: "lingtai_whatsapp", envVarName: "LINGTAI_WHATSAPP_CONFIG", defaultRel: ".secrets/whatsapp.json"},
 }
 
 // convertAddonsInInitFile is the per-init.json workhorse. Atomic write,

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1064,8 +1064,8 @@ func AddonSecretsPathFromAgent(addon string) string {
 	return filepath.Join(".secrets", addon+".json")
 }
 
-// defaultMCPSpec returns the canonical wiring for one of the four curated
-// addons (imap / telegram / feishu / wechat) — the Python module to invoke,
+// defaultMCPSpec returns the canonical wiring for one of the curated
+// addons (imap / telegram / feishu / wechat / whatsapp) — the Python module to invoke,
 // the env-var name the MCP reads its config path from, and the config path
 // (relative to the agent working dir) to point that env var at by default.
 //
@@ -1086,6 +1086,8 @@ func defaultMCPSpec(name string) (module, envVar, configRel string, supported bo
 		return "lingtai_feishu", "LINGTAI_FEISHU_CONFIG", filepath.Join(".secrets", "feishu.json"), true
 	case "wechat":
 		return "lingtai_wechat", "LINGTAI_WECHAT_CONFIG", filepath.Join(".secrets", "wechat", "config.json"), true
+	case "whatsapp":
+		return "lingtai_whatsapp", "LINGTAI_WHATSAPP_CONFIG", filepath.Join(".secrets", "whatsapp.json"), true
 	}
 	return "", "", "", false
 }

--- a/tui/internal/preset/preset_addons_default_test.go
+++ b/tui/internal/preset/preset_addons_default_test.go
@@ -31,7 +31,7 @@ func TestGenerateInitJSONWritesNewShapeWithLocalVenv(t *testing.T) {
 
 	p := DefaultPreset()
 	opts := AgentOpts{
-		Addons: []string{"imap", "telegram", "feishu", "wechat"},
+		Addons: []string{"imap", "telegram", "feishu", "wechat", "whatsapp"},
 	}
 	if err := GenerateInitJSONWithOpts(p, "alice", "alice", lingtaiDir, globalDir, opts); err != nil {
 		t.Fatal(err)
@@ -51,7 +51,7 @@ func TestGenerateInitJSONWritesNewShapeWithLocalVenv(t *testing.T) {
 	if !ok {
 		t.Fatalf("addons not a list: %T (%v)", got["addons"], got["addons"])
 	}
-	wantNames := map[string]bool{"imap": true, "telegram": true, "feishu": true, "wechat": true}
+	wantNames := map[string]bool{"imap": true, "telegram": true, "feishu": true, "wechat": true, "whatsapp": true}
 	if len(addons) != len(wantNames) {
 		t.Errorf("addons len = %d, want %d (%v)", len(addons), len(wantNames), addons)
 	}
@@ -69,7 +69,7 @@ func TestGenerateInitJSONWritesNewShapeWithLocalVenv(t *testing.T) {
 	if !ok {
 		t.Fatalf("mcp not a dict: %T (%v)", got["mcp"], got["mcp"])
 	}
-	for _, name := range []string{"imap", "telegram", "feishu", "wechat"} {
+	for _, name := range []string{"imap", "telegram", "feishu", "wechat", "whatsapp"} {
 		entry, ok := mcp[name].(map[string]interface{})
 		if !ok {
 			t.Errorf("mcp.%s missing or wrong type: %T", name, mcp[name])


### PR DESCRIPTION
## Summary
- Add `whatsapp` to TUI default MCP wiring (`lingtai_whatsapp`, `LINGTAI_WHATSAPP_CONFIG`, `.secrets/whatsapp.json`).
- Add WhatsApp to the TUI and portal addon→MCP migration mirrors.
- Extend preset test coverage for WhatsApp MCP seeding.

## Tests
- `cd tui && go test ./internal/preset ./internal/migrate`
- `cd portal && go test ./internal/migrate`
