### PR TITLE
docs: add headless Telegram bot swiss-knife workflow

### DIFF
--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -7,8 +7,10 @@ description: >
   opencode for coding CLIs; minimax-cli for MiniMax media/TTS/vision; token-usage
   for token/cost reports; html-report for standalone browser deliverables;
   xiaomi-mimo for Xiaomi MiMo provider discovery; zhipu-coding-plan for Z.AI /
-  BigModel coding-plan capabilities. This parent is the route map; each nested
-  reference is self-contained under `reference/<name>/SKILL.md`.
+  BigModel coding-plan capabilities; headless-telegram-bot for provisioning
+  fresh LingTai Telegram bot projects from `lingtai-tui spawn`. This parent is
+  the route map; each nested reference is self-contained under
+  `reference/<name>/SKILL.md`.
 version: 2.0.0
 tags: [utilities, umbrella, toolkit, nested-skill]
 ---
@@ -73,6 +75,13 @@ nested_references:
       Nested swiss-knife reference for the Zhipu / Z.AI / BigModel coding-plan
       subscription. Read this when the human asks about Zhipu credentials or the
       plan's vision, web search, web-read, and zread MCP capabilities.
+  - name: headless-telegram-bot
+    location: reference/headless-telegram-bot/SKILL.md
+    description: >
+      Nested swiss-knife reference and helper for creating a fresh LingTai
+      Telegram bot project headlessly from `lingtai-tui spawn`, wiring
+      `.secrets/telegram.json`, `addons`, and `mcp.telegram`, then verifying the
+      bot with token-safe checks.
 ```
 
 ## Routing table
@@ -87,6 +96,7 @@ nested_references:
 | Produce standalone HTML reports/dashboards/memos | `reference/html-report/SKILL.md` |
 | Discover/configure Xiaomi MiMo | `reference/xiaomi-mimo/SKILL.md` |
 | Discover/configure Zhipu / Z.AI coding-plan capabilities | `reference/zhipu-coding-plan/SKILL.md` |
+| Create or automate a headless LingTai Telegram bot project | `reference/headless-telegram-bot/SKILL.md` |
 
 ## How to use this router
 

--- a/tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: headless-telegram-bot
+description: >
+  Create a fresh LingTai project for a Telegram bot without opening the TUI:
+  spawn the project with `lingtai-tui spawn`, write the Telegram MCP sidecar
+  secret, activate `addons` and `mcp.telegram` in init.json, then refresh or
+  relaunch and verify the bot safely. Use when the human asks to provision or
+  automate a LingTai Telegram bot project.
+version: 1.0.0
+tags: [utilities, telegram, mcp, headless, bootstrap]
+---
+
+# Headless Telegram Bot Project
+
+This utility creates a new LingTai project from the supported headless entrypoint, then applies the Telegram MCP wiring that the bot needs. Do not fabricate `.lingtai/` by hand: always start from `lingtai-tui spawn`.
+
+## Inputs
+
+- `PROJECT_DIR`: new project directory. It must not already contain `.lingtai/`.
+- `PRESET`: saved or template preset name, for example `minimax`.
+- `AGENT_NAME`: agent directory/name to create under `.lingtai/`.
+- `LANGUAGE`: one of `en`, `zh`, or `wen`.
+- `TELEGRAM_BOT_TOKEN`: bot token from `@BotFather`. Keep it in the environment or a local prompt, never in shell history, logs, git, or docs.
+- `ALLOWED_USERS`: comma-separated Telegram numeric user IDs allowed to talk to the bot.
+
+## Preferred Helper
+
+Run the bundled helper from an installed utility bundle:
+
+```bash
+read -rsp 'Telegram bot token: ' TELEGRAM_BOT_TOKEN; export TELEGRAM_BOT_TOKEN; echo
+python3 ~/.lingtai-tui/utilities/swiss-knife/reference/headless-telegram-bot/scripts/create_telegram_bot_project.py \
+  --project-dir /path/to/new-project \
+  --preset minimax \
+  --agent-name my-telegram-agent \
+  --language en \
+  --allowed-users 123456789
+```
+
+Or run it from a source checkout:
+
+```bash
+read -rsp 'Telegram bot token: ' TELEGRAM_BOT_TOKEN; export TELEGRAM_BOT_TOKEN; echo
+python3 tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot/scripts/create_telegram_bot_project.py \
+  --project-dir /path/to/new-project \
+  --preset minimax \
+  --agent-name my-telegram-agent \
+  --language en \
+  --allowed-users 123456789
+```
+
+The helper:
+
+1. Runs `lingtai-tui spawn <dir> --preset <name> --agent-name <name> --language <code>`.
+2. Writes `<agent_dir>/.secrets/telegram.json` with mode `0600`.
+3. Adds `telegram` to top-level `addons`.
+4. Adds top-level `mcp.telegram` using the local LingTai runtime Python and `LINGTAI_TELEGRAM_CONFIG=.secrets/telegram.json`.
+5. Touches `<agent_dir>/.refresh` so a running agent reloads the updated config. If refresh is not enough for the installed runtime, relaunch the agent.
+
+The helper intentionally reads `TELEGRAM_BOT_TOKEN` from the environment instead of a command-line flag, because argv can be captured by shell history and process monitors. Its output redacts token-like values.
+
+## Manual Workflow
+
+Use this when you need to inspect or adapt each step. Replace placeholders, but never paste a real token into committed files or chat transcripts.
+
+```bash
+lingtai-tui spawn "$PROJECT_DIR" \
+  --preset "$PRESET" \
+  --agent-name "$AGENT_NAME" \
+  --language "$LANGUAGE"
+```
+
+The command prints JSON containing `agent_dir`. Treat that as the only supported source for the agent path.
+
+Create the sidecar secret:
+
+```json
+{
+  "accounts": [
+    {
+      "alias": "main",
+      "bot_token": "<redacted-telegram-bot-token>",
+      "allowed_users": [123456789]
+    }
+  ],
+  "poll_interval": 1.0
+}
+```
+
+Save it as:
+
+```text
+<agent_dir>/.secrets/telegram.json
+```
+
+Then set restrictive permissions:
+
+```bash
+chmod 700 "<agent_dir>/.secrets"
+chmod 600 "<agent_dir>/.secrets/telegram.json"
+```
+
+Patch `<agent_dir>/init.json` so these top-level keys exist:
+
+```json
+{
+  "addons": ["telegram"],
+  "mcp": {
+    "telegram": {
+      "type": "stdio",
+      "command": "~/.lingtai-tui/runtime/venv/bin/python",
+      "args": ["-m", "lingtai_telegram"],
+      "env": {
+        "LINGTAI_TELEGRAM_CONFIG": ".secrets/telegram.json"
+      }
+    }
+  }
+}
+```
+
+If `addons` or `mcp` already exists, merge instead of replacing unrelated entries. The `command` should point to the local LingTai runtime Python. On unusual installs, resolve it with:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+print(Path.home() / ".lingtai-tui" / "runtime" / "venv" / "bin" / "python")
+PY
+```
+
+## Refresh Or Relaunch
+
+After writing `init.json` and `.secrets/telegram.json`, refresh the running agent:
+
+```bash
+touch "<agent_dir>/.refresh"
+```
+
+If the Telegram listener does not appear in logs within a minute, stop and relaunch the agent from the project:
+
+```bash
+lingtai-tui list "$PROJECT_DIR"
+cd "$PROJECT_DIR"
+lingtai-tui
+```
+
+Use the local process controls available in your environment if you need a hard restart. Do not start a second copy of the same agent without checking `lingtai-tui list` first.
+
+## Verification Checklist
+
+Run these checks before handing the bot to a user:
+
+- `lingtai-tui list "$PROJECT_DIR"` shows the new agent and no duplicate copy.
+- Bot API `getMe` succeeds. Redact the token in commands and logs:
+
+```bash
+python3 - <<'PY'
+import json, os, urllib.request
+token = os.environ["TELEGRAM_BOT_TOKEN"]
+with urllib.request.urlopen(f"https://api.telegram.org/bot{token}/getMe", timeout=15) as r:
+    data = json.load(r)
+print(json.dumps({"ok": data.get("ok"), "result": data.get("result", {})}, indent=2))
+print("token: <redacted>")
+PY
+```
+
+- The agent log shows the Telegram MCP/listener starting, without printing the bot token.
+- Slash commands still work in the TUI, especially `/refresh`, `/doctor`, and a simple chat prompt.
+- From an allowed Telegram account, send `/start` to the bot and confirm the agent responds.
+- From a non-allowed account, confirm access is denied or ignored.
+
+## Security Rules
+
+- Never commit `.secrets/telegram.json`, `.env`, screenshots, terminal captures, or issue comments containing a real bot token.
+- Prefer `allowed_users`; an omitted allowlist makes the bot reachable by anyone who discovers it.
+- Rotate the token in `@BotFather` immediately if it appears in logs, git history, chat, crash reports, or process arguments.
+- Use placeholders such as `<redacted-telegram-bot-token>` in examples. Do not use realistic token-shaped dummy strings.
+- Keep generated secret files mode `0600` and directories mode `0700` on shared machines.

--- a/tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot/scripts/create_telegram_bot_project.py
+++ b/tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot/scripts/create_telegram_bot_project.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Create a fresh LingTai project with Telegram MCP wiring.
+
+The token is read from TELEGRAM_BOT_TOKEN so it does not appear in argv.
+All status output avoids printing the token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+TOKENISH = re.compile(r"\b\d{6,}:[A-Za-z0-9_-]{20,}\b")
+
+
+def redact(text: str) -> str:
+    return TOKENISH.sub("<redacted-telegram-bot-token>", text)
+
+
+def parse_allowed_users(raw: str) -> list[int]:
+    users: list[int] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            users.append(int(item))
+        except ValueError as exc:
+            raise SystemExit(f"allowed user IDs must be integers: {item!r}") from exc
+    if not users:
+        raise SystemExit("--allowed-users must contain at least one Telegram numeric user ID")
+    return users
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise SystemExit(f"{path} must contain a JSON object")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any], mode: int | None = None) -> None:
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    if mode is not None:
+        path.chmod(mode)
+
+
+def write_secret_json(path: Path, data: dict[str, Any]) -> None:
+    flags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = -1
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    path.chmod(0o600)
+
+
+def runtime_python() -> str:
+    suffix = "Scripts/python.exe" if os.name == "nt" else "bin/python"
+    return str(Path.home() / ".lingtai-tui" / "runtime" / "venv" / suffix)
+
+
+def ensure_telegram_init(init_path: Path) -> None:
+    init = load_json(init_path)
+
+    addons = init.get("addons")
+    if addons is None:
+        addons = []
+    if not isinstance(addons, list):
+        raise SystemExit(f"{init_path}: top-level addons exists but is not a list")
+    if "telegram" not in addons:
+        addons.append("telegram")
+    init["addons"] = addons
+
+    mcp = init.get("mcp")
+    if mcp is None:
+        mcp = {}
+    if not isinstance(mcp, dict):
+        raise SystemExit(f"{init_path}: top-level mcp exists but is not an object")
+    mcp.setdefault(
+        "telegram",
+        {
+            "type": "stdio",
+            "command": runtime_python(),
+            "args": ["-m", "lingtai_telegram"],
+            "env": {"LINGTAI_TELEGRAM_CONFIG": ".secrets/telegram.json"},
+        },
+    )
+    init["mcp"] = mcp
+
+    write_json(init_path, init)
+
+
+def run_spawn(args: argparse.Namespace) -> dict[str, Any]:
+    cmd = [
+        "lingtai-tui",
+        "spawn",
+        str(args.project_dir),
+        "--preset",
+        args.preset,
+        "--agent-name",
+        args.agent_name,
+        "--language",
+        args.language,
+    ]
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        sys.stderr.write(redact(proc.stderr or proc.stdout))
+        raise SystemExit(proc.returncode)
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit("lingtai-tui spawn did not return JSON:\n" + redact(proc.stdout)) from exc
+    if not isinstance(data, dict) or not data.get("agent_dir"):
+        raise SystemExit("lingtai-tui spawn JSON did not include agent_dir")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-dir", required=True, type=Path)
+    parser.add_argument("--preset", required=True)
+    parser.add_argument("--agent-name", required=True)
+    parser.add_argument("--language", default="en", choices=("en", "zh", "wen"))
+    parser.add_argument("--allowed-users", required=True, help="Comma-separated Telegram numeric user IDs")
+    parser.add_argument("--alias", default="main")
+    parser.add_argument("--poll-interval", default=1.0, type=float)
+    args = parser.parse_args()
+
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise SystemExit("TELEGRAM_BOT_TOKEN is required and must not be passed on argv")
+
+    allowed_users = parse_allowed_users(args.allowed_users)
+    spawn = run_spawn(args)
+    agent_dir = Path(spawn["agent_dir"])
+
+    secrets_dir = agent_dir / ".secrets"
+    secrets_dir.mkdir(mode=0o700, exist_ok=True)
+    secrets_dir.chmod(0o700)
+
+    telegram_config = {
+        "accounts": [
+            {
+                "alias": args.alias,
+                "bot_token": token,
+                "allowed_users": allowed_users,
+            }
+        ],
+        "poll_interval": args.poll_interval,
+    }
+    write_secret_json(secrets_dir / "telegram.json", telegram_config)
+
+    init_path = agent_dir / "init.json"
+    ensure_telegram_init(init_path)
+
+    refresh_path = agent_dir / ".refresh"
+    refresh_path.touch()
+
+    result = {
+        "status": "configured",
+        "project_dir": spawn.get("project_dir"),
+        "agent_name": spawn.get("agent_name"),
+        "agent_dir": str(agent_dir),
+        "telegram_config": str(secrets_dir / "telegram.json"),
+        "init_json": str(init_path),
+        "refresh_signal": str(refresh_path),
+        "next_checks": [
+            "lingtai-tui list <project_dir>",
+            "Bot API getMe with token redacted",
+            "agent log shows Telegram listener/MCP startup",
+            "allowed user sends /start",
+        ],
+    }
+    print(redact(json.dumps(result, indent=2)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #226.

Adds a shipped swiss-knife nested reference for creating a fresh LingTai Telegram bot project headlessly, based on the supported `lingtai-tui spawn` workflow rather than manual `.lingtai/` fabrication.

## What changed

- Adds `swiss-knife/reference/headless-telegram-bot/` docs with:
  - supported `lingtai-tui spawn <dir> --preset <name> --agent-name <name> --language <code>` starting point
  - `.secrets/telegram.json` example with `allowed_users`
  - `init.json` merge guidance for `addons` and `mcp.telegram`
  - refresh/relaunch guidance
  - verification checklist: `lingtai-tui list`, redacted Bot API `getMe`, listener/log check, slash commands, allowed-user `/start`, non-allowed-user behavior
  - token redaction and rotation/security rules
- Adds a helper script:
  - reads `TELEGRAM_BOT_TOKEN` from env only, not argv
  - docs use a silent prompt (`read -rsp`) rather than shell-history-prone token examples
  - writes `.secrets/telegram.json` with `0600` via secure file creation
  - keeps `.secrets` at `0700`
  - merges Telegram addon/MCP config into `init.json`
  - touches `.refresh`
  - redacts token-shaped output
- Wires the new nested reference into the swiss-knife v2 router for discoverability.

## Validation

```bash
python3 -m py_compile tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot/scripts/create_telegram_bot_project.py
rg -n '[0-9]{6,}:[A-Za-z0-9_-]{20,}|export TELEGRAM_BOT_TOKEN='   tui/internal/preset/skills/swiss-knife/reference/headless-telegram-bot   tui/internal/preset/skills/swiss-knife/SKILL.md
cd tui && go test ./internal/preset ./internal/headless
```

Results:

- Python compile passed
- Token/history-pattern scan found no matches
- `go test ./internal/preset ./internal/headless` passed