### PR TITLE
Add SQLite log backfill migration

### DIFF
--- a/portal/internal/migrate/ANATOMY.md
+++ b/portal/internal/migrate/ANATOMY.md
@@ -9,10 +9,10 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 ## Components
 
 ### Registry (`migrate.go`)
-- `CurrentVersion` (`migrate.go:11`) — `35`. Must match the TUI's `CurrentVersion` exactly; the cross-binary contract requires lockstep bumps.
+- `CurrentVersion` (`migrate.go:11`) — `36`. Must match the TUI's `CurrentVersion` exactly; the cross-binary contract requires lockstep bumps.
 - `metaFile` struct (`migrate.go:13-15`) — `{"version": N}` shape of `.lingtai/meta.json`.
 - `Migration` type (`migrate.go:18-22`) — version + name + function.
-- `migrations` slice (`migrate.go:25-61`) — the append-only ordered list of all 35 migrations. **Real** entries have a named migration function; **no-op stubs** use `func(_ string) error { return nil }`.
+- `migrations` slice (`migrate.go:25-61`) — the append-only ordered list of all 36 migrations. **Real** entries have a named migration function; **no-op stubs** use `func(_ string) error { return nil }`.
 
 ### Real migrations (touch shared on-disk state)
 - **m001** — `topology-to-portal` (`m001_topology.go:9-31`). Portal-only: moves `topology.jsonl` from `.tui-asset/` to `.portal/`.
@@ -30,7 +30,7 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 - **m035** — `remove-brief` (`m035_remove_brief.go:13`). Portal mirror of the TUI's brief-cleanup migration: deletes `system/brief.md` for each agent, drops `brief`/`brief_file` from `init.json`, and drops `brief` from `human/settings.json`. Touches shared on-disk state — either binary may be the first to open a post-secretary-removal project, so identical logic lives in both packages.
 
 ### No-op stubs (preserve version slots)
-m005 (`soul-inquiry-source`), m007 (`normalize-ledger`), m008 (`recipe-state`), m009 (`procedures`), m010 (`legacy-addons-warn`), m011 (`session-backfill`), m012 (`session-resort`), m013 (`agora-rename`), m014 (`skills-groups`), m016 (`rename-pad-codex-library`), m017 (`rename-preset-caps`), m018 (`library-split`), m019 (`procedures-english-only`), m020 (`pseudo-agent-subscriptions`), m021 (`library-paths`), m022 (`recipe-lang-suffix`), m023 (`recipe-state-rename`), m024 (`add-active-preset`), m025 (`preset-description-object`), m032 (`cleanup-codex-oauth`), m033 (`strip-codex-api-key-env`), m034 (`library-skills-caps`). (m035 is real — listed above.)
+m005 (`soul-inquiry-source`), m007 (`normalize-ledger`), m008 (`recipe-state`), m009 (`procedures`), m010 (`legacy-addons-warn`), m011 (`session-backfill`), m012 (`session-resort`), m013 (`agora-rename`), m014 (`skills-groups`), m016 (`rename-pad-codex-library`), m017 (`rename-preset-caps`), m018 (`library-split`), m019 (`procedures-english-only`), m020 (`pseudo-agent-subscriptions`), m021 (`library-paths`), m022 (`recipe-lang-suffix`), m023 (`recipe-state-rename`), m024 (`add-active-preset`), m025 (`preset-description-object`), m032 (`cleanup-codex-oauth`), m033 (`strip-codex-api-key-env`), m034 (`library-skills-caps`). m036 (`sqlite-log-backfill`). (m035 is real — listed above.)
 
 All are `TUI-only` — they touch `.tui-asset/`, global preset files, the TUI's saved-preset directory, or TUI-side capability aliases. The portal doesn't care about these but must hold the version slot so `meta.json` version numbers match.
 

--- a/portal/internal/migrate/migrate.go
+++ b/portal/internal/migrate/migrate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CurrentVersion is the latest migration version compiled into this binary.
-const CurrentVersion = 35
+const CurrentVersion = 36
 
 type metaFile struct {
 	Version int `json:"version"`
@@ -58,6 +58,7 @@ var migrations = []Migration{
 	{Version: 33, Name: "strip-codex-api-key-env", Fn: func(_ string) error { return nil }},               // TUI-only: strips auto-stamped CODEX_N_API_KEY from saved codex presets
 	{Version: 34, Name: "library-skills-caps", Fn: func(_ string) error { return nil }},                   // TUI-only: rewrites codex/library capability keys to library/skills
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},                                           // shared: strips brief.md + brief_file/brief keys after secretary removal
+	{Version: 36, Name: "sqlite-log-backfill", Fn: func(_ string) error { return nil }},                   // TUI-only: optional command-line SQLite log backfill prompt/progress
 }
 
 // StampCurrent writes meta.json at CurrentVersion without running any

--- a/tui/ANATOMY.md
+++ b/tui/ANATOMY.md
@@ -29,7 +29,7 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
 ## Connections
 
 - **Called from:** the shell (`lingtai-tui`), Homebrew tap (`lingtai-ai/lingtai/lingtai-tui`), `install.sh`.
-- **Calls out:** `tui/internal/tui` (Bubble Tea app), `tui/internal/migrate` (per-project migrations), `tui/internal/globalmigrate` (per-machine migrations), `tui/internal/preset` (bootstrap + utility skill population), `tui/internal/process` (agent launch), `tui/internal/config` (global config, venv, upgrade checks), `tui/internal/postman` (mail relay daemon), `tui/internal/timemachine` (git history daemon).
+- **Calls out:** `tui/internal/tui` (Bubble Tea app), `tui/internal/migrate` (per-project migrations), `tui/internal/globalmigrate` (per-machine migrations), `tui/internal/preset` (bootstrap + utility skill population), `tui/internal/process` (agent launch), `tui/internal/processscan` (shared ps-based agent-process detection), `tui/internal/config` (global config, venv, upgrade checks), `tui/internal/postman` (mail relay daemon), `tui/internal/timemachine` (git history daemon).
 - **Bootstrap sequence** (`main.go:228-273`): on every launch, the TUI runs `config.MigrateLegacyLanguage` → `config.NeedsVenv` (for setup banner) → `config.EnsureRuntime` (create/repair venv if needed, then always run the non-blocking `CheckUpgrade`) → `config.EnsureAddons` → `preset.Bootstrap` → `tui.ExportCommandsJSON` → `maybePromptRustToolchain` (one-time optional Rust/Cargo prompt only when file search is on Python fallback and no cargo is on PATH). `CheckUpgrade` auto-upgrades the `lingtai` meta-package from PyPI, which bundles `lingtai-kernel` + all addon MCPs. See `tui/internal/config/ANATOMY.md`.
 - **`lingtai-tui doctor` subcommand** (`main.go:962-1002`): runs `config.RunDoctorUpdate` (`main.go:974`) with both `ForceTUI=true` and `ForcePython=true`, then refreshes presets, utility skills, and `commands.json`. The report includes native file-search sidecar / Rust toolchain diagnostics (`config.checkFileSearchNative`). Designed to be usable when the TUI cannot start (broken venv, missing migrations) — it never touches `.lingtai/`. Exit nonzero only on unrecoverable failures.
 - **Version flow:** `Makefile:4` injects `git describe` into `main.go:31`. On startup, `main.go:112` calls `tui.SetTUIVersion(version)`, which stores it for `/doctor` drift detection.
@@ -47,6 +47,7 @@ This folder is the self-contained Go module for the `lingtai-tui` terminal UI bi
   - `tui/internal/fs/` — filesystem readers for agent state
   - `tui/internal/config/` — bootstrap, venv, global config (`tui/internal/config/ANATOMY.md`)
   - `tui/internal/process/` — subprocess launcher
+  - `tui/internal/processscan/` — shared ps-based `lingtai run <agentDir>` process detection used by launch and migrations
   - `tui/internal/headless/` — JSON-emitting non-interactive CLI surface (`bootstrap`, `presets`, `spawn` subcommands)
   - `tui/internal/postman/` — UDP cross-internet mail relay
   - `tui/internal/timemachine/` — git-backed history daemon

--- a/tui/internal/migrate/ANATOMY.md
+++ b/tui/internal/migrate/ANATOMY.md
@@ -10,9 +10,9 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 
 | Symbol | Citation | Purpose |
 |--------|----------|---------|
-| `CurrentVersion` | `tui/internal/migrate/migrate.go:12` | latest version compiled into this binary (currently 35) |
+| `CurrentVersion` | `tui/internal/migrate/migrate.go:12` | latest version compiled into this binary (currently 36) |
 | `Migration` struct | `tui/internal/migrate/migrate.go:20` | `{Version int, Name string, Fn func(string) error}` |
-| `migrations` slice | `tui/internal/migrate/migrate.go:27` | ordered list of all m001..m035, append-only |
+| `migrations` slice | `tui/internal/migrate/migrate.go:27` | ordered list of all m001..m036, append-only |
 | `Run(lingtaiDir)` | `tui/internal/migrate/migrate.go:68` | reads `meta.json` → runs pending migrations → persists atomically |
 | `StampCurrent(lingtaiDir)` | `tui/internal/migrate/migrate.go:116` | stamps `CurrentVersion` without running migrations (fresh projects) |
 | `metaFile` struct | `tui/internal/migrate/migrate.go:14` | `{Version int, AddonCommentCleanupNotified bool}` |
@@ -25,6 +25,7 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 | m033 | `tui/internal/migrate/m033_strip_codex_api_key_env.go:21` | strip bogus `api_key_env` from saved codex presets |
 | m034 | `tui/internal/migrate/m034_library_skills_caps.go:23` | rename capability keys `codex`→`library` and `library`→`skills` |
 | m035 | `tui/internal/migrate/m035_remove_brief.go:13` | strip secretary-era brief plumbing: delete `system/brief.md`, drop `brief`/`brief_file` keys from each agent `init.json`, drop `brief` from `human/settings.json` |
+| m036 | `tui/internal/migrate/m036_sqlite_log_backfill.go:34` | optional command-line prompt/progress to backfill stopped agents' historical `events.jsonl` into derived `logs/log.sqlite`; safe to skip |
 
 Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002 is a no-op `func(_ string) error { return nil }` — it preserves the version slot.
 
@@ -32,7 +33,7 @@ Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002
 
 - **Called by** `tui/main.go` — Bootstrap runs `Run(lingtaiDir)` on startup; `InitProject` calls `StampCurrent` for fresh projects.
 - **Reads/writes** `<project>/.lingtai/meta.json` — version stamp shared with portal.
-- **Migrations touch** `init.json`, `presets/saved/`, `.portal/`, `.tui-asset/`, and agent subdirectories.
+- **Migrations touch** `init.json`, `presets/saved/`, `.portal/`, `.tui-asset/`, and agent subdirectories. m036 may also create/replace derived per-agent `logs/log.sqlite` when the user explicitly confirms the backfill prompt.
 - **Cross-binary contract with portal** — see `portal/internal/migrate/ANATOMY.md`. Each `CurrentVersion` bump must be mirrored. Migrations touching shared state (e.g. m029, m030) live in both packages. TUI-only migrations get a no-op stub in the portal registry.
 
 ## Composition
@@ -54,3 +55,4 @@ Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002
 - **Fresh-project shortcut.** `StampCurrent` writes `CurrentVersion` without running migrations — a freshly-generated project conforms to the current schema by construction. Running historical migrations against it would corrupt valid data (e.g. m016 renames `library→codex`, but a fresh project never had the old key).
 - **Version-check error.** `Run` returns `"data version N is newer than this binary supports (M); upgrade lingtai-tui"` when meta.json version exceeds `CurrentVersion`.
 - **Idempotent.** Migrations are designed to be re-runnable — they check preconditions and skip if already applied (e.g. m029 checks for existing `allowed` list).
+- **Optional sidecar backfill.** m036 is a TUI-only, user-confirmed command-line migration for the kernel SQLite log sidecar. It warns that large histories may take time, shows progress when confirmed, and emphasizes that skipping does not affect normal use because JSONL remains the source of truth.

--- a/tui/internal/migrate/ANATOMY.md
+++ b/tui/internal/migrate/ANATOMY.md
@@ -40,7 +40,7 @@ Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002
 
 - **Parent:** `tui/internal/` (no own anatomy)
 - **Subfolders:** none — flat package, one file per migration
-- **Siblings:** `tui/internal/preset/ANATOMY.md` — m029/m030 reference preset directory layout; `tui/internal/globalmigrate/` — per-machine analogue under `~/.lingtai-tui/`
+- **Siblings:** `tui/internal/preset/ANATOMY.md` — m029/m030 reference preset directory layout; `tui/internal/globalmigrate/` — per-machine analogue under `~/.lingtai-tui/`; `tui/internal/processscan/` — m036 reuses ps-based running-agent detection before attempting offline SQLite rebuilds
 
 ## State
 

--- a/tui/internal/migrate/m036_sqlite_log_backfill.go
+++ b/tui/internal/migrate/m036_sqlite_log_backfill.go
@@ -1,0 +1,408 @@
+package migrate
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/anthropics/lingtai-tui/internal/config"
+)
+
+// sqliteBackfillCandidate is a stopped agent whose historical JSONL event log
+// has not yet been explicitly backfilled into logs/log.sqlite.
+type sqliteBackfillCandidate struct {
+	AgentDir    string
+	Name        string
+	EventsPath  string
+	EventsBytes int64
+	Reason      string
+}
+
+// migrateSQLiteLogBackfill is a one-time, optional command-line migration for
+// the kernel's derived SQLite event-log sidecar. JSONL remains the source of
+// truth, so declining or failing this migration must not prevent normal use.
+func migrateSQLiteLogBackfill(lingtaiDir string) error {
+	if !sqliteHasAgentEvents(lingtaiDir) {
+		return nil
+	}
+	globalDir := globalTUIDir()
+	if globalDir == "" {
+		return nil
+	}
+	if config.NeedsVenv(globalDir) {
+		fmt.Println("Setting up Python environment for SQLite log backfill check...")
+	}
+	if _, err := config.EnsureRuntime(globalDir); err != nil {
+		fmt.Printf("warning: could not prepare Python runtime for SQLite log backfill: %v\n", err)
+		fmt.Println("Skipping this optional backfill; LingTai will continue to use JSONL logs normally.")
+		return nil
+	}
+	python := config.LingtaiCmd(globalDir)
+	if !sqliteRuntimeSupportsLogCLI(python) {
+		return nil
+	}
+
+	candidates, skippedRunning, err := sqliteDiscoverBackfillCandidates(python, lingtaiDir)
+	if err != nil {
+		fmt.Printf("warning: failed to inspect SQLite log backfill state: %v\n", err)
+		return nil
+	}
+	if len(candidates) == 0 {
+		if skippedRunning > 0 {
+			fmt.Printf("SQLite log backfill: %d running agent(s) skipped; stop them and run `lingtai-agent log rebuild <agent_dir>` if you want historical SQLite queries.\n", skippedRunning)
+		}
+		return nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Printf("SQLite log backfill available for %d stopped agent(s), but stdin is not interactive; continuing without backfill.\n", len(candidates))
+		return nil
+	}
+
+	sqlitePrintBackfillPrompt(os.Stdout, candidates, skippedRunning)
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	answer := strings.TrimSpace(strings.ToLower(line))
+	if answer != "y" && answer != "yes" {
+		fmt.Println("Skipping SQLite backfill. LingTai will start normally; new events still write to SQLite automatically.")
+		fmt.Println("You can backfill later with: lingtai-agent log rebuild <agent_dir>")
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Println("Starting SQLite log backfill migration...")
+	for i, c := range candidates {
+		fmt.Printf("\n[%d/%d] %s\n", i+1, len(candidates), c.Name)
+		if err := sqliteRunRebuildWithProgress(python, c, os.Stdout, os.Stderr); err != nil {
+			fmt.Fprintf(os.Stderr, "\nwarning: SQLite backfill failed for %s: %v\n", c.Name, err)
+			fmt.Fprintln(os.Stderr, "LingTai will continue to start normally; JSONL logs remain intact.")
+		}
+	}
+	fmt.Println("\nSQLite backfill migration complete. Continuing startup...")
+	return nil
+}
+
+func sqliteRuntimeSupportsLogCLI(python string) bool {
+	return exec.Command(python, "-m", "lingtai", "log", "--help").Run() == nil
+}
+
+func sqliteHasAgentEvents(lingtaiDir string) bool {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		agentDir := filepath.Join(lingtaiDir, entry.Name())
+		if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(agentDir, "logs", "events.jsonl"))
+		if err != nil || info.Size() == 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func sqlitePrintBackfillPrompt(w io.Writer, candidates []sqliteBackfillCandidate, skippedRunning int) {
+	totalBytes := int64(0)
+	for _, c := range candidates {
+		totalBytes += c.EventsBytes
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "SQLite log backfill migration is available for historical agent events.")
+	fmt.Fprintf(w, "Found %d stopped agent(s) with %s of events.jsonl history that has not been backfilled.\n", len(candidates), sqliteHumanBytes(totalBytes))
+	if skippedRunning > 0 {
+		fmt.Fprintf(w, "%d running agent(s) were skipped; backfill requires stopped/offline agents.\n", skippedRunning)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Warning: this migration can take a long time for large histories. It builds a derived logs/log.sqlite query index from existing logs/events.jsonl files.")
+	fmt.Fprintln(w, "If you confirm, LingTai will show a clear progress bar for each agent while it backfills.")
+	fmt.Fprintln(w, "Skipping is safe and does not affect normal LingTai use: JSONL remains the source of truth, and new events will still be written to SQLite automatically.")
+	fmt.Fprintln(w, "If you skip now, old events simply will not be available through SQLite queries until you backfill manually later.")
+	fmt.Fprintln(w)
+	for _, c := range candidates {
+		fmt.Fprintf(w, "  - %s (%s): %s\n", c.Name, sqliteHumanBytes(c.EventsBytes), c.Reason)
+	}
+	fmt.Fprint(w, "\nBackfill historical logs now? [y/N] ")
+}
+
+func sqliteDiscoverBackfillCandidates(python, lingtaiDir string) ([]sqliteBackfillCandidate, int, error) {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	var candidates []sqliteBackfillCandidate
+	skippedRunning := 0
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		agentDir := filepath.Join(lingtaiDir, entry.Name())
+		if _, err := os.Stat(filepath.Join(agentDir, "init.json")); err != nil {
+			continue
+		}
+		eventsPath := filepath.Join(agentDir, "logs", "events.jsonl")
+		info, err := os.Stat(eventsPath)
+		if err != nil || info.Size() == 0 {
+			continue
+		}
+		if sqliteIsAgentRunning(agentDir) {
+			skippedRunning++
+			continue
+		}
+		needs, reason := sqliteNeedsBackfill(python, agentDir, eventsPath)
+		if needs {
+			candidates = append(candidates, sqliteBackfillCandidate{
+				AgentDir:    agentDir,
+				Name:        entry.Name(),
+				EventsPath:  eventsPath,
+				EventsBytes: info.Size(),
+				Reason:      reason,
+			})
+		}
+	}
+	return candidates, skippedRunning, nil
+}
+
+func sqliteNeedsBackfill(python, agentDir, eventsPath string) (bool, string) {
+	sqlitePath := filepath.Join(agentDir, "logs", "log.sqlite")
+	if _, err := os.Stat(sqlitePath); err != nil {
+		return true, "SQLite sidecar is missing"
+	}
+	absEvents, err := filepath.Abs(eventsPath)
+	if err == nil {
+		if resolved, evalErr := filepath.EvalSymlinks(absEvents); evalErr == nil {
+			absEvents = resolved
+		}
+	} else {
+		absEvents = eventsPath
+	}
+
+	sql := fmt.Sprintf("SELECT byte_offset, line_no FROM import_cursors WHERE source_file = '%s'", strings.ReplaceAll(absEvents, "'", "''"))
+	cmd := exec.Command(python, "-m", "lingtai", "log", "query", agentDir, sql)
+	out, err := cmd.Output()
+	if err != nil {
+		return true, "SQLite sidecar could not be inspected"
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return true, "SQLite sidecar query returned unreadable output"
+	}
+	if len(rows) == 0 {
+		return true, "historical JSONL has not been backfilled yet"
+	}
+	if sqliteAsInt64(rows[0]["byte_offset"]) <= 0 {
+		return true, "backfill cursor is empty"
+	}
+	return false, ""
+}
+
+func sqliteIsAgentRunning(agentDir string) bool {
+	abs, err := filepath.Abs(agentDir)
+	if err != nil {
+		abs = agentDir
+	}
+	out, err := exec.Command("ps", "-eo", "pid=,command=").Output()
+	if err != nil {
+		return false
+	}
+	needle := "lingtai run " + abs
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "lingtai run") {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, needle+" ") || strings.HasSuffix(trimmed, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+type sqliteProgressLine struct {
+	Kind       string         `json:"kind"`
+	ByteOffset int64          `json:"byte_offset,omitempty"`
+	TotalBytes int64          `json:"total_bytes,omitempty"`
+	LineNo     int64          `json:"line_no,omitempty"`
+	Result     map[string]any `json:"result,omitempty"`
+}
+
+func sqliteRunRebuildWithProgress(python string, c sqliteBackfillCandidate, stdout, stderr io.Writer) error {
+	cmd := exec.Command(python, "-c", sqliteRebuildProgressScript, c.AgentDir)
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	updates := make(chan sqliteProgressLine, 16)
+	scanDone := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(pipe)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			var line sqliteProgressLine
+			if err := json.Unmarshal(scanner.Bytes(), &line); err == nil && line.Kind != "" {
+				updates <- line
+			}
+		}
+		close(updates)
+		scanDone <- scanner.Err()
+	}()
+
+	start := time.Now()
+	current := int64(0)
+	total := c.EventsBytes
+	lineNo := int64(0)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+
+	var waitErr error
+	waiting := true
+	for waiting {
+		select {
+		case update, ok := <-updates:
+			if !ok {
+				updates = nil
+				continue
+			}
+			if update.TotalBytes > 0 {
+				total = update.TotalBytes
+			}
+			if update.ByteOffset > current {
+				current = update.ByteOffset
+			}
+			if update.LineNo > 0 {
+				lineNo = update.LineNo
+			}
+			sqliteRenderProgress(stdout, current, total, lineNo, time.Since(start))
+		case <-ticker.C:
+			sqliteRenderProgress(stdout, current, total, lineNo, time.Since(start))
+		case waitErr = <-waitDone:
+			waiting = false
+		}
+	}
+	if scanErr := <-scanDone; scanErr != nil && waitErr == nil {
+		waitErr = scanErr
+	}
+	if waitErr != nil {
+		msg := strings.TrimSpace(errBuf.String())
+		if msg != "" {
+			return fmt.Errorf("%w: %s", waitErr, msg)
+		}
+		return waitErr
+	}
+	sqliteRenderProgress(stdout, total, total, lineNo, time.Since(start))
+	fmt.Fprintln(stdout)
+	return nil
+}
+
+func sqliteRenderProgress(w io.Writer, current, total, lineNo int64, elapsed time.Duration) {
+	if total <= 0 {
+		total = 1
+	}
+	if current > total {
+		current = total
+	}
+	width := 32
+	filled := int((current * int64(width)) / total)
+	if filled > width {
+		filled = width
+	}
+	bar := strings.Repeat("=", filled) + strings.Repeat("-", width-filled)
+	pct := float64(current) * 100 / float64(total)
+	fmt.Fprintf(w, "\r  [%s] %5.1f%%  %s/%s  lines:%d  elapsed:%s", bar, pct, sqliteHumanBytes(current), sqliteHumanBytes(total), lineNo, elapsed.Truncate(time.Second))
+}
+
+func sqliteHumanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for n >= div*unit && exp < 4 {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+func sqliteAsInt64(v any) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case int64:
+		return x
+	case int:
+		return int64(x)
+	case json.Number:
+		n, _ := x.Int64()
+		return n
+	case string:
+		n, _ := strconv.ParseInt(x, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+const sqliteRebuildProgressScript = `
+import json
+import sys
+from pathlib import Path
+
+from lingtai_kernel.services import logging as logmod
+
+agent_dir = Path(sys.argv[1]).resolve()
+source = agent_dir / "logs" / "events.jsonl"
+total = source.stat().st_size if source.exists() else 0
+orig_iter = logmod._iter_jsonl_events_with_offsets
+threshold = max(total // 200, 1024 * 1024)
+last_emit = 0
+
+def emit(byte_offset=0, line_no=0, kind="progress", result=None):
+    payload = {"kind": kind, "byte_offset": int(byte_offset), "total_bytes": int(total), "line_no": int(line_no)}
+    if result is not None:
+        payload["result"] = result
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+
+def iter_with_progress(path):
+    global last_emit
+    last_line = 0
+    for event, offset, next_offset, line_no in orig_iter(path):
+        last_line = line_no
+        if next_offset - last_emit >= threshold or next_offset >= total:
+            emit(next_offset, line_no)
+            last_emit = next_offset
+        yield event, offset, next_offset, line_no
+    if total and last_emit < total:
+        emit(total, last_line)
+
+logmod._iter_jsonl_events_with_offsets = iter_with_progress
+emit(0, 0)
+result = logmod.rebuild_sqlite_event_index(agent_dir)
+emit(total, result.get("line_no", 0), kind="result", result=result)
+`

--- a/tui/internal/migrate/m036_sqlite_log_backfill.go
+++ b/tui/internal/migrate/m036_sqlite_log_backfill.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/anthropics/lingtai-tui/internal/config"
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
 // sqliteBackfillCandidate is a stopped agent whose historical JSONL event log
@@ -31,6 +32,10 @@ type sqliteBackfillCandidate struct {
 // migrateSQLiteLogBackfill is a one-time, optional command-line migration for
 // the kernel's derived SQLite event-log sidecar. JSONL remains the source of
 // truth, so declining or failing this migration must not prevent normal use.
+// Returning nil intentionally stamps the project migration version even when the
+// user declines, stdin is non-interactive, or the existing Python runtime cannot
+// inspect/rebuild: this is an offer-at-most-once startup prompt, not a recurring
+// health check. The manual rebuild hint below keeps the skipped path recoverable.
 func migrateSQLiteLogBackfill(lingtaiDir string) error {
 	if !sqliteHasAgentEvents(lingtaiDir) {
 		return nil
@@ -40,15 +45,14 @@ func migrateSQLiteLogBackfill(lingtaiDir string) error {
 		return nil
 	}
 	if config.NeedsVenv(globalDir) {
-		fmt.Println("Setting up Python environment for SQLite log backfill check...")
-	}
-	if _, err := config.EnsureRuntime(globalDir); err != nil {
-		fmt.Printf("warning: could not prepare Python runtime for SQLite log backfill: %v\n", err)
-		fmt.Println("Skipping this optional backfill; LingTai will continue to use JSONL logs normally.")
+		fmt.Println("SQLite log backfill migration: Python runtime is not ready yet; skipping optional historical backfill for this one-time migration.")
+		sqlitePrintManualBackfillHint()
 		return nil
 	}
 	python := config.LingtaiCmd(globalDir)
 	if !sqliteRuntimeSupportsLogCLI(python) {
+		fmt.Println("SQLite log backfill migration: installed Python runtime does not expose `lingtai log`; skipping optional historical backfill.")
+		sqlitePrintManualBackfillHint()
 		return nil
 	}
 
@@ -65,6 +69,7 @@ func migrateSQLiteLogBackfill(lingtaiDir string) error {
 	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		fmt.Printf("SQLite log backfill available for %d stopped agent(s), but stdin is not interactive; continuing without backfill.\n", len(candidates))
+		sqlitePrintManualBackfillHint()
 		return nil
 	}
 
@@ -93,6 +98,11 @@ func migrateSQLiteLogBackfill(lingtaiDir string) error {
 
 func sqliteRuntimeSupportsLogCLI(python string) bool {
 	return exec.Command(python, "-m", "lingtai", "log", "--help").Run() == nil
+}
+
+func sqlitePrintManualBackfillHint() {
+	fmt.Println("Skipping is safe and does not affect normal LingTai use: JSONL logs remain the source of truth, and new events still write to SQLite automatically.")
+	fmt.Println("You can backfill historical logs later with: lingtai-agent log rebuild <agent_dir>")
 }
 
 func sqliteHasAgentEvents(lingtaiDir string) bool {
@@ -163,7 +173,7 @@ func sqliteDiscoverBackfillCandidates(python, lingtaiDir string) ([]sqliteBackfi
 		if err != nil || info.Size() == 0 {
 			continue
 		}
-		if sqliteIsAgentRunning(agentDir) {
+		if processscan.IsAgentRunning(agentDir) {
 			skippedRunning++
 			continue
 		}
@@ -195,6 +205,8 @@ func sqliteNeedsBackfill(python, agentDir, eventsPath string) (bool, string) {
 		absEvents = eventsPath
 	}
 
+	// The `lingtai log query` CLI accepts a SQL string (not bound parameters), so
+	// quote the local resolved source path using SQLite's single-quote doubling.
 	sql := fmt.Sprintf("SELECT byte_offset, line_no FROM import_cursors WHERE source_file = '%s'", strings.ReplaceAll(absEvents, "'", "''"))
 	cmd := exec.Command(python, "-m", "lingtai", "log", "query", agentDir, sql)
 	out, err := cmd.Output()
@@ -212,28 +224,6 @@ func sqliteNeedsBackfill(python, agentDir, eventsPath string) (bool, string) {
 		return true, "backfill cursor is empty"
 	}
 	return false, ""
-}
-
-func sqliteIsAgentRunning(agentDir string) bool {
-	abs, err := filepath.Abs(agentDir)
-	if err != nil {
-		abs = agentDir
-	}
-	out, err := exec.Command("ps", "-eo", "pid=,command=").Output()
-	if err != nil {
-		return false
-	}
-	needle := "lingtai run " + abs
-	for _, line := range strings.Split(string(out), "\n") {
-		if !strings.Contains(line, "lingtai run") {
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		if strings.Contains(trimmed, needle+" ") || strings.HasSuffix(trimmed, needle) {
-			return true
-		}
-	}
-	return false
 }
 
 type sqliteProgressLine struct {

--- a/tui/internal/migrate/m036_sqlite_log_backfill_test.go
+++ b/tui/internal/migrate/m036_sqlite_log_backfill_test.go
@@ -1,0 +1,122 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSQLiteDiscoverBackfillCandidatesMissingSidecar(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	agentDir := makeSQLiteBackfillAgentWithEvents(t, lingtaiDir, "agent-a")
+
+	candidates, skipped, err := sqliteDiscoverBackfillCandidates("/definitely/not/used", lingtaiDir)
+	if err != nil {
+		t.Fatalf("sqliteDiscoverBackfillCandidates: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped running = %d, want 0", skipped)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(candidates))
+	}
+	if candidates[0].AgentDir != agentDir {
+		t.Fatalf("candidate agent dir = %q, want %q", candidates[0].AgentDir, agentDir)
+	}
+	if !strings.Contains(candidates[0].Reason, "missing") {
+		t.Fatalf("reason = %q, want missing sidecar", candidates[0].Reason)
+	}
+}
+
+func TestSQLiteDiscoverBackfillCandidatesExistingSidecarWithoutCursor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake python shell script is POSIX-only")
+	}
+	lingtaiDir := t.TempDir()
+	agentDir := makeSQLiteBackfillAgentWithEvents(t, lingtaiDir, "agent-a")
+	if err := os.WriteFile(filepath.Join(agentDir, "logs", "log.sqlite"), []byte("placeholder"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	python := fakeSQLitePython(t, "printf '[]\\n'")
+
+	candidates, skipped, err := sqliteDiscoverBackfillCandidates(python, lingtaiDir)
+	if err != nil {
+		t.Fatalf("sqliteDiscoverBackfillCandidates: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped running = %d, want 0", skipped)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(candidates))
+	}
+	if !strings.Contains(candidates[0].Reason, "not been backfilled") {
+		t.Fatalf("reason = %q, want missing backfill cursor", candidates[0].Reason)
+	}
+}
+
+func TestSQLiteDiscoverBackfillCandidatesExistingSidecarWithCursor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake python shell script is POSIX-only")
+	}
+	lingtaiDir := t.TempDir()
+	agentDir := makeSQLiteBackfillAgentWithEvents(t, lingtaiDir, "agent-a")
+	if err := os.WriteFile(filepath.Join(agentDir, "logs", "log.sqlite"), []byte("placeholder"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	python := fakeSQLitePython(t, "printf '[{\"byte_offset\":12,\"line_no\":1}]\\n'")
+
+	candidates, skipped, err := sqliteDiscoverBackfillCandidates(python, lingtaiDir)
+	if err != nil {
+		t.Fatalf("sqliteDiscoverBackfillCandidates: %v", err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped running = %d, want 0", skipped)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates = %d, want 0", len(candidates))
+	}
+}
+
+func TestSQLiteBackfillPromptCopyEmphasizesCostProgressAndSafeSkip(t *testing.T) {
+	var b strings.Builder
+	sqlitePrintBackfillPrompt(&b, []sqliteBackfillCandidate{{Name: "agent-a", EventsBytes: 2048, Reason: "SQLite sidecar is missing"}}, 1)
+	out := b.String()
+	for _, want := range []string{
+		"can take a long time",
+		"Skipping is safe",
+		"does not affect normal LingTai use",
+		"Backfill historical logs now? [y/N]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func makeSQLiteBackfillAgentWithEvents(t *testing.T, lingtaiDir, name string) string {
+	t.Helper()
+	agentDir := filepath.Join(lingtaiDir, name)
+	logsDir := filepath.Join(agentDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), []byte(`{"manifest":{"agent_name":"`+name+`"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(`{"type":"test","ts":1}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return agentDir
+}
+
+func fakeSQLitePython(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "python")
+	content := "#!/bin/sh\nset -eu\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/tui/internal/migrate/migrate.go
+++ b/tui/internal/migrate/migrate.go
@@ -9,7 +9,7 @@ import (
 
 // CurrentVersion is the latest migration version compiled into this binary.
 // IMPORTANT: when bumping, also bump portal/internal/migrate/migrate.go (see CLAUDE.md).
-const CurrentVersion = 35
+const CurrentVersion = 36
 
 type metaFile struct {
 	Version                     int  `json:"version"`
@@ -60,6 +60,7 @@ var migrations = []Migration{
 	{Version: 33, Name: "strip-codex-api-key-env", Fn: migrateStripCodexAPIKeyEnv},
 	{Version: 34, Name: "library-skills-caps", Fn: migrateLibrarySkillsCaps},
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},
+	{Version: 36, Name: "sqlite-log-backfill", Fn: migrateSQLiteLogBackfill},
 }
 
 // Run executes all pending migrations on the given .lingtai/ directory.

--- a/tui/internal/process/check.go
+++ b/tui/internal/process/check.go
@@ -1,88 +1,33 @@
 package process
 
-import (
-	"os/exec"
-	"path/filepath"
-	"strconv"
-	"strings"
-)
+import "github.com/anthropics/lingtai-tui/internal/processscan"
 
 // AgentProcess is a single `lingtai run <agentDir>` process discovered by
 // scanning `ps`. The command field holds the trimmed ps line; pid is parsed
 // from the leading column. Used by FindAgentProcesses /
 // TerminateAgentProcesses so callers can both detect and act on lingering
 // interpreters.
-type AgentProcess struct {
-	PID     int
-	Command string
-}
+type AgentProcess = processscan.AgentProcess
 
-// parsePSOutput extracts AgentProcess records from `ps -eo pid=,command=`
-// output that match `lingtai run <abs>`. Split out from FindAgentProcesses so
-// the parsing logic is unit-testable without shelling out to ps.
-//
-// The ps output format is: leading whitespace, PID, single space, command
-// line (which itself may contain spaces). We split on the first whitespace
-// run to separate pid from command.
 func parsePSOutput(out, abs string) []AgentProcess {
-	needle := "lingtai run " + abs
-	var results []AgentProcess
-	for _, line := range strings.Split(out, "\n") {
-		if !strings.Contains(line, "lingtai run") {
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		// Match either `... lingtai run <abs> ...` (additional args follow)
-		// or `... lingtai run <abs>` at end-of-line. Without this guard we
-		// would also match `lingtai run <abs>-suffix`, picking up sibling
-		// agent dirs that share a prefix.
-		if !(strings.Contains(trimmed, needle+" ") || strings.HasSuffix(trimmed, needle)) {
-			continue
-		}
-		// Split off the leading pid column. ps emits "  1234 python ..." so
-		// Fields collapses leading whitespace; we take the first token.
-		fields := strings.Fields(trimmed)
-		if len(fields) < 2 {
-			continue
-		}
-		pid, err := strconv.Atoi(fields[0])
-		if err != nil {
-			continue
-		}
-		results = append(results, AgentProcess{PID: pid, Command: trimmed})
-	}
-	return results
+	return processscan.ParsePSOutput(out, abs)
 }
 
 // FindAgentProcesses returns all running `lingtai run <agentDir>` processes
 // visible to the current user via `ps -eo pid=,command=`. Empty slice on
 // error or no match. Use IsAgentRunning if you only need a boolean.
 func FindAgentProcesses(agentDir string) []AgentProcess {
-	abs, err := filepath.Abs(agentDir)
-	if err != nil {
-		abs = agentDir
-	}
-	out, err := exec.Command("ps", "-eo", "pid=,command=").Output()
-	if err != nil {
-		return nil
-	}
-	return parsePSOutput(string(out), abs)
+	return processscan.FindAgentProcesses(agentDir)
 }
 
 // IsAgentRunning returns true if any `python -m lingtai run <agentDir>`
 // (or `lingtai-agent run <agentDir>`) process exists on this machine.
-// Independent of `.agent.heartbeat`: even
-// when the heartbeat file is missing or stale (a previous agent mid-teardown,
-// a crashed process, an old kernel version that unlinked the file early),
-// the lingering Python interpreter is still visible in `ps` and we can
-// refuse to spawn a duplicate.
+// Independent of `.agent.heartbeat`: even when the heartbeat file is missing or
+// stale, the lingering Python interpreter is still visible in `ps`.
 //
-// Used by LaunchAgent as a hard gate. Callers that want fast-path liveness
-// from the heartbeat freshness should use fs.IsAlive instead — this scan
-// shells out to ps and is meant for the launch boundary, not hot paths.
+// Used by LaunchAgent as a hard gate. Callers that want fast-path liveness from
+// the heartbeat freshness should use fs.IsAlive instead — this scan shells out to
+// ps and is meant for the launch boundary, not hot paths.
 func IsAgentRunning(agentDir string) bool {
-	return len(FindAgentProcesses(agentDir)) > 0
+	return processscan.IsAgentRunning(agentDir)
 }

--- a/tui/internal/processscan/ANATOMY.md
+++ b/tui/internal/processscan/ANATOMY.md
@@ -1,0 +1,25 @@
+# processscan
+
+> **Maintenance:** see `lingtai-tui-anatomy` (at `~/.lingtai-tui/utilities/lingtai-tui-anatomy/SKILL.md`). Update this file in the same commit as code changes.
+
+`processscan` is the small, dependency-light subprocess detector for running LingTai agents. It exists outside `tui/internal/process` so packages that cannot import `process` (notably `migrate`, because `process` imports `migrate` during fresh-project stamping) can still reuse one tested `ps` matching implementation instead of copying it.
+
+## Components
+
+| Component | File | Purpose |
+|---|---|---|
+| `AgentProcess` | `tui/internal/processscan/check.go:10` | parsed `ps` record for a matching `lingtai run <agentDir>` interpreter |
+| `ParsePSOutput` | `tui/internal/processscan/check.go:20` | unit-testable parser for `ps -eo pid=,command=` output; guards against prefix-sibling false positives |
+| `FindAgentProcesses` | `tui/internal/processscan/check.go:60` | shells out to `ps`, normalizes the requested agent dir, and parses matches |
+| `IsAgentRunning` | `tui/internal/processscan/check.go:75` | boolean convenience wrapper used by launch/migration boundaries |
+
+## Composition
+
+- **Upstream callers:** `tui/internal/process/check.go` re-exports this package for existing launch/refresh callers; `tui/internal/migrate/m036_sqlite_log_backfill.go` calls it directly to skip running agents before attempting offline SQLite rebuilds.
+- **External dependency:** host `ps -eo pid=,command=`. Errors fail closed to “no match”; the kernel workdir lock remains the authoritative safety gate for SQLite rebuilds.
+
+## Invariants
+
+1. Match only exact `lingtai run <absAgentDir>` command arguments, allowing extra trailing args but rejecting prefix siblings such as `<absAgentDir>-old`.
+2. Keep this package free of imports back into TUI logic packages (`migrate`, `process`, `tui`) so it remains safe for low-level reuse.
+3. Treat `ps` detection as advisory. Callers that need correctness under races must also rely on their own hard gate (for example, the kernel offline workdir lock in SQLite rebuilds).

--- a/tui/internal/processscan/check.go
+++ b/tui/internal/processscan/check.go
@@ -1,0 +1,78 @@
+package processscan
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// AgentProcess is a single `lingtai run <agentDir>` process discovered by
+// scanning `ps`. The command field holds the trimmed ps line; pid is parsed
+// from the leading column. Used by FindAgentProcesses so callers can both
+// detect and act on lingering interpreters.
+type AgentProcess struct {
+	PID     int
+	Command string
+}
+
+// ParsePSOutput extracts AgentProcess records from `ps -eo pid=,command=`
+// output that match `lingtai run <abs>`. Split out from FindAgentProcesses so
+// the parsing logic is unit-testable without shelling out to ps.
+//
+// The ps output format is: leading whitespace, PID, single space, command
+// line (which itself may contain spaces). We split on the first whitespace
+// run to separate pid from command.
+func ParsePSOutput(out, abs string) []AgentProcess {
+	needle := "lingtai run " + abs
+	var results []AgentProcess
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "lingtai run") {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// Match either `... lingtai run <abs> ...` (additional args follow)
+		// or `... lingtai run <abs>` at end-of-line. Without this guard we
+		// would also match `lingtai run <abs>-suffix`, picking up sibling
+		// agent dirs that share a prefix.
+		if !(strings.Contains(trimmed, needle+" ") || strings.HasSuffix(trimmed, needle)) {
+			continue
+		}
+		// Split off the leading pid column. ps emits "  1234 python ..." so
+		// Fields collapses leading whitespace; we take the first token.
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		results = append(results, AgentProcess{PID: pid, Command: trimmed})
+	}
+	return results
+}
+
+// FindAgentProcesses returns all running `lingtai run <agentDir>` processes
+// visible to the current user via `ps -eo pid=,command=`. Empty slice on
+// error or no match. Use IsAgentRunning if you only need a boolean.
+func FindAgentProcesses(agentDir string) []AgentProcess {
+	abs, err := filepath.Abs(agentDir)
+	if err != nil {
+		abs = agentDir
+	}
+	out, err := exec.Command("ps", "-eo", "pid=,command=").Output()
+	if err != nil {
+		return nil
+	}
+	return ParsePSOutput(string(out), abs)
+}
+
+// IsAgentRunning returns true if any `python -m lingtai run <agentDir>`
+// (or `lingtai-agent run <agentDir>`) process exists on this machine.
+func IsAgentRunning(agentDir string) bool {
+	return len(FindAgentProcesses(agentDir)) > 0
+}


### PR DESCRIPTION
## Summary

- add TUI project migration `m036_sqlite_log_backfill` in the existing `tui/internal/migrate` registry
- bump shared migration version to 36 and add the matching portal no-op slot
- prompt users in the `lingtai-tui` command-line migration flow to optionally backfill stopped agents' historical `logs/events.jsonl` into derived `logs/log.sqlite`
- warn that the migration can take a long time, emphasize that skipping is safe and does not affect normal use, and show a byte/line progress bar when confirmed

## Notes

- Running agents are skipped because kernel `rebuild_sqlite_event_index` requires an offline/stopped-agent workdir lock.
- The migration is optional/fail-open: JSONL remains the source of truth; SQLite is a derived sidecar; decline/failure does not block startup.
- The migration uses the TUI-managed Python runtime and the kernel log CLI/API introduced by the merged SQLite log-index work.

## Tests

```bash
cd tui
go test ./internal/migrate
env -u LINGTAI_DEV_ROOT go test ./...
cd ../portal
go test ./internal/migrate
```

Also checked `git diff --check`.

`go test ./...` under `portal/` still requires built frontend assets (`embed.go: pattern all:web/dist: no matching files found`), so this PR verifies the touched portal migration package directly.
