### PR TITLE
Add OpenCode swiss-knife subskill

### DIFF
--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -12,16 +12,20 @@ description: >
   (3) openai-codex — OpenAI Codex CLI for local coding agent with remote
   control, Vim editing, plugins, hooks, and Chrome browser integration.
   Read when the human asks to use OpenAI Codex or compare with Claude Code;
-  (4) token-usage — token usage tracking and cost reporting;
-  (5) html-report — checklist + template for producing standalone HTML
+  (4) opencode — OpenCode CLI for local coding-agent runs with 75+ provider
+  routing, non-interactive `opencode run`, reusable `opencode serve`, custom
+  agents, MCP integration, and session resume/fork support. Read when the
+  human asks to use OpenCode as a CLI tool or compare coding CLIs;
+  (5) token-usage — token usage tracking and cost reporting;
+  (6) html-report — checklist + template for producing standalone HTML
   research memos, dashboards, and audit reports (with MathJax math
   rendering, anchor navigation, print styles). Read when the human asks
   for an HTML deliverable, especially one containing equations;
-  (6) xiaomi-mimo — discovery protocol for the Xiaomi MiMo (小米MiMo)
+  (7) xiaomi-mimo — discovery protocol for the Xiaomi MiMo (小米MiMo)
   LLM provider: one API key, OpenAI/Anthropic-compatible endpoint, family
   of ~9 models spanning long-context reasoning, multimodal chat, and TTS.
   Read when the human asks to use or configure Xiaomi MiMo;
-  (7) zhipu-coding-plan — pointer for the Zhipu / Z.AI GLM coding-plan
+  (8) zhipu-coding-plan — pointer for the Zhipu / Z.AI GLM coding-plan
   subscription that unlocks vision, web search, web page reading, and
   zread MCP servers from one API key. Read when the human asks about
   Zhipu / Z.AI / BigModel credentials or the coding-plan subscription.
@@ -31,7 +35,7 @@ description: >
   `lingtai-tui bootstrap` in a shell — that re-extracts shipped skills
   to ~/.lingtai-tui/utilities/ without restarting the TUI — then call
   `system(action="refresh")` to pick them up.
-version: 1.6.0
+version: 1.7.0
 tags: [utilities, umbrella, toolkit]
 ---
 
@@ -47,6 +51,7 @@ A collection of small, useful skills. Each sub-skill lives in its own folder und
 | [claude-code](claude-code/) | Delegate code implementation, patch writing, docs, and refactoring to Claude Code CLI | Human asks to write code, generate patches, refactor, or delegate implementation work |
 | [minimax-cli](minimax-cli/) | MiniMax CLI for text-to-image, text-to-video, music generation, TTS, and vision | Human asks for image/video/music generation, TTS narration, or vision tasks |
 | [openai-codex](openai-codex/) | OpenAI Codex CLI — local coding agent with remote control, Vim editing, plugins, hooks, and Chrome extension | Human asks to use OpenAI Codex CLI, compare with Claude Code, or needs browser integration |
+| [opencode](opencode/) | OpenCode CLI — provider-flexible local coding agent with `opencode run`, `serve`, custom agents, MCPs, and session resume/fork | Human asks to use OpenCode as a CLI tool, compare coding CLIs, or script a provider-flexible coding agent |
 | [html-report](html-report/) | Checklist + standalone HTML template (MathJax, nav, print styles) for research memos, dashboards, audit reports | Human asks for an HTML deliverable — especially one with equations, where `<pre>`/`<code>` won't render LaTeX |
 | [xiaomi-mimo](xiaomi-mimo/) | Discovery protocol for Xiaomi MiMo (小米MiMo) — OpenAI/Anthropic-compatible LLM provider with one key unlocking ~9 models (reasoning, multimodal, TTS) | Human asks to use or configure Xiaomi MiMo |
 | [zhipu-coding-plan](zhipu-coding-plan/) | Pointer for the Zhipu / Z.AI GLM coding-plan subscription (one key → vision, web search, web read, zread MCP servers) | Human asks about Zhipu / Z.AI / BigModel credentials or the coding-plan subscription |

--- a/tui/internal/preset/skills/swiss-knife/opencode/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/opencode/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: opencode
+description: >
+  Manual (not a tool) for OpenCode CLI — an open-source terminal coding agent
+  that runs locally, supports 75+ LLM providers through Models.dev, and can be
+  scripted with `opencode run` or served through a reusable headless backend.
+  Read this when the human asks to use OpenCode as a CLI tool, compare it with
+  Claude Code or Codex, configure providers/agents/MCPs, or run non-interactive
+  coding tasks from bash.
+version: 1.0.0
+tags: [cli, code, delegation, opencode, automation]
+---
+
+# OpenCode CLI — Local Coding Agent
+
+OpenCode is an open-source coding agent with a terminal UI plus scriptable CLI commands. Use it when you want a provider-flexible local coding agent that can run one-off prompts, reuse a headless server to avoid cold starts, or work with custom OpenCode agents and MCP servers.
+
+Official docs: <https://opencode.ai/docs/cli/>
+
+## Prerequisites
+
+```bash
+# Official install script
+curl -fsSL https://opencode.ai/install | bash
+
+# Or install with a Node.js package manager
+npm install -g opencode-ai      # also works with bun/pnpm/yarn
+
+# Confirm it is on PATH
+opencode --version
+```
+
+Authenticate at least one provider before relying on it for work:
+
+```bash
+opencode auth login          # interactive provider selection
+opencode auth login -p openai
+opencode auth list           # or: opencode auth ls
+```
+
+OpenCode stores provider credentials in `~/.local/share/opencode/auth.json`. It also loads provider keys from the environment and from a project `.env` file.
+
+## CLI vs Long-Running Work
+
+This sub-skill is about using OpenCode directly from the shell. For longer work, first check whether your active LingTai daemon schema explicitly supports an OpenCode backend; otherwise supervise OpenCode through bash/worktrees.
+
+### CLI (`opencode run ...` via bash)
+
+A single synchronous subprocess. You wait for it to finish, review its transcript/diff, and decide the next step in your own context.
+
+**Use the CLI when:**
+- The task is **one-off** and bounded: a small edit, quick code review, narrow documentation pass, or a question about a repo.
+- You want the result **threaded back into your current reasoning** instead of launching a background worker.
+- You need a specific OpenCode flag, provider/model, agent, attached file, or headless-server attachment.
+- You only need **one** OpenCode run at a time.
+
+**Examples:**
+
+```bash
+# Quick answer without opening the TUI
+opencode run "Explain how this parser is structured"
+
+# Run in a specific repository
+opencode run --dir /path/to/repo "Fix the typo in README.md"
+
+# Pick a provider/model explicitly (format: provider/model)
+opencode run --model openai/gpt-5.5 "Review the auth module for race conditions"
+
+# Ask for raw JSON events, useful for scripts
+opencode run --format json "Summarize the public API changes"
+```
+
+### Long-running work from the CLI
+
+This sub-skill documents OpenCode as a direct CLI. Some LingTai installations may also expose external coding CLIs through `daemon` backends, but do not assume an OpenCode daemon is available unless the active `daemon` tool schema explicitly lists `backend="opencode"`.
+
+If `backend="opencode"` is available, use the daemon for parallel or long-running worker tasks that should be tracked outside your current context. If it is not available, keep OpenCode CLI work supervised from bash:
+
+- create a disposable git worktree;
+- run `opencode run --dir /path/to/worktree ...` with a generous bash timeout or async bash job;
+- periodically inspect `git diff`, captured stdout/stderr, and test output yourself;
+- commit only after review.
+
+**Quick decision rule:**
+
+| Signal | Pick |
+|--------|------|
+| “I need the answer inline now” | **CLI** |
+| “Use this exact OpenCode model/agent/flag” | **CLI** |
+| “I want to attach to a warm OpenCode server” | **CLI** |
+| “Run three disjoint coding tasks at once” | **Daemon only if `backend="opencode"` is present; otherwise separate supervised worktrees/async bash jobs** |
+| “This may take 15+ minutes and produce a branch/diff” | **Daemon if supported; otherwise supervised CLI in a worktree** |
+
+## Key Commands
+
+| Command | Purpose |
+|---------|---------|
+| `opencode` or `opencode [project]` | Start the terminal UI in the current/project directory |
+| `opencode run [message...]` | Run non-interactively and exit |
+| `opencode serve` | Start a headless HTTP server for API/attached runs |
+| `opencode attach [url]` | Attach a terminal to an existing backend server |
+| `opencode auth login/list/logout` | Manage provider credentials |
+| `opencode agent create/list` | Manage custom OpenCode agents |
+| `opencode mcp add/list/auth/logout/debug` | Manage MCP servers |
+| `opencode models` / `opencode models --refresh` | List or refresh provider/model cache |
+| `opencode github install/run` | Install or run the GitHub agent workflow |
+
+## Important `opencode run` Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--dir DIR` | Run in a directory (or remote path when using `--attach`) |
+| `--model PROVIDER/MODEL` / `-m` | Choose model, e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4-5` |
+| `--variant VALUE` | Provider-specific reasoning effort / model variant |
+| `--agent NAME` | Use a named OpenCode agent |
+| `--file PATH` / `-f` | Attach file(s) to the message |
+| `--format json` | Emit raw JSON events for scripts |
+| `--continue` / `-c` | Continue the last session |
+| `--session ID` / `-s` | Continue a specific session |
+| `--fork` | Fork when continuing a session |
+| `--share` | Share the session |
+| `--title TITLE` | Set session title |
+| `--attach URL` | Attach the run to an existing `opencode serve` backend |
+| `--thinking` | Show thinking blocks if the provider exposes them |
+| `--dangerously-skip-permissions` | Auto-approve permissions not explicitly denied. Dangerous; only use in an externally sandboxed worktree. |
+
+Run `opencode run --help` before depending on flags in automation; OpenCode is moving quickly.
+
+## Recommended Patterns
+
+### 1. Safe one-off read/review
+
+```bash
+cd /path/to/repo
+opencode run "Review the uncommitted diff for correctness. Do not modify files. Return actionable findings only."
+```
+
+### 2. Small automated edit in a worktree
+
+```bash
+git worktree add -b fix/readme-typo /tmp/fix-readme origin/main
+cd /tmp/fix-readme
+opencode run --dangerously-skip-permissions \
+  "Fix the README typo, run relevant formatting checks, and summarize the diff."
+```
+
+Review the diff yourself before committing.
+
+### 3. Warm server for repeated calls
+
+Starting a fresh OpenCode run can cold-boot MCP servers. For many short calls, keep a server warm:
+
+```bash
+# Terminal/session 1: save the generated password where another shell can read it
+pwfile=/tmp/opencode-server-password
+openssl rand -hex 16 > "$pwfile"
+chmod 600 "$pwfile"
+OPENCODE_SERVER_PASSWORD="$(cat "$pwfile")" opencode serve --port 4096
+
+# Terminal/session 2: read the same password
+opencode run --attach http://localhost:4096 \
+  --password "$(cat /tmp/opencode-server-password)" \
+  --dir /path/to/repo \
+  "Explain async/await in this codebase"
+```
+
+### 4. Continue or fork a session
+
+```bash
+# Continue the last session
+opencode run --continue "Now add tests for the change"
+
+# Continue a specific session
+opencode run --session <session-id> "Apply the simpler approach we discussed"
+
+# Fork instead of mutating the prior session
+opencode run --session <session-id> --fork "Try an alternative implementation"
+```
+
+### 5. Custom agent with constrained permissions
+
+```bash
+mkdir -p .opencode/agent
+opencode agent create \
+  --path .opencode/agent/reviewer.md \
+  --description "Read-only reviewer for docs and code diffs" \
+  --mode primary \
+  --permissions read,grep,glob
+
+opencode run --agent reviewer "Review this diff; do not edit files."
+```
+
+`opencode agent create` denies any omitted permission in the generated agent frontmatter. Available permissions include `bash`, `read`, `edit`, `glob`, `grep`, `webfetch`, `task`, `todowrite`, `websearch`, `lsp`, and `skill`.
+
+## Best Practices
+
+1. **Use a clean worktree.** OpenCode can edit files. Isolate risky runs in `/tmp/...` worktrees so you can inspect or discard changes safely.
+2. **Prefer read-only prompts for review.** Say “Do not modify files” when you only want findings.
+3. **Set `--dir` explicitly.** Avoid running against the wrong repository when the bash working directory is ambiguous.
+4. **Use `--format json` for scripts.** Parse events rather than scraping terminal formatting.
+5. **Use `opencode serve` for batches.** A warm server avoids repeated MCP startup costs for many small calls.
+6. **Treat `--dangerously-skip-permissions` like `rm -rf` privileges.** Only use it inside an externally sandboxed repo/worktree, and still review the diff.
+7. **Refresh models when a provider changes.** `opencode models --refresh` updates the local cache from Models.dev.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `opencode: command not found` | Install with `npm install -g opencode-ai`, then confirm `$(npm prefix -g)/bin` is on PATH (or use your package manager's global-bin command). |
+| No provider/model available | Run `opencode auth login`, check environment variables / project `.env`, then `opencode models --refresh`. |
+| Wrong repository edited | Stop, inspect `git diff`, and rerun with explicit `--dir /path/to/repo` in a disposable worktree. |
+| Permission prompts hang automation | Prefer a custom agent with explicit permissions; if externally sandboxed, use `--dangerously-skip-permissions`. |
+| Slow repeated calls | Use `opencode serve` and `opencode run --attach http://localhost:4096 ...`. |
+| Session continuation goes to wrong thread | Use `--session <id>` instead of `--continue`; add `--fork` for experiments. |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.


### PR DESCRIPTION
## Summary
- add an `opencode` swiss-knife subskill for using OpenCode as a CLI coding agent
- document install/auth, `opencode run`, `opencode serve --attach`, sessions, custom agents, MCP commands, and safe worktree usage
- update the swiss-knife umbrella description/table to route OpenCode CLI requests

## Validation
- frontmatter parse check for swiss-knife + opencode skill
- local markdown link check for swiss-knife skills
- `git diff --check`
- `cd tui && go test ./internal/preset`
- Codex xhigh review run twice; addressed findings about daemon-backend wording, server password sharing, deterministic custom-agent recipe, and npm PATH troubleshooting

Note: `cd tui && go test ./...` was also attempted, but the existing `internal/config` devmode tests failed because this machine has dev checkouts visible without `LINGTAI_DEV_ROOT`; unrelated packages including `internal/preset` passed.