### PR TITLE
install.sh: fall back to a writable bin dir instead of aborting on non-Homebrew systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,11 +37,16 @@ if command -v curl &>/dev/null && \
   export NPM_CONFIG_REGISTRY="https://registry.npmmirror.com"
 fi
 
-# Detect install path — use Homebrew prefix if available, else /usr/local/bin
+# Detect install path — prefer Homebrew prefix, then a writable /usr/local/bin,
+# else fall back to a user-writable dir so non-Homebrew systems don't abort with
+# a Permission denied at the install step.
 if command -v brew &>/dev/null; then
   BIN_DIR="$(brew --prefix)/bin"
-else
+elif [ -w /usr/local/bin ]; then
   BIN_DIR="/usr/local/bin"
+else
+  BIN_DIR="$HOME/.local/bin"
+  mkdir -p "$BIN_DIR"
 fi
 
 # Check dependencies — install via brew if missing
@@ -99,5 +104,16 @@ fi
 echo "==> Cleaning up ..."
 rm -rf "$BUILD_DIR"
 
-echo "==> Done. $(lingtai-tui version 2>&1 || echo "$VERSION")"
+echo "==> Done. $("$BIN_DIR/lingtai-tui" version 2>&1 || echo "$VERSION")"
+
+# Tell the user how to put BIN_DIR on PATH if it isn't already, so the next
+# shell can find lingtai-tui (common on fresh accounts using the ~/.local/bin fallback).
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *)
+    echo "==> Note: $BIN_DIR is not on your PATH. Add it with:"
+    echo "      echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+    ;;
+esac
+
 echo "    To revert to Homebrew version later: brew reinstall lingtai-tui"


### PR DESCRIPTION
## What

Makes `install.sh` choose a **writable** install directory instead of unconditionally using `/usr/local/bin`, and prints a PATH hint when needed.

Fixes #239.

## Why

On a system without Homebrew, `BIN_DIR` was hardcoded to `/usr/local/bin`, which a normal user can't write to. `install -m 755 … /usr/local/bin/…` then failed with `Permission denied`, and under `set -euo pipefail` the whole script aborted — *after* already cloning the repo and compiling the Go TUI + npm portal. No `sudo` fallback, no user-writable fallback, no guidance. This is the documented from-source path in the README, so it currently only works cleanly for Homebrew users.

## Changes

- **BIN_DIR selection:** brew prefix → a *writable* `/usr/local/bin` → `$HOME/.local/bin` (created if missing).
- **PATH hint:** if the chosen `BIN_DIR` isn't already on `PATH`, print the exact line to add it (common with the `~/.local/bin` fallback).
- **Version check:** verify via `"$BIN_DIR/lingtai-tui"` instead of a bare `lingtai-tui`, which only resolved when `BIN_DIR` happened to be on `PATH`.

Existing behavior for Homebrew users is unchanged. `bash -n install.sh` passes.

## Test plan

- Homebrew present → installs to `$(brew --prefix)/bin` as before.
- No Homebrew, non-root, `/usr/local/bin` not writable → installs to `~/.local/bin` and prints the PATH hint instead of aborting.
- `/usr/local/bin` writable (e.g. root) → still uses it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
