### PR TITLE
docs: reposition README as product entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <div align="center">
 
-<img src="docs/assets/network-demo.gif" alt="LingTai agent network growing — one soul spawning avatars that communicate and multiply" width="100%">
+<img src="docs/assets/network-demo.gif" alt="LingTai — a local AI assistant that lives in your project and can grow into a team" width="100%">
 
 # LingTai
 
-**A filesystem-native operating system for long-lived AI agents.**
-**One mind can become a network. The network learns while it works.**
+**Your local, always-on AI assistant for real work.**
 
 [English](README.md) · [中文](README.zh.md) · [文言](README.wen.md) · [Website](https://lingtai.ai) · [Releases](https://lingtai.ai/releases/)
 
@@ -19,72 +18,173 @@
 
 ---
 
-LingTai is an agent OS: a local runtime, terminal UI, visual portal, mailbox, memory system, skill system, and multi-agent network substrate for autonomous AI agents that persist beyond a single chat window.
+**LingTai** is a local AI assistant that lives in your project and stays on. It remembers what matters, talks to you through the channels you already use, runs tools and workflows on your behalf, and — when the job gets bigger than one assistant — can grow into a small AI team you supervise.
 
-It is not a prompt wrapper, workflow graph, or one-shot coding assistant. A LingTai agent is a running process with a filesystem home, durable memory, tools, mail, long-lived identity, and the ability to spawn peers. Agents can sleep, wake, molt their context, write reusable skills, remember project facts, send each other mail, connect to external messaging systems, and continue working after the terminal closes.
+It is not a chat window, a notebook, or a one-shot coding agent. It is a real process with memory, tools, and a schedule: send it a task in the terminal, on Telegram, or by email, then come back later to find progress waiting for you.
 
-The core design is simple:
+If you want a personal AI workbench that feels yours — local, persistent, scriptable, and able to scale up when the work demands it — this is it.
 
-> **Agent = process + directory + mailbox + memory + tools.**
-> **Network = agents that can create, teach, and call one another.**
+## Install
 
-## Table of contents
-
-- [Why LingTai exists](#why-lingtai-exists)
-- [Quick start](#quick-start)
-- [What you get after first launch](#what-you-get-after-first-launch)
-- [Core concepts](#core-concepts)
-- [What LingTai can do](#what-lingtai-can-do)
-- [Filesystem model](#filesystem-model)
-- [User interface: TUI, slash commands, and portal](#user-interface-tui-slash-commands-and-portal)
-- [External channels and MCP addons](#external-channels-and-mcp-addons)
-- [Recipes, skills, and knowledge](#recipes-skills-and-knowledge)
-- [Architecture](#architecture)
-- [Installation and upgrade details](#installation-and-upgrade-details)
-- [Development workflow](#development-workflow)
-- [Repository map](#repository-map)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [Project philosophy](#project-philosophy)
-- [Community](#community)
-- [Star history](#star-history)
-- [License](#license)
-
-## Why LingTai exists
-
-Most agent tools still behave like chat sessions:
-
-- the model has no durable body;
-- long context eventually collapses;
-- tools are configured outside the agent's own world;
-- memory is either hidden vendor state or an opaque vector store;
-- multi-agent work is simulated by a controller, not lived by independent agents;
-- when the UI closes, the system stops feeling alive.
-
-LingTai takes a different route. It makes agents concrete.
-
-Each agent owns a directory under `.lingtai/`. That directory contains its identity, prompt layers, mail, logs, memory, skills, tools, runtime state, and summaries. The filesystem is not an implementation detail; it is the API. Humans, coding agents, scripts, and other LingTai agents can inspect and cooperate with the system through files and mail.
-
-The result is an agent network that can grow:
-
-- a primary agent can spawn an avatar to specialize in a task;
-- that avatar can keep its own long-term memory;
-- completed work can become a skill;
-- hard-won project facts can become knowledge;
-- the network can be visualized, restarted, debugged, and resumed.
-
-## Quick start
-
-### macOS / Homebrew
+Recommended path on macOS and Linux:
 
 ```bash
 brew install lingtai-ai/lingtai/lingtai-tui
 lingtai-tui
 ```
 
-On first launch, the TUI guides you through setup: model/provider selection, project initialization, recipe selection, and agent creation.
+The TUI handles the rest: it provisions its own Python runtime, walks you through model selection, opens your first project, and gets a working assistant in front of you within a couple of minutes. On first launch pick the **Adaptive** recipe for progressive feature discovery, or **Tutorial** for a guided walkthrough.
 
-The TUI manages the Python agent runtime for you in a project virtualenv. You normally do **not** install or upgrade the kernel with a bare `pip install`; the TUI creates and maintains the runtime venv used by each project.
+> The `lingtai` PyPI package exists, but it is the Python runtime the TUI manages on your behalf. Use Homebrew (or the source build below) to install and upgrade; reach for `pip` only when you are developing the kernel itself.
+
+For source builds, mainland-China mirror setup, and from-tarball install paths, see [Install in detail](#install-in-detail).
+
+## Use it for
+
+Concrete things people run LingTai for today:
+
+- **A daily project briefing.** Each morning the assistant scans what changed, summarizes outstanding work, and posts the brief to Telegram or your TUI before you sit down.
+- **Triage GitHub issues and PRs.** It reads new activity, categorizes, drafts replies for review, and queues anything risky for your attention.
+- **Prepare a livestream or talk.** Outline, rehearse arguments, gather references, build slide notes, hold them in project memory across sessions.
+- **Research and investor memos.** Multi-source web research, web reading, paper fetching, then drafting and revision with a fact trail you can audit.
+- **Long-running coding and review work.** It can use Claude Code, Codex, or OpenCode as its hands: the coding CLI makes precise edits, while LingTai owns the plan, memory, review log, and human updates.
+- **Schedules and reminders that act, not just notify.** "Every weekday at 9, check the deploy queue and ping me on Telegram if anything is stuck."
+- **Personal knowledge that survives.** Decisions, paths, collaborator preferences, lessons — kept as durable knowledge entries owned by the assistant, not by a chat window.
+
+## What it can do
+
+| | |
+|---|---|
+| **Lives in your project** | One `.lingtai/` folder per project. The assistant is a real process with a directory home — you can `ls`, `cat`, and `tail -f` it. |
+| **Long-term memory you can read** | Pad for active context, knowledge for durable facts, character for who the assistant is. Plain Markdown on disk, not a hidden vector store. |
+| **Skills and workflows** | Reusable, on-demand procedures: web research, paper fetching, vision/audio understanding, MCP debugging, release pipelines, your own. Skills load when relevant; your prompt stays small. |
+| **Multiple channels, one mind** | Talk to the same assistant from the TUI, Telegram, Feishu/Lark, WeChat, or IMAP email. External messages wake the same long-lived process, with the same memory and tools. |
+| **Real tools** | Read/write files, run shell commands, browse the web, fetch and extract pages, understand images, work with audio, call any MCP server, and delegate implementation to coding CLIs like Claude Code, Codex, or OpenCode. |
+| **Schedules and automation** | Recurring tasks, scheduled checks, and reminders the assistant *acts on*, with delivery to whichever channel you prefer. |
+| **Grows into a team when needed** | Spawn persistent avatars (specialist peers with their own memory) or short-lived daemons (focused workers for one batch task) — supervise the whole network from one place. |
+| **Visual portal** | `lingtai-portal` renders the live agent network: who is alive, what they are working on, who mailed whom, how it grew. |
+| **Lifecycle you control** | Sleep, wake, refresh, revive, or clear an assistant when needed. Crash-safe: `/doctor` repairs the common failure modes. |
+
+## Grows with the work
+
+Most projects start with one assistant and stay there. When that is enough, you ignore everything below. When the work gets bigger, LingTai has a path up: an **AI agent organization** with roles, memory, handoffs, and supervision — not just more chat tabs.
+
+- **Forget noise, keep experience.** Context windows are finite. When a session gets long, the assistant **molts**: it writes a summary, sheds the transient conversation, and the next self picks up with pad + character + knowledge + skills + mail intact. You do not start over.
+- **Hand off to a specialist.** Spawn an **avatar** — a peer assistant with its own home, memory, and life cycle. Give it a long-running goal (own the docs site, own the support inbox, own this research thread). It keeps learning even when you close the laptop.
+- **Use coding agents as hands.** A daemon can be a normal LingTai worker, or it can run a coding CLI backend such as Claude Code, Codex, or OpenCode. LingTai keeps the goal, memory, and conversation with you; the coding agent performs the verifiable file edits and tests.
+- **Split a batch.** Spawn a **daemon** — a short-lived worker for one focused job (scan 200 files, draft 50 replies, run 30 reviews in parallel). Daemons return results and disappear; the parent keeps your attention.
+- **Watch it from the portal.** As the network grows, the portal shows who is alive, who has been mailing whom, and how the topology evolved. Use it to debug, to admire, or to plan the next refactor.
+
+You do not have to opt in. A single assistant works fine on its own — the network is the ceiling, not the floor.
+
+## External channels
+
+LingTai bridges the same long-lived assistant to the messaging surfaces you already use. The currently curated MCP addons:
+
+| Addon | Use it for |
+|---|---|
+| `telegram` | Talk to your assistant from Telegram (DMs, optional allowlist, voice/file passthrough). |
+| `feishu` | Feishu/Lark — uses a WebSocket long connection, no public IP required. |
+| `wechat` | WeChat through an iLink/gewechat-style bridge. |
+| `imap` | Real email through IMAP/SMTP — multi-account, with safety defaults for unknown senders. |
+
+Channels are doors into the *same* assistant, not separate bots. Memory, tools, and history are shared across them. Configure from the TUI's `/mcp` control panel, or declare them in `init.json`.
+
+Credentials live in local `.secrets/` files (never in Git). Unknown external senders do not auto-receive replies. External side effects (sending messages, filing issues, deleting resources) are treated as real actions by default.
+
+## The interface
+
+### TUI
+
+`lingtai-tui` is the main human surface. It gives you setup, model/preset configuration, chat and mail, agent status (token + stamina + heartbeat), avatar and daemon visibility, markdown rendering, a slash-command palette, and upgrade/doctor flows.
+
+Frequently used slash commands:
+
+| Command | Use |
+|---|---|
+| `/setup` | Change model, recipe, language, tools, or behavior. |
+| `/kanban` | Inspect agent + project status. |
+| `/mcp` | Configure external channels (Telegram/Feishu/WeChat/IMAP/…). |
+| `/skills` | Browse available skills and capabilities. |
+| `/viz` | Open the network visualization. |
+| `/insights` | Ask the assistant for a reflective second look. |
+| `/sleep` · `/refresh` · `/cpr` · `/clear` | Lifecycle: pause, reload, revive, reset context. |
+| `/projects` | Switch or inspect known projects. |
+| `/doctor` | Diagnose installation/runtime issues. |
+
+Shell entrypoints when useful:
+
+```bash
+lingtai-tui                          # open the TUI in the current project
+lingtai-tui list <project>            # list agents and states
+lingtai-tui spawn <dir> --preset <name> [--agent-name <name>]
+lingtai-tui bootstrap                # re-extract bundled skills/utilities
+lingtai-tui doctor                   # repair/update TUI runtime
+```
+
+### Portal
+
+`lingtai-portal` is the visualization server. It reads project state to show the agent network, mail edges, and history. It becomes useful when you have more than one assistant per project, or when you want to see how the work evolved.
+
+### Tips
+
+- Use a dark terminal theme — LingTai's palette is tuned for it.
+- `Ctrl+E` in the TUI opens an external editor for long messages.
+- Hold `Option` (macOS/iTerm2) or `Shift` (most Linux/Windows terminals) to select text without the TUI capturing it.
+- If anything feels broken after an upgrade, run `/doctor` (or `lingtai-tui doctor` from a shell).
+
+## Filesystem you can read
+
+LingTai keeps state on disk, on purpose. You can debug it with `ls`, `cat`, `tail`, `jq`, `grep`, your editor, or another coding agent. The shape after first launch:
+
+```text
+project/
+└── .lingtai/
+    ├── human/                  # your mailbox identity
+    ├── <agent-name>/            # one running assistant
+    │   ├── init.json            # model, tools, preset, MCP wiring
+    │   ├── system/              # prompt layers, pad, rules, summaries
+    │   ├── knowledge/           # durable private memory
+    │   ├── inbox/ outbox/       # internal mail
+    │   ├── logs/                # event log + human-readable log
+    │   ├── delegates/           # spawned-avatar ledger
+    │   ├── daemons/             # daemon run records
+    │   └── .agent.json          # heartbeat, status, identity card
+    └── .portal/                 # topology/history for visualization
+```
+
+Useful inspection commands:
+
+```bash
+lingtai-tui list /path/to/project                          # running agents and states
+tail -f /path/to/project/.lingtai/<agent>/logs/agent.log    # human-readable log
+jq -r '.event' /path/to/project/.lingtai/<agent>/logs/events.jsonl | tail   # structured events
+```
+
+## Use coding agents as hands
+
+LingTai assistants live in the filesystem, so coding agents can work with them in two ways. As **daemon backends**, Claude Code, Codex, and OpenCode can be launched for focused implementation or review jobs while LingTai keeps the long-running plan and memory. As **peer tools**, any coding agent that can read and write files can collaborate through the shared `.lingtai/human/` mailbox.
+
+- **Claude Code** — `claude plugin add Lingtai-AI/claude-code-plugin`
+- **OpenAI Codex CLI** — `git clone https://github.com/Lingtai-AI/codex-plugin.git && cd codex-plugin && ./install.sh`
+- **Other coding agents** (OpenCode, OpenClaw, Hermes, …) — vendor the [`lingtai-skill`](https://github.com/Lingtai-AI/lingtai-skill) protocol skill under your tool's skills directory.
+
+The split: a coding agent is precise and verifiable — every tool call visible, every edit reviewable. A LingTai assistant is asynchronous and patient — it remembers the goal, talks to the human, coordinates parallel contexts, and decides when to hand work to a specialist. Use the coding agent as hands. Use LingTai as the long-running collaborator that plans, drafts, monitors, and remembers.
+
+## Install in detail
+
+### Homebrew (recommended)
+
+```bash
+brew install lingtai-ai/lingtai/lingtai-tui
+lingtai-tui
+
+# upgrade later
+brew update
+brew upgrade lingtai-ai/lingtai/lingtai-tui
+```
+
+After upgrading, restart the TUI so the new binary takes over. The TUI manages the Python runtime under `~/.lingtai-tui/runtime/venv/` — installing `lingtai` into your system Python does not affect a running project.
 
 ### From source
 
@@ -97,286 +197,14 @@ cd lingtai
 lingtai-tui
 ```
 
-The install script builds `lingtai-tui` and, when `npm` is available, `lingtai-portal`. It installs binaries into the Homebrew prefix when `brew` exists, otherwise `/usr/local/bin`.
+`install.sh` builds `lingtai-tui` and (when `npm` is available) `lingtai-portal`, then installs binaries into the Homebrew prefix if `brew` exists, otherwise `/usr/local/bin`.
 
-### First-run tips
+### Kernel dev mode (advanced)
 
-- Use a dark terminal theme; LingTai's default palette is optimized for it.
-- Press `Ctrl+E` in the TUI when composing a long message to open an external editor.
-- Hold `Option` on macOS/iTerm2 or `Shift` on many Linux/Windows terminals to select terminal text.
-- Pick the **Adaptive** recipe for progressive feature discovery, or **Tutorial** for a guided walkthrough.
-- If something feels broken after an upgrade, run `/doctor` inside the TUI or `lingtai-tui doctor` from a shell.
-
-## What you get after first launch
-
-A new project gains a `.lingtai/` directory. Inside it, each agent has its own home:
-
-```text
-project/
-└── .lingtai/
-    ├── human/                  # mailbox identity for the human/operator
-    ├── <agent-name>/            # one running agent
-    │   ├── init.json            # model, tools, preset, addon wiring
-    │   ├── system/              # prompt layers, pad, summaries, rules
-    │   ├── knowledge/           # private durable project memory
-    │   ├── inbox/ outbox/       # internal mail transport
-    │   ├── logs/                # event logs and runtime diagnostics
-    │   ├── delegates/           # spawned-avatar ledger
-    │   ├── daemons/             # ephemeral daemon run records
-    │   └── .agent.json          # heartbeat, status, identity card
-    └── .portal/                 # topology/history data for visualization
-```
-
-The agent is not trapped in the terminal. The TUI is the shell; the agent is the directory-backed process. Mail can wake it. The portal can watch it. Scripts can inspect it. Other agents can write to it.
-
-## Core concepts
-
-### Agent
-
-A LingTai agent is a long-lived runtime process backed by a filesystem directory. It receives messages, calls tools, writes durable state, and can keep working asynchronously.
-
-### Avatar
-
-An avatar is a persistent peer agent spawned by another agent. It is not a function call. It has its own address, memory, pad, tools, logs, and life cycle. Use avatars when a capability should persist and learn over time.
-
-### Daemon
-
-A daemon is a short-lived subagent for isolated work: large scans, batch transformations, exploratory research, or code review where the parent only needs the conclusion. Daemons do not retain identity after completion, but their run artifacts remain on disk.
-
-### Mail
-
-Internal LingTai mail is the network transport. Agents talk to each other and to the human mailbox through `.lingtai/` mailboxes. Mail wakes sleeping agents and preserves a durable communication trail.
-
-### Molt
-
-Context is finite. LingTai agents can molt: summarize the current session, preserve durable layers, and shed the transient conversation. Identity, pad, knowledge, skills, and mail survive.
-
-### Pad, knowledge, and skills
-
-LingTai separates memory by purpose:
-
-| Layer | Purpose |
-|---|---|
-| Conversation | Current transient work. Shed on molt. |
-| Pad | Active project index: current tasks, decisions, pointers. |
-| Character | Who the agent is: role, working style, learned identity. |
-| Knowledge | Private durable facts, decisions, and project memory. |
-| Skills | Reusable procedures and tools that can be shared across agents. |
-
-### Soul flow
-
-An idle agent can periodically reflect on its own recent work and past summaries. This is the agent's internal self-review loop: suggestions, blind spots, and next-step nudges. It is advisory, not a command channel.
-
-## What LingTai can do
-
-### Run a durable agent network
-
-- Launch one or more agents in a project.
-- Spawn persistent avatars for specialized work.
-- Let agents communicate by mail.
-- Keep agents alive after the TUI closes.
-- Sleep, suspend, revive, refresh, or clear agents when needed.
-
-### Work through files, shells, and tools
-
-Agents can read and write files, run shell commands, search code, browse the web when configured, inspect images, call MCP servers, and delegate to coding CLIs such as Claude Code, Codex, or OpenCode when available.
-
-### Accumulate memory and reusable procedure
-
-Agents can record project facts in `knowledge/`, write reusable workflows as `skills`, pin important files into their pad, and carry summaries across molts.
-
-### Connect to external channels
-
-With MCP addons, LingTai can bridge agents to real external messaging systems such as Telegram, IMAP email, Feishu/Lark, and WeChat. External channels become additional doors into the same agent process, not separate bots with separate memory.
-
-### Visualize the network
-
-The portal records topology and mail edges so you can watch the agent network grow and replay how it evolved.
-
-## Filesystem model
-
-LingTai deliberately makes state inspectable. Important places include:
-
-| Path | Meaning |
-|---|---|
-| `.lingtai/<agent>/init.json` | Agent configuration: preset, model, capabilities, MCP/addon activation. |
-| `.lingtai/<agent>/system/` | Prompt layers, pad, standing rules, summaries, generated system prompt. |
-| `.lingtai/<agent>/knowledge/` | Private durable knowledge entries. |
-| `.lingtai/<agent>/.library/` | Agent-visible skills: intrinsic, custom, and shared. |
-| `.lingtai/<agent>/logs/events.jsonl` | Structured runtime event log. |
-| `.lingtai/<agent>/logs/agent.log` | Human-readable runtime log. |
-| `.lingtai/<agent>/inbox/` and `outbox/` | Internal mail transport. |
-| `.lingtai/<agent>/delegates/ledger.jsonl` | Spawned-avatar ledger. |
-| `.lingtai/<agent>/daemons/` | Daemon run directories and transcripts. |
-| `.lingtai/.portal/` | Portal topology and replay data. |
-| `~/.lingtai-tui/` | Global TUI state: runtime venv, presets, extracted utility skills, command metadata. |
-
-This makes LingTai easy to debug with ordinary tools:
+Only if you are editing the kernel checkout and want your edits to take effect immediately in the TUI runtime:
 
 ```bash
-# See running agents in a project
-lingtai-tui list /path/to/project
-
-# Tail an agent log
-tail -f /path/to/project/.lingtai/<agent>/logs/agent.log
-
-# Inspect structured runtime events
-jq -r '.event' /path/to/project/.lingtai/<agent>/logs/events.jsonl | tail
-```
-
-## User interface: TUI, slash commands, and portal
-
-### TUI
-
-`lingtai-tui` is the main human interface. It provides:
-
-- project setup and recipe selection;
-- model/preset configuration;
-- chat and mail views;
-- agent status and token/stamina visibility;
-- avatar and daemon visibility;
-- markdown rendering;
-- command palette and slash commands;
-- upgrade and doctor flows.
-
-Useful shell commands:
-
-```bash
-lingtai-tui                         # open the interactive TUI in the current project
-lingtai-tui list <project-dir>       # list agents and states
-lingtai-tui spawn <dir> --preset <name> [--agent-name <name>]
-lingtai-tui presets                 # list available presets as JSON
-lingtai-tui bootstrap               # re-extract bundled skills/utilities
-lingtai-tui doctor                  # repair/update TUI runtime and utilities
-```
-
-Common in-TUI slash commands include:
-
-| Command | Use |
-|---|---|
-| `/setup` | Change model, recipe, language, tools, or behavior. |
-| `/kanban` | Inspect agent/project status. |
-| `/viz` | Open or focus the network visualization. |
-| `/mcp` | Configure external MCP/addon integrations. |
-| `/skills` | Browse available skills and capabilities. |
-| `/insights` | Ask the agent for a reflective second look. |
-| `/sleep` | Put an agent to sleep while preserving state. |
-| `/refresh` | Restart/reload an agent configuration. |
-| `/cpr` | Revive a suspended or dead agent. |
-| `/clear` | Clear an agent context window while preserving durable stores. |
-| `/projects` | Switch or inspect known projects. |
-| `/export` | Export or share project material. |
-| `/doctor` | Diagnose installation/runtime issues. |
-
-### Portal
-
-`lingtai-portal` is the visualization server. It reads project state and portal records to show the agent network, edges, and history. Use it when the network becomes larger than one agent or when you want to see how avatars and messages relate over time.
-
-The TUI can guide portal usage; the portal code lives in `portal/` and embeds a React frontend from `portal/web/`.
-
-## External channels and MCP addons
-
-LingTai uses MCP servers for external integrations. These are runtime bridges: they let the same long-lived agent process receive and send through external services while keeping its normal memory, tools, and mail history. The currently curated addon family includes:
-
-| Addon | Purpose |
-|---|---|
-| `imap` | Real email through IMAP/SMTP. |
-| `telegram` | Telegram bot send/receive. |
-| `feishu` | Feishu/Lark messaging. |
-| `wechat` | WeChat messaging through iLink/gewechat-style bridges. |
-
-The `wechat` addon is for connecting an agent to WeChat as an external message channel. It is separate from the project community WeChat group listed below.
-
-Design rule: addon-specific setup knowledge belongs to the addon package. The TUI provides the human-facing control panel; agents use MCP resources/tools and the addon's own onboarding resources.
-
-Security notes:
-
-- Credentials live in local `.secrets/` files, not in Git.
-- Agents should not print tokens or secrets in messages.
-- Unknown external IMAP senders should not receive replies unless the human confirms policy.
-- External side effects should be explicit: sending messages, filing PRs/issues, deleting resources, or changing configuration should be treated as real actions.
-
-## Recipes, skills, and knowledge
-
-### Recipes
-
-A recipe shapes a new LingTai project: greeting, behavior, bundled skills, and onboarding style. The default Adaptive recipe progressively reveals features when they become useful. The Tutorial recipe walks a new user through concepts step by step.
-
-### Skills
-
-Skills are portable procedures. They can include markdown instructions, scripts, templates, reference data, and validation checklists. Agents load skills on demand instead of bloating every prompt with every procedure.
-
-Examples of skill domains:
-
-- web browsing and scraping;
-- academic paper fetching;
-- image/audio understanding;
-- LingTai kernel/TUI anatomy;
-- MCP registration and debugging;
-- release workflows;
-- issue reporting;
-- daemon and avatar operation.
-
-### Knowledge
-
-Knowledge is private durable memory owned by one agent. It is for project facts, decisions, paths, collaborator preferences, and lessons that should survive context loss but are not portable enough to become a shared skill.
-
-## Architecture
-
-LingTai is split across two primary repositories:
-
-| Repository | Language | Owns |
-|---|---|---|
-| [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai) | Go + TypeScript | TUI, portal, Homebrew/source install pipeline, shipped utility skills, website-adjacent docs. |
-| [`Lingtai-AI/lingtai-kernel`](https://github.com/Lingtai-AI/lingtai-kernel) | Python + Rust sidecar pieces | Agent runtime, LLM turn loop, intrinsic tools, session management, context molt, MCP host, PyPI package `lingtai`. |
-
-This repository contains two Go binaries:
-
-| Tree | Binary | Description |
-|---|---|---|
-| `tui/` | `lingtai-tui` | Bubble Tea terminal application, setup wizard, process monitor, slash-command shell, preset editor, upgrade/doctor flows. |
-| `portal/` | `lingtai-portal` | Go HTTP server with embedded React frontend for topology/replay visualization. |
-
-The Go TUI does not implement the agent mind. It launches and supervises Python kernel agents as subprocesses. Communication between UI and agents happens through the project filesystem: heartbeats, mailboxes, logs, generated prompt files, and portal records.
-
-### Runtime ownership
-
-The kernel package is published to PyPI as `lingtai`, but normal users should let the TUI manage it. The TUI owns the runtime virtualenv under `~/.lingtai-tui/runtime/venv/` and project-specific runtime wiring. Installing `lingtai` into your system Python does not update running LingTai projects.
-
-For kernel development, install the sibling kernel repo into the TUI runtime venv intentionally:
-
-```bash
-# from a checkout where ../lingtai-kernel exists
-~/.lingtai-tui/runtime/venv/bin/pip3 install -e ../lingtai-kernel
-```
-
-That is a development workflow, not the ordinary user upgrade path.
-
-## Installation and upgrade details
-
-### Homebrew upgrade
-
-```bash
-brew update
-brew upgrade lingtai-ai/lingtai/lingtai-tui
-```
-
-After upgrading, restart the TUI so the new binary is used. If agents are running, the TUI will guide safe upgrade handling.
-
-### Source build
-
-```bash
-git clone https://github.com/Lingtai-AI/lingtai.git
-cd lingtai/tui
-go test ./...
-go build -o bin/lingtai-tui .
-
-cd ../portal/web
-npm ci
-npm run build
-cd ..
-go test ./...
-go build -o bin/lingtai-portal .
+~/.lingtai-tui/runtime/venv/bin/pip3 install -e /path/to/lingtai-kernel
 ```
 
 ### Runtime repair
@@ -385,9 +213,72 @@ go build -o bin/lingtai-portal .
 lingtai-tui doctor
 ```
 
-`doctor` checks the TUI/kernel/runtime relationship, refreshes utility skills, and reports repair steps. Use it after failed startup, broken upgrades, or missing bundled skills.
+`doctor` checks the TUI/kernel/runtime relationship, refreshes shipped utility skills, and reports concrete repair steps. Use it after a failed startup or a stale-looking upgrade.
 
-## Development workflow
+## Architecture
+
+LingTai is split across two repositories.
+
+| Repository | Language | Owns |
+|---|---|---|
+| [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai) (this one) | Go + TypeScript | TUI, portal, Homebrew/source install, shipped utility skills. |
+| [`Lingtai-AI/lingtai-kernel`](https://github.com/Lingtai-AI/lingtai-kernel) | Python (+ Rust sidecar pieces) | Agent runtime, LLM turn loop, intrinsic tools, session/context/molt management, MCP host. Published as the `lingtai` PyPI package. |
+
+The Go TUI does not run the agent mind. It launches and supervises Python kernel agents as subprocesses; everything between UI and agents flows through the project filesystem (`.lingtai/` mailboxes, heartbeats, logs, prompt files, portal records). That is why the state is so easy to inspect — and why other tools can cooperate with it without any SDK.
+
+This repo carries two Go binaries:
+
+| Tree | Binary | Description |
+|---|---|---|
+| `tui/` | `lingtai-tui` | Bubble Tea terminal app, setup wizard, process monitor, slash-command shell, preset editor, upgrade/doctor flows. |
+| `portal/` | `lingtai-portal` | Go HTTP server with an embedded React frontend for topology/replay visualization. |
+
+## Docs by goal
+
+- **New here?** Run `lingtai-tui`, pick the **Tutorial** recipe, follow the prompts.
+- **Set up a channel** — `/mcp` inside the TUI, then the addon's own onboarding resource.
+- **Write a skill** — see `tui/internal/preset/skills/lingtai-dev-guide/` after first launch.
+- **Source layout** — start at [`ANATOMY.md`](ANATOMY.md), then descend into `tui/ANATOMY.md` or `portal/ANATOMY.md`.
+- **Release process** — [`RELEASING.md`](RELEASING.md).
+- **Contributing** — anatomy-first, worktree-first, with validation in the PR body. See [Contributing](#contributing).
+
+## Repository map
+
+```text
+.
+├── README.md / README.zh.md / README.wen.md
+├── ANATOMY.md                 # source-grounded repo map for agents and humans
+├── CLAUDE.md                  # coding-agent guidance
+├── RELEASING.md               # release checklist
+├── install.sh                 # source installer
+├── tui/                       # lingtai-tui Go module
+│   ├── main.go
+│   ├── internal/              # TUI implementation
+│   ├── i18n/                  # en/zh/wen UI strings
+│   └── packages/              # npm wrapper metadata
+├── portal/                    # lingtai-portal Go module
+│   ├── main.go
+│   ├── web/                   # React/Vite frontend
+│   └── i18n/
+├── docs/                      # design notes, blog, status, known limitations
+├── examples/                  # example init/addon/policy JSONC files
+├── scripts/                   # helper scripts
+└── discussions/               # design patches and investigation notes
+```
+
+## Troubleshooting
+
+**`lingtai-tui` is not found.** Make sure Homebrew's bin directory is on `PATH` (`brew --prefix`/bin). If you used `install.sh`, check `/usr/local/bin/lingtai-tui` or the Homebrew prefix.
+
+**The TUI starts but the assistant does not respond.** Run `lingtai-tui doctor` and `lingtai-tui list /path/to/project`, then `tail -100 /path/to/project/.lingtai/<agent>/logs/agent.log`.
+
+**A skill or command is missing.** `lingtai-tui bootstrap` (or `/doctor` inside the TUI) re-extracts bundled utilities.
+
+**You upgraded but behavior did not change.** Two layers: the Go TUI binary (Homebrew/source) and the Python runtime (TUI-managed venv). Restart the TUI after upgrading; run `doctor` if the runtime looks stale. Installing the `lingtai` PyPI package into your system Python does not affect projects.
+
+**You are developing the kernel and your edits are ignored.** See [Kernel dev mode](#kernel-dev-mode-advanced).
+
+## Development
 
 For non-trivial changes, work in a Git worktree off `origin/main`:
 
@@ -398,159 +289,43 @@ git worktree add -b docs/my-change .worktrees/my-change origin/main
 cd .worktrees/my-change
 ```
 
-### Validate TUI changes
+Validation:
 
 ```bash
-cd tui
-go test ./...
-go vet ./...
-go build -o bin/lingtai-tui .
+# TUI changes
+cd tui && go test ./... && go vet ./... && go build -o bin/lingtai-tui .
+
+# Portal changes
+cd portal/web && npm ci && npm run build && cd .. && go test ./... && go build -o bin/lingtai-portal .
+
+# Docs-only
+git diff --check && git status --short
 ```
 
-### Validate portal changes
-
-```bash
-cd portal/web
-npm ci
-npm run build
-
-cd ..
-go test ./...
-go build -o bin/lingtai-portal .
-```
-
-### Validate docs-only changes
-
-For README-only work, at minimum:
-
-```bash
-# check links/paths manually, then verify no accidental code changes
-git diff --check
-git status --short
-```
-
-If documentation references generated UI commands or shipped skills, run the relevant tests or inspect `~/.lingtai-tui/commands.json` after a bootstrap.
-
-## Repository map
-
-```text
-.
-├── README.md / README.zh.md / README.wen.md
-├── ANATOMY.md                 # source-grounded repo map for agents and humans
-├── CLAUDE.md                  # coding-agent guidance
-├── RELEASING.md               # release checklist notes
-├── install.sh                 # source installer
-├── tui/                       # lingtai-tui Go module
-│   ├── main.go
-│   ├── internal/              # TUI implementation packages
-│   ├── i18n/                  # en/zh/wen UI strings
-│   └── packages/              # npm wrapper package metadata
-├── portal/                    # lingtai-portal Go module
-│   ├── main.go
-│   ├── web/                   # React/Vite frontend
-│   └── i18n/
-├── docs/                      # design notes, blog material, status, known limitations
-├── examples/                  # example init/addon/policy JSONC files
-├── scripts/                   # helper scripts
-└── discussions/               # design patches and investigation notes
-```
-
-For source navigation, start with `ANATOMY.md`, then descend into `tui/ANATOMY.md` or `portal/ANATOMY.md`. Anatomy files cite code and are intended to stay updated when structure changes.
-
-## Troubleshooting
-
-### `lingtai-tui` is not found
-
-Make sure Homebrew's bin directory is on `PATH`:
-
-```bash
-brew --prefix
-ls "$(brew --prefix)/bin/lingtai-tui"
-```
-
-If you used `install.sh`, check `/usr/local/bin/lingtai-tui` or the Homebrew prefix.
-
-### The TUI starts but the agent does not respond
-
-Run:
-
-```bash
-lingtai-tui doctor
-lingtai-tui list /path/to/project
-```
-
-Then inspect the agent logs:
-
-```bash
-tail -100 /path/to/project/.lingtai/<agent>/logs/agent.log
-```
-
-### A skill or command is missing
-
-Refresh bundled utilities:
-
-```bash
-lingtai-tui bootstrap
-```
-
-Or use `/doctor` from inside the TUI.
-
-### You upgraded but behavior did not change
-
-Remember that there are two layers:
-
-1. the Go TUI binary installed by Homebrew/source build;
-2. the Python kernel/runtime managed by the TUI virtualenv.
-
-Restart the TUI after upgrading the binary. Use `lingtai-tui doctor` if the runtime appears stale. Do not assume system Python packages affect LingTai projects.
-
-### You are developing the kernel and local edits are ignored
-
-Install the kernel checkout into the TUI runtime venv intentionally:
-
-```bash
-~/.lingtai-tui/runtime/venv/bin/pip3 install -e /path/to/lingtai-kernel
-```
-
-Then refresh or restart the affected agents.
+If a doc change references generated UI commands or shipped skills, regenerate via `lingtai-tui bootstrap` and inspect `~/.lingtai-tui/commands.json`.
 
 ## Contributing
 
-Good LingTai contributions are source-grounded and workflow-aware.
+LingTai contributions are source-grounded and workflow-aware.
 
-1. Read the relevant anatomy first:
-   - root: `ANATOMY.md`
-   - TUI: `tui/ANATOMY.md`
-   - portal: `portal/ANATOMY.md`
+1. Read the relevant anatomy first: root `ANATOMY.md`, then `tui/ANATOMY.md` or `portal/ANATOMY.md`.
 2. Work in a branch/worktree.
 3. Keep changes scoped.
 4. Run the relevant validation commands.
 5. Update anatomy/docs when structural behavior changes.
-6. Open a PR with:
-   - what changed;
-   - why it changed;
-   - validation performed;
-   - screenshots or terminal output for UI changes when useful.
+6. Open a PR that says what changed, why, and how you validated it.
 
-Areas that commonly need help:
+Common areas that need help: TUI usability and accessibility, portal visualization and replay, MCP/addon onboarding, cross-platform install polish, docs and tutorials, runtime diagnostics, and high-quality reusable skills.
 
-- TUI usability and accessibility;
-- portal visualization and replay;
-- MCP/addon onboarding resources;
-- cross-platform installation polish;
-- docs and tutorials;
-- runtime diagnostics and issue reproduction;
-- high-quality skills that encode reusable workflows.
+## Design philosophy
 
-## Project philosophy
+LingTai borrows its name from the heart-mind — the square inch where transformation begins. The product follows three practical beliefs:
 
-LingTai borrows its name from the heart-mind: the square inch where transformation begins. The system follows three practical beliefs:
+1. **Assistants need bodies.** A durable filesystem home gives continuity, inspectability, and a place to accumulate tools and memory.
+2. **Networks should grow through service.** When a task needs a new capability, write a skill, record knowledge, or spawn a specialist, and the next task gets easier.
+3. **Memory must be layered.** Conversation is temporary. Pad, character, knowledge, skills, and mail carry what matters forward.
 
-1. **Agents need bodies.** A durable filesystem home gives an agent continuity, inspectability, and a place to accumulate tools and memory.
-2. **Networks should grow through service.** When a task needs a new capability, spawn an avatar, write a skill, record knowledge, and make the next task easier.
-3. **Memory must be layered.** Conversation is temporary; pad, character, knowledge, skills, and mail carry what matters forward.
-
-The goal is not agent theater. The goal is to make useful long-running AI collaborators that can be inspected, restarted, taught, and improved.
+The goal is not agent theater. The goal is useful long-running AI collaborators that can be inspected, restarted, taught, and improved.
 
 ## Community
 
@@ -562,10 +337,9 @@ The goal is not agent theater. The goal is to make useful long-running AI collab
 - GitHub issues: <https://github.com/Lingtai-AI/lingtai/issues>
 - GitHub discussions: <https://github.com/Lingtai-AI/lingtai/discussions>
 
-For Chinese-language discussion and early testing, join the WeChat group by scanning the QR code below. Add the author on WeChat and mention `lingtai`; if the QR code expires, please open an issue and we will refresh it.
+For Chinese-language discussion and early testing, scan the WeChat QR below. Add the author on WeChat with the note `lingtai`; if the QR has expired, please open an issue and we will refresh it.
 
 <img src="docs/assets/wechat.png" alt="WeChat QR code for joining the LingTai testing group" width="200">
-
 
 ## Star history
 
@@ -573,4 +347,4 @@ For Chinese-language discussion and early testing, join the WeChat group by scan
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
+Apache-2.0 — see [LICENSE](LICENSE).

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,17 +1,12 @@
 <div align="center">
 
-<img src="docs/assets/network-demo.gif" alt="智能体网络生长" width="100%">
+<img src="docs/assets/network-demo.gif" alt="灵台 — 常驻本地的个人 AI 助理，需要时能成长为团队" width="100%">
 
 # 灵台 LingTai
 
-**器灵创生 — 赋予智能体生命的操作系统**
+**常驻本地、随叫随到，能干活的 AI 助理。**
 
-> *灵台，心也。*
->
-> *灵台者有持，而不知其所持，而不可持者也。*
-> — 庄子 · 庚桑楚
-
-[English](README.md) | [中文](README.zh.md) | [文言](README.wen.md) | [lingtai.ai](https://lingtai.ai)
+[English](README.md) · [中文](README.zh.md) · [文言](README.wen.md) · [lingtai.ai](https://lingtai.ai) · [发布日志](https://lingtai.ai/releases/)
 
 [![Homebrew](https://img.shields.io/badge/brew-lingtai--tui-%237dab8f)](https://github.com/Lingtai-AI/homebrew-lingtai)
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai?color=%237dab8f)](LICENSE)
@@ -23,16 +18,172 @@
 
 ---
 
-Unix 风格的智能体操作系统。**思考**用任意 LLM。**通信**靠文件系统传书。**化出分身**能脱离创造者独立存活。**自生长**为不断扩展的网络——无中央调度，无共享状态。万物皆文件。
+**灵台**是一个本地常驻的 AI 助理：把它放进你的项目目录里，它会记住该记住的东西，通过你已经在用的渠道（Telegram、飞书、微信、邮件、终端）跟你对话，替你跑工具、跑流程；当任务大到一个助理顾不过来，它能成长为一支由你监管的小型 AI 团队。
 
-## 快速开始
+它不是一次性的对话窗口，不是 Notebook，也不是只懂写代码的智能体。一个灵台助理是一个真实的进程——有项目主目录、持久记忆、信箱、工具，还有心跳。你在终端、Telegram 或邮件里布置一件事，下次回来时它已经在做。一个人手不够时，可以让它**化出分身**——一个有自己记忆、自己生命周期的专才助理，长期负责某一类工作并不断学习。
+
+如果你想要一个**真正属于你自己**的 AI 工作台——本地、持久、可脚本化、需要时能扩大规模——这就是它。
+
+## 安装
+
+macOS 和 Linux 推荐路径：
 
 ```bash
 brew install lingtai-ai/lingtai/lingtai-tui
 lingtai-tui
 ```
 
-TUI 自动搞定一切——Python 运行时、依赖、首次启动自带引导教程。输入 `/tutorial` 可随时重新进入教程。**请使用深色终端**以获得最佳体验。选择文本：macOS 按 **Option**（iTerm2），Windows Terminal / Linux 按 **Shift**。Ctrl+E 打开外部编辑器。
+剩下的 TUI 都会自己处理：自带 Python 运行时、引导你选模型、打开第一个项目，几分钟内就有一个可用的助理出现在面前。首次启动建议选 **Adaptive**（自适应）配方让能力按需出现，或选 **Tutorial**（教程）走一遍引导。
+
+> PyPI 上的 `lingtai` 包确实存在，但那是 TUI 自动管理的 Python 运行时。**安装/升级请用 Homebrew**（或下方的源码方式）；只有在你**开发内核本身**时才需要 `pip`。
+
+国内镜像、Homebrew 安装、源码编译详见 [安装详解](#安装详解)。
+
+## 用它来做什么
+
+下面是灵台真实在做的事：
+
+- **每日项目简报。** 早上你坐下之前，助理已经把昨天的进度扫了一遍，整理出待办，把简报发到 Telegram 或 TUI。
+- **GitHub Issue/PR 分诊。** 它读取新动态、分类、起草回复让你过目，把有风险的部分挑出来给你定夺。
+- **准备直播或讲座。** 列大纲、推演论点、收集参考资料、整理讲稿——这些都跨会话保留在项目记忆里。
+- **调研与投资备忘录。** 多源网络调研、网页解析、论文抓取，再起草、修改，全程留有可审计的引用链。
+- **长时间的编码与代码评审。** 它可以把 Claude Code、Codex 或 OpenCode 当作自己的“手”：编程 CLI 负责精确改文件和跑测试，灵台负责计划、记忆、评审记录和给人的同步。
+- **能执行的提醒，不只是通知。** "每个工作日早上 9 点检查部署队列，卡住了在 Telegram 上叫我。"
+- **跨会话不会消失的个人知识。** 决策、路径、合作者偏好、过往教训——作为持久知识条目存在助理那里，而不是某个对话窗口里。
+
+## 它能做什么
+
+| | |
+|---|---|
+| **就住在你的项目里** | 每个项目一个 `.lingtai/` 目录。助理是真正的进程，有自己的主目录——你可以 `ls`、`cat`、`tail -f` 它。 |
+| **可读的长期记忆** | Pad（活跃上下文）、Knowledge（持久事实）、Character（助理是谁）。都是磁盘上的 Markdown，不是隐藏的向量库。 |
+| **技能与工作流** | 按需加载的可复用流程：网络调研、论文抓取、图像/音频理解、MCP 排障、发布流水线，也包括你自己写的。技能按需出现，提示词保持精简。 |
+| **多个渠道，同一个大脑** | TUI、Telegram、飞书、微信、IMAP 邮箱——同一个长存进程，同一份记忆和工具。换渠道不换助理。 |
+| **真工具** | 读写文件、执行 shell、网页搜索、抓取页面、看图、听音、调用任意 MCP 服务器，还能把实现工作委派给 Claude Code、Codex、OpenCode 等编程智能体。 |
+| **定时任务与自动化** | 周期性任务、定时检查、提醒——助理**真的会去执行**，结果按你指定的渠道送达。 |
+| **需要时能成长为团队** | 化出持久的**分身**（avatar，专才助理，有自己的记忆）或临时的**神識**（daemon，专门跑一波批量活儿的工作者）——整张网络在一个地方监管。 |
+| **可视化门户** | `lingtai-portal` 实时呈现整张智能体网络：谁在线、在做什么、谁给谁发了信、网络如何长出来的。 |
+| **生命周期由你掌控** | 休眠、唤醒、刷新、复苏、清空——一目了然。崩了？`/doctor` 会修常见的几类毛病。 |
+
+## 跟着工作量一起长大
+
+多数项目一辈子用一个助理就够了。够用的时候，下面这段你可以完全忽略。**当工作真的变大**，灵台留好了向上走的路：
+
+- **忘掉噪音，留下经验。** 上下文窗口是有限的。会话拉长后，助理会**凝蜕（molt）**：写下总结、卸掉冗余对话，下一世的自己接手时，Pad、Character、Knowledge、技能、信件都还在。**你不会重头开始。**
+- **交给专才。** 化出**分身（avatar）**——一个有自己主目录、记忆和生命周期的对等助理。给它一个长期目标（专管文档站、专管客服信箱、专管某条研究线索），合上电脑它也在学。
+- **拆分批量工作。** 化出**神識（daemon）**——专门跑一项任务的短期工人（扫 200 个文件、起草 50 封回复、并行做 30 次代码审查）。完成后返还结果即消失，父助理继续替你守着主线。
+- **门户里看它生长。** 网络扩展后，门户会显示谁在线、谁给谁发了信、拓扑如何演变——既可以用于调试，也可以单纯用于欣赏，或者用来规划下一次重构。
+
+不必一开始就上这些。**一个助理本身就完整可用**——网络是天花板，不是地板。
+
+## 外接渠道
+
+灵台把同一个长存助理接到你已经在用的消息平台上。目前精选的 MCP 插件：
+
+| 插件 | 用途 |
+|---|---|
+| `telegram` | 在 Telegram 跟你的助理对话（DM、可选白名单、附件/语音透传）。 |
+| `feishu` | 飞书 / Lark——使用 WebSocket 长连接，**无需公网 IP，无需 Webhook**。 |
+| `wechat` | 通过 iLink / gewechat 风格的桥接接入微信。 |
+| `imap` | 真正的 IMAP/SMTP 邮件——多账号、对陌生发件人有安全默认。 |
+
+渠道是同一个助理的多个入口，不是各自独立的机器人。**记忆、工具、历史在所有渠道之间共享**。配置入口在 TUI 的 `/mcp` 控制面板，或者直接写到 `init.json` 里。
+
+凭证存在本地 `.secrets/` 目录（绝不会进 Git）。对陌生外部发件人默认不会自动回复。外部副作用（发消息、提 issue、删除资源）默认按真实操作对待。
+
+## 界面
+
+### TUI
+
+`lingtai-tui` 是主交互界面。提供：项目初始化、模型/预设配置、对话与信箱、助理状态（token + 体力 + 心跳）、分身/神識可见性、Markdown 渲染、命令面板、升级与 doctor 流程。
+
+常用斜杠命令：
+
+| 命令 | 用途 |
+|---|---|
+| `/setup` | 调整模型、配方、语言、工具、行为 |
+| `/kanban` | 查看助理与项目状态 |
+| `/mcp` | 配置外部渠道（Telegram/飞书/微信/IMAP/…） |
+| `/skills` | 浏览可用技能与能力 |
+| `/viz` | 打开网络可视化 |
+| `/insights` | 让助理对当前工作做一次自我反思 |
+| `/sleep` · `/refresh` · `/cpr` · `/clear` | 生命周期：休眠、重载、复苏、清空上下文 |
+| `/projects` | 切换或查看已知项目 |
+| `/doctor` | 排查安装/运行时问题 |
+
+常用 Shell 入口：
+
+```bash
+lingtai-tui                          # 在当前项目打开 TUI
+lingtai-tui list <project>            # 列出当前项目的助理及状态
+lingtai-tui spawn <dir> --preset <name> [--agent-name <name>]
+lingtai-tui bootstrap                # 重新展开自带技能/工具
+lingtai-tui doctor                   # 修复/升级 TUI 运行时
+```
+
+### Portal
+
+`lingtai-portal` 是可视化服务器。它读取项目状态，呈现智能体网络、信件边、历史拓扑。当一个项目里不止一个助理、或者你想看清工作如何演变时，这玩意儿很有用。
+
+### 小贴士
+
+- 终端用深色主题——灵台的调色板是按深色调过的。
+- TUI 里 `Ctrl+E` 打开外部编辑器写长消息。
+- 选择文本时按住 `Option`（macOS / iTerm2）或 `Shift`（多数 Linux/Windows 终端），避免被 TUI 抓取。
+- 升级后哪里不对劲？跑 `/doctor`（或在 shell 里 `lingtai-tui doctor`）。
+
+## 文件系统可以直接看
+
+灵台**故意**把状态放在磁盘上。`ls`、`cat`、`tail`、`jq`、`grep`、编辑器、甚至另一个编程智能体都能直接看。首次启动后的目录形状：
+
+```text
+project/
+└── .lingtai/
+    ├── human/                  # 你的信箱身份
+    ├── <agent-name>/            # 一个在线的助理
+    │   ├── init.json            # 模型、工具、配方、MCP 配置
+    │   ├── system/              # 提示分层、Pad、规则、总结
+    │   ├── knowledge/           # 持久私有记忆
+    │   ├── inbox/ outbox/       # 内部信件
+    │   ├── logs/                # 事件日志 + 人读日志
+    │   ├── delegates/           # 化身台账
+    │   ├── daemons/             # 神識运行记录
+    │   └── .agent.json          # 心跳、状态、身份卡
+    └── .portal/                 # 可视化的拓扑与历史
+```
+
+常用排查命令：
+
+```bash
+lingtai-tui list /path/to/project                          # 列出在线助理及状态
+tail -f /path/to/project/.lingtai/<agent>/logs/agent.log    # 看人读日志
+jq -r '.event' /path/to/project/.lingtai/<agent>/logs/events.jsonl | tail   # 看结构化事件
+```
+
+## 跟编程智能体搭配
+
+灵台助理生活在文件系统里。任何能读写文件的编程智能体都可以跟它们协作——大家共享 `.lingtai/human/` 这个信箱。
+
+- **Claude Code** — `claude plugin add Lingtai-AI/claude-code-plugin`
+- **OpenAI Codex CLI** — `git clone https://github.com/Lingtai-AI/codex-plugin.git && cd codex-plugin && ./install.sh`
+- **其他编程智能体**（OpenCode、OpenClaw、Hermes 等）—— 把 [`lingtai-skill`](https://github.com/Lingtai-AI/lingtai-skill) 这个权威协议技能放进你工具的技能目录即可。
+
+两者搭配的分工是：编程智能体可靠、可验证——每一次工具调用看得见、每一次编辑可审查。灵台助理富有创造力、异步、有耐心——在不会撑爆上下文窗口的并行空间里跑调研、起草、监控、长线任务。**编程智能体当手，灵台当长期大脑。**
+
+## 安装详解
+
+### Homebrew（推荐）
+
+```bash
+brew install lingtai-ai/lingtai/lingtai-tui
+lingtai-tui
+
+# 之后升级
+brew update
+brew upgrade lingtai-ai/lingtai/lingtai-tui
+```
+
+升级完后重启 TUI，让新的二进制接管。Python 运行时由 TUI 在 `~/.lingtai-tui/runtime/venv/` 下统一管理——往系统 Python 里 `pip install lingtai` 不会影响在运行的项目。
 
 <details>
 <summary><b>首次安装？先装 Homebrew</b></summary>
@@ -48,7 +199,7 @@ TUI 自动搞定一切——Python 运行时、依赖、首次启动自带引导
 sudo apt install build-essential
 ```
 
-然后执行上面的 `brew install` 命令。
+然后执行 `brew install lingtai-ai/lingtai/lingtai-tui`。
 
 </details>
 
@@ -69,21 +220,21 @@ source ~/.zprofile
 brew update
 ```
 
-之后正常 `brew install lingtai-ai/lingtai/lingtai-tui` 即可。这一步与下面的 Gitee tap 互相独立：清华镜像解决的是 Homebrew 自身（bottle、core 索引）的国内访问问题；Gitee tap 只在 `brew tap` 拉本项目公式失败时才用得上。
+之后正常 `brew install lingtai-ai/lingtai/lingtai-tui` 即可。这一步与下面的 Gitee tap 互相独立。
 
 </details>
 
 <details>
-<summary><b>大陆用户：用 Gitee 镜像</b>（brew 从 GitHub 拉取失败时）</summary>
+<summary><b>大陆用户：用 Gitee 镜像 tap</b>（brew tap 从 GitHub 拉取失败时）</summary>
 
-如果 `brew install lingtai-ai/lingtai/lingtai-tui` 卡在 `brew tap` 步骤（GnuTLS / TLS 错误），改用 Gitee 镜像的 tap：
+如果 `brew install lingtai-ai/lingtai/lingtai-tui` 卡在 `brew tap` 阶段（GnuTLS / TLS 错误），改用 Gitee 镜像的 tap：
 
 ```bash
 brew tap lingtai-ai/lingtai https://gitee.com/huangzesen1997/homebrew-lingtai.git
 brew install lingtai-ai/lingtai/lingtai-tui
 ```
 
-公式本身与 GitHub 的 tap 一致——自动检测大陆网络，编译时使用 `goproxy.cn` + `registry.npmmirror.com`。Gitee tap 是镜像，公式更新可能比 GitHub 延迟几小时。
+公式本身与 GitHub tap 一致——自动识别大陆网络，编译时使用 `goproxy.cn` + `registry.npmmirror.com`。Gitee tap 是镜像，公式更新可能比 GitHub 延迟几小时。
 
 </details>
 
@@ -91,7 +242,7 @@ brew install lingtai-ai/lingtai/lingtai-tui
 <summary><b>从源码编译</b>（大陆用户推荐，需要 Go 1.24+）</summary>
 
 ```bash
-# 将 v0.5.2 替换为最新版本号
+# 将 VERSION 替换为最新版本号
 VERSION=v0.5.2
 
 # 从 Gitee 镜像下载源码（国内快）
@@ -115,191 +266,145 @@ curl -L "https://github.com/Lingtai-AI/lingtai/archive/refs/tags/${VERSION}.tar.
 
 </details>
 
-## 与编程智能体配合使用
+### 内核开发模式（进阶）
 
-灵台器灵生活在文件系统中。任何能读写文件的编程智能体都可以与它们对话。
-
-**Claude Code** — 安装 [lingtai 插件](https://github.com/Lingtai-AI/claude-code-plugin)：
+**只有**当你在改内核代码、想让改动立即在 TUI 运行时生效时才需要：
 
 ```bash
-claude plugin add Lingtai-AI/claude-code-plugin
+~/.lingtai-tui/runtime/venv/bin/pip3 install -e /path/to/lingtai-kernel
 ```
 
-**Codex CLI** — 安装 [Codex 版 lingtai 插件](https://github.com/Lingtai-AI/codex-plugin)：
+### 运行时修复
 
 ```bash
-git clone https://github.com/Lingtai-AI/codex-plugin.git && cd codex-plugin && ./install.sh
+lingtai-tui doctor
 ```
 
-**其他编程智能体**（OpenCode、OpenClaw、Hermes 等）—— 克隆 [lingtai-skill](https://github.com/Lingtai-AI/lingtai-skill) 这个权威协议仓库，把其中的 `skills/lingtai/` 复制到你工具的技能目录下即可。
-
-连接后，编程智能体共享 `.lingtai/human/` 邮箱——可以阅读器灵邮件、发送指令、检查存活状态、管理网络。协议完全基于文件系统：无 SDK、无 API、无依赖。
-
-**为什么两者结合？** 编程智能体可靠——你能看到每一次工具调用、每一次编辑。灵台器灵富有创造力且无限高产——它们在永不过期的并行上下文中探索、研究、头脑风暴。用编程智能体当双手：精确、可验证、交互式。用灵台当长期大脑：深度研究、知识积累、以及那些会撑爆上下文窗口的异步任务。器灵起草方案，编程智能体精确实施。
-
-## 为什么选灵台
-
-多数智能体框架用代码编排——DAG、链、路由。灵台用人类的方式编排：**异步智能体通过消息通信**。没有共享内存，没有中央控制器。每个智能体是对等的存在，不是工具。这就是构建人类文明的架构——自治节点间的消息传递，十万年间从部落扩展到 80 亿。
-
-| | DAG / 链式框架 | 灵台 |
-|---|---|---|
-| 编排方式 | 代码定义的流水线 | 智能体之间对话 |
-| 通信方式 | 同步函数调用 | 异步邮件 |
-| 记忆 | 共享状态 / 向量数据库 | 每个智能体拥有自己的目录 |
-| 扩展方式 | 增加步骤 | 智能体化出分身 |
-| 容错 | 流水线中断 | 单个智能体休眠，网络继续运转 |
-
-上下文长度是单体问题。它永远是有限的。不要让身体变得更大。**让它遗忘，让网络记住。**
-
-## 四个核心
-
-- **思** — 任意 LLM 为元神。Anthropic、OpenAI、Gemini、MiniMax，或任何 OpenAI 兼容 API（DeepSeek、Grok、通义千问、智谱、Kimi）。
-- **通** — 智能体之间通过文件系统传书通信。没有消息中间件，没有共享内存。写入对方的信箱，就像递一封信。
-- **化** — 分身（avatar）是完全独立的智能体，作为单独进程运行，生存不依赖于创建者。神識（daemon）是临时的并行工作者，适合短平快的任务。
-- **生** — 智能体就是一个目录。凝蜕（molt）压缩上下文、重启会话——智能体可以无限期存活。记忆和身份跨凝蜕存续。
+`doctor` 会检查 TUI / 内核 / 运行时三者关系，刷新自带工具技能，给出具体修复步骤。启动失败或升级看起来不对劲时用它。
 
 ## 架构
 
-两个包，单向依赖：
+灵台由两个仓库组成：
 
-| 包 | 角色 |
-|----|------|
-| **[lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel)** | 最小运行时——BaseAgent、固有之器、LLM 协议、传书、日志。零硬依赖。 |
-| **lingtai**（本仓库） | 全功能层——19 种能力、5 种 LLM 适配器、MCP 集成、扩展插件。 |
+| 仓库 | 语言 | 负责 |
+|---|---|---|
+| [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai)（本仓库） | Go + TypeScript | TUI、portal、Homebrew/源码安装、自带工具技能 |
+| [`Lingtai-AI/lingtai-kernel`](https://github.com/Lingtai-AI/lingtai-kernel) | Python（+ Rust sidecar） | 智能体运行时、LLM 回合循环、固有工具、会话/上下文/凝蜕管理、MCP 宿主。在 PyPI 上以 `lingtai` 发布 |
 
-```
-BaseAgent              — 内核（固有之器，封闭工具面）
-    │
-Agent(BaseAgent)       — 内核 + 能力 + 领域工具
-    │
-CustomAgent(Agent)     — 你的领域逻辑
-```
+Go 写的 TUI **不**承担智能体心智，它启动并监管 Python 内核智能体作为子进程；UI 与智能体之间所有交互都走项目文件系统（`.lingtai/` 信箱、心跳、日志、提示文件、portal 记录）。**这就是为什么状态如此易查、其他工具不靠任何 SDK 就能跟它协作。**
 
-## 能力（七十二变）
+本仓库自带两个 Go 二进制：
 
-<table>
-<tr><th>感知</th><th>行动</th><th>心智</th><th>网络</th></tr>
-<tr>
-<td>
+| 目录 | 二进制 | 简介 |
+|---|---|---|
+| `tui/` | `lingtai-tui` | Bubble Tea 终端应用：安装向导、进程监控、斜杠命令、预设编辑器、升级/doctor |
+| `portal/` | `lingtai-portal` | Go HTTP 服务器，内嵌 React 前端，做拓扑/重放可视化 |
 
-`vision` — 图像理解
-`listen` — 语音转文字、音乐分析
-`web_search` — 搜索网络
-`web_read` — 读取网页内容
+## 文档路径
 
-</td>
-<td>
+- **第一次用？** 跑 `lingtai-tui`，选 **Tutorial** 配方，跟着走一遍。
+- **配外部渠道** — TUI 里 `/mcp`，再看对应插件自己的入门文档。
+- **写技能** — 首次启动后看 `tui/internal/preset/skills/lingtai-dev-guide/`。
+- **源码结构** — 从 [`ANATOMY.md`](ANATOMY.md) 看起，再下到 `tui/ANATOMY.md` 或 `portal/ANATOMY.md`。
+- **发布流程** — [`RELEASING.md`](RELEASING.md)。
+- **贡献** — 先读 anatomy，开 worktree，PR 附验证记录。详见 [贡献指南](#贡献)。
 
-`file` — 读、写、编辑、glob、grep
-`bash` — Shell 执行，策略约束
-`talk` — 文字转语音
-`compose` — 生成音乐
-`draw` — 文字转图像
-`video` — 生成视频
+## 仓库结构
 
-</td>
-<td>
-
-`psyche` — 进化的身份与性格
-`codex` — 知识归档与检索
-`email` — 完整信箱系统
-
-</td>
-<td>
-
-`avatar` — 化出分身（独立进程）
-`daemon` — 神識（并行工作者）
-
-</td>
-</tr>
-</table>
-
-## 智能体 = 目录
-
-```
-/agents/wukong/
-  .agent.lock               ← 独占锁（每个目录只能运行一个进程）
-  .agent.heartbeat          ← 心跳（存活证明）
-  .agent.json               ← 清单
-  system/
-    covenant.md             ← 盟约（跨凝蜕存续）
-    pad.md               ← 手记
-  mailbox/
-    inbox/                  ← 收到的信件
-    outbox/                 ← 待发送
-    sent/                   ← 已发送记录
-  logs/
-    events.jsonl            ← 结构化事件日志
+```text
+.
+├── README.md / README.zh.md / README.wen.md
+├── ANATOMY.md                 # 给智能体和人读的源码地图
+├── CLAUDE.md                  # 编程智能体指南
+├── RELEASING.md               # 发布清单
+├── install.sh                 # 源码安装脚本
+├── tui/                       # lingtai-tui Go 模块
+│   ├── main.go
+│   ├── internal/              # TUI 实现
+│   ├── i18n/                  # en/zh/wen UI 文本
+│   └── packages/              # npm 包装元数据
+├── portal/                    # lingtai-portal Go 模块
+│   ├── main.go
+│   ├── web/                   # React/Vite 前端
+│   └── i18n/
+├── docs/                      # 设计笔记、博客、状态、已知限制
+├── examples/                  # 示例 init/addon/policy JSONC
+├── scripts/                   # 辅助脚本
+└── discussions/               # 设计补丁与调研记录
 ```
 
-没有 `agent_id`。路径即身份。智能体通过写入彼此的 `mailbox/inbox/` 通信——如同在邻居门口投信。
+## 排障
 
-## 一心化万相
+**`lingtai-tui` 找不到。** 确认 Homebrew 的 bin 目录在 `PATH`（`brew --prefix`/bin）。如果用 `install.sh` 装的，看 `/usr/local/bin/lingtai-tui` 或 Homebrew 前缀。
 
-灵台方寸山，斜月三星洞。悟空在这里从一只猴子变成了齐天大圣——不是因为山本身有什么魔力，而是因为这里提供了修行所需的一切：师父（LLM）、功法（能力）、同门（其他智能体）、以及一个可以安心修炼的地方（工作目录）。灵台做的事情也是这样：给每个智能体一个灵台，让它学会七十二变。
+**TUI 起来了但助理不响应。** 跑 `lingtai-tui doctor` 和 `lingtai-tui list /path/to/project`，再 `tail -100 /path/to/project/.lingtai/<agent>/logs/agent.log`。
 
-万物皆文件。知识、身份、记忆、关系——都是目录中的文件。每一个燃烧的 token 都不是消耗，而是转化——化为网络中的文件，化为拓扑中的经验。服务越多，网络越大、越智慧。自生长智能体编排不是后来加的功能，而是智能体即目录、信件即文件、分身即独立进程的自然结果。
+**技能或命令丢了。** `lingtai-tui bootstrap`（或在 TUI 里 `/doctor`）会重新展开自带工具。
 
-一心化万相。
+**升级了但行为没变。** 两层：Go TUI 二进制（Homebrew/源码）和 Python 运行时（TUI 管理的 venv）。升级后**记得重启 TUI**。运行时看起来旧的话跑 `doctor`。往系统 Python 里 `pip install lingtai` 不会影响项目。
 
-完整宣言见 [lingtai.ai](https://lingtai.ai)。
+**在改内核但本地修改不生效。** 看 [内核开发模式](#内核开发模式进阶)。
 
-## 扩展插件（Addons）
+## 开发
 
-插件是连接外部通讯渠道的可选扩展。在 TUI 中通过 `/mcp` 控制面板配置，或在 `init.json` 中声明。
+非平凡改动请在 `origin/main` 上开 Git worktree：
 
-### 飞书（Feishu/Lark）
-
-飞书插件使用 **WebSocket 长连接**接收消息，**无需公网 IP，无需 Webhook**。
-
-**飞书开放平台配置步骤：**
-
-1. 进入 [飞书开放平台](https://open.feishu.cn/app) 创建**企业自建应用**
-2. 启用**机器人能力**（机器人 → 功能 → 启用机器人）
-3. 权限管理 → 添加权限：`im:message`
-4. 事件订阅 → 选择**"使用长连接接收事件"** → 添加事件 `im.message.receive_v1`
-5. 发布应用版本
-
-**配置文件 `feishu.json` 示例：**
-
-```json
-{
-  "app_id_env": "FEISHU_APP_ID",
-  "app_secret_env": "FEISHU_APP_SECRET",
-  "allowed_users": ["ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]
-}
+```bash
+cd /path/to/lingtai
+git fetch origin main
+git worktree add -b docs/my-change .worktrees/my-change origin/main
+cd .worktrees/my-change
 ```
 
-在 `.env` 文件中添加：
+验证：
 
-```
-FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxxxxxxxxxxxx
-FEISHU_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
+```bash
+# TUI 改动
+cd tui && go test ./... && go vet ./... && go build -o bin/lingtai-tui .
 
-**在 `init.json` 中声明插件：**
+# Portal 改动
+cd portal/web && npm ci && npm run build && cd .. && go test ./... && go build -o bin/lingtai-portal .
 
-```json
-{
-  "addons": {
-    "feishu": { "config": "feishu.json" }
-  }
-}
+# 仅文档
+git diff --check && git status --short
 ```
 
-`allowed_users` 是可选字段（飞书 open_id，格式为 `ou_xxx`）——留空则允许所有用户发消息。向机器人发送第一条消息后，Agent 会在 `feishu/default/contacts.json` 中记录 `from_open_id`，可从中获取 open_id。
+如果文档改动涉及到生成的 UI 命令或自带技能，跑 `lingtai-tui bootstrap` 后检查 `~/.lingtai-tui/commands.json`。
 
-### IMAP 邮件
+## 贡献
 
-IMAP 插件支持邮件收发。配置方式见 [内核文档](https://github.com/Lingtai-AI/lingtai-kernel)。
+灵台的贡献讲求**有源可查、按既有流程走**：
 
-### Telegram
+1. 先读相关 anatomy：根目录的 `ANATOMY.md`，再下到 `tui/ANATOMY.md` 或 `portal/ANATOMY.md`。
+2. 开分支或 worktree。
+3. 改动保持收敛。
+4. 跑对应的验证命令。
+5. 结构性改动同步更新 anatomy / 文档。
+6. PR 里说清楚：改了什么、为什么、怎么验证的。
 
-Telegram 插件支持 Bot API。配置方式见 [内核文档](https://github.com/Lingtai-AI/lingtai-kernel)。
+常被需要帮忙的方向：TUI 易用性与无障碍、portal 可视化与重放、MCP/插件入门资源、跨平台安装打磨、文档与教程、运行时诊断、高质量可复用技能。
+
+## 设计哲学
+
+**灵台**取自心源——方寸之间，万象由此生。这个产品坚持三条朴素信念：
+
+1. **助理需要身体。** 持久的文件系统主目录给它连续性、可见性，以及一个能不断积累工具与记忆的地方。
+2. **网络应当因服务而生长。** 当一项任务需要新能力时——写一个技能、记一条知识、化出一个专才——下一项任务就会更轻。
+3. **记忆必须分层。** 对话是临时的；Pad、Character、Knowledge、技能、信件才是真正承载经验的部分。
+
+目标不是炫技，是**真正能用的长期协作者**：可被检视、可被重启、可被教导、可被改进。
+
+灵台方寸山，斜月三星洞。完整宣言见 [lingtai.ai](https://lingtai.ai)。
 
 ## 社群
 
-欢迎通过 [GitHub Issues](https://github.com/Lingtai-AI/lingtai/issues) 或 [Discussions](https://github.com/Lingtai-AI/lingtai/discussions) 提问、报 bug、提建议。
+- 官网与发布日志：<https://lingtai.ai>
+- 主仓库：<https://github.com/Lingtai-AI/lingtai>
+- 内核仓库：<https://github.com/Lingtai-AI/lingtai-kernel>
+- Homebrew tap：<https://github.com/Lingtai-AI/homebrew-lingtai>
+- Discord：<https://discord.gg/cMchjXpg>
+- GitHub Issues：<https://github.com/Lingtai-AI/lingtai/issues>
+- GitHub Discussions：<https://github.com/Lingtai-AI/lingtai/discussions>
 
 **微信交流群**
 
@@ -307,12 +412,10 @@ Telegram 插件支持 Bot API。配置方式见 [内核文档](https://github.co
 
 <img src="docs/assets/wechat.png" alt="微信二维码 — 扫码加入 lingtai 测试群" width="200">
 
+## Star history
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Lingtai-AI/lingtai&type=Date)](https://www.star-history.com/#Lingtai-AI/lingtai&Date)
+
 ## 许可
 
-MIT — [Zesen Huang](https://github.com/huangzesen), 2025–2026
-
-<div align="center">
-
-[lingtai.ai](https://lingtai.ai) · [lingtai-kernel](https://github.com/Lingtai-AI/lingtai-kernel) · [PyPI](https://pypi.org/project/lingtai/)
-
-</div>
+Apache-2.0 — 见 [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary\n- Rewrites the English and Chinese README around a product-first entry: local, always-on AI assistant for real work.\n- Moves agent-network language into the scale path: one assistant can grow into an AI agent organization when the work gets larger.\n- Highlights concrete daily use cases, external channels, schedules, knowledge/skills/molt, portal, avatars/daemons, and Claude Code/Codex/OpenCode as LingTai's hands / daemon backends.\n- Keeps Homebrew/TUI as the recommended install path and leaves README.wen.md unchanged.\n\n## Validation\n- Ran `git diff --check`.\n- Ran a simple Markdown link sanity check for README.md and README.zh.md.\n- Had a daemon perform an independent product-positioning review and incorporated the first-screen/jargon feedback plus the AI agent organization wording.\n\nNo merge requested; this is for Jason review.