### PR TITLE
fix(preset): require configured credentials for preset validity

### DIFF
--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -20,7 +20,7 @@ The preset package owns the atomic `{llm, capabilities}` bundle layer — loadin
 | `BuiltinPresets()` | `tui/internal/preset/preset.go:446` | minimax, zhipu, mimo, deepseek, gemini, kimi, openrouter, codex, custom |
 | `IsTemplate(p)` | `tui/internal/preset/preset.go:464` | canonical "is this read-only?" — prefer over `IsBuiltin(p.Name)` |
 | `RefFor(p)` | `tui/internal/preset/preset.go:473` | `~/.lingtai-tui/presets/{templates\|saved}/<name>.json` |
-| `ResolveRefs(refs, keys)` | `tui/internal/preset/preset.go:528` | health-check: Source, Exists, HasKey for each preset path |
+| `ResolveRefsWithAuth(refs, keys, auth)` / `ResolveRefs(refs, keys)` | `tui/internal/preset/preset.go:574` | health-check: Source, Exists, HasKey for each preset path; credential validity requires configured `api_key_env` or Codex OAuth |
 | `Validate()` | `tui/internal/preset/preset.go:282` | mirrors kernel-side validation; `summary` non-empty, `tier` 1..5, `llm.provider`/`model` non-empty |
 | `//go:embed` directives | `tui/internal/preset/preset.go:16-47` | covenant, principle, procedures, templates, soul, recipe_assets, skills |
 | `CopyBundle` | `tui/internal/preset/recipe_apply.go:59` | copies `.recipe/` (replace) + recipe skill library sibling (merge) + `.lingtai/` (merge) into project |

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -529,11 +529,27 @@ type ResolvedRef struct {
 	Source PresetSource
 	// Exists reports whether the file is readable on disk right now.
 	Exists bool
-	// HasKey reports whether the preset's api_key_env (if any) is
-	// populated in the passed existingKeys map. True when the preset
-	// declares no api_key_env (codex OAuth, locally-hosted custom).
-	// Only meaningful when Exists is true.
+	// HasKey reports whether the preset's credential is actually
+	// configured. For a preset with a non-empty api_key_env, this is true
+	// only when that env var has a value in the passed existingKeys map.
+	// For a codex preset (provider "codex", which uses ChatGPT OAuth and
+	// declares no api_key_env), this is true only when OAuth is configured
+	// (see AuthState.CodexOAuthConfigured). A preset with an empty
+	// api_key_env that is NOT codex has no configured credential and no
+	// OAuth, so this is false. Only meaningful when Exists is true.
 	HasKey bool
+}
+
+// AuthState carries machine-level credential facts the credential guard
+// cannot derive from a preset file alone. Today that is only Codex OAuth,
+// but the struct leaves room to add future OAuth providers without churning
+// the ResolveRefs signature again.
+type AuthState struct {
+	// CodexOAuthConfigured is true when ~/.lingtai-tui/codex-auth.json
+	// parses and carries a non-empty refresh_token. The preset package must
+	// not import the tui package (import cycle), so this is computed by the
+	// caller and passed in.
+	CodexOAuthConfigured bool
 }
 
 // ResolveRefs expands and inspects a list of preset path strings. For
@@ -550,15 +566,28 @@ type ResolvedRef struct {
 // existingKeys is the env-var-name → value map (typically
 // Config.Keys). Pass nil when no key store is available; HasKey will
 // be false for any preset that declares an api_key_env.
+//
+// ResolveRefs assumes NO OAuth is configured (the conservative default):
+// a codex preset resolves to HasKey=false under this entry point. Callers
+// that make credential-sensitive validity decisions should use
+// ResolveRefsWithAuth and pass the real OAuth state.
 func ResolveRefs(refs []string, existingKeys map[string]string) []ResolvedRef {
+	return ResolveRefsWithAuth(refs, existingKeys, AuthState{})
+}
+
+// ResolveRefsWithAuth is ResolveRefs plus machine-level credential state
+// (auth), so the codex-OAuth case can be judged correctly: a codex preset
+// is valid only when auth.CodexOAuthConfigured is true. See ResolveRefs for
+// the ref-string and existingKeys contracts.
+func ResolveRefsWithAuth(refs []string, existingKeys map[string]string, auth AuthState) []ResolvedRef {
 	out := make([]ResolvedRef, 0, len(refs))
 	for _, ref := range refs {
-		out = append(out, resolveOneRef(ref, existingKeys))
+		out = append(out, resolveOneRef(ref, existingKeys, auth))
 	}
 	return out
 }
 
-func resolveOneRef(ref string, existingKeys map[string]string) ResolvedRef {
+func resolveOneRef(ref string, existingKeys map[string]string, auth AuthState) ResolvedRef {
 	r := ResolvedRef{Ref: ref}
 	if ref == "" {
 		return r
@@ -581,13 +610,28 @@ func resolveOneRef(ref string, existingKeys map[string]string) ResolvedRef {
 	}
 	if p, err := loadFromPath(abs); err == nil {
 		envName := ""
+		provider := ""
 		if llm, ok := p.Manifest["llm"].(map[string]interface{}); ok {
 			envName, _ = llm["api_key_env"].(string)
+			provider, _ = llm["provider"].(string)
 		}
-		if envName == "" {
-			r.HasKey = true // OAuth flow / locally-hosted: no key needed
-		} else if v, ok := existingKeys[envName]; ok && v != "" {
-			r.HasKey = true
+		switch {
+		case envName != "":
+			// Keyed provider: valid only when the env var has a value.
+			if v, ok := existingKeys[envName]; ok && v != "" {
+				r.HasKey = true
+			}
+		case provider == "codex":
+			// Codex declares no api_key_env by design — it uses ChatGPT
+			// OAuth (codex-auth.json). Valid only when OAuth is configured.
+			r.HasKey = auth.CodexOAuthConfigured
+		default:
+			// No api_key_env and not codex: no configured credential and no
+			// OAuth, so the preset is not valid. (A preset that genuinely
+			// needs no credential must still be reached through a configured
+			// auth path; an empty api_key_env on a non-codex provider is
+			// treated as missing, not as "no key needed".)
+			r.HasKey = false
 		}
 	}
 	return r

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -72,6 +72,95 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 	})
 }
 
+// writePresetFile writes a minimal valid preset JSON to dir/<name>.json with
+// the given provider and api_key_env, and returns its absolute path. Values
+// are placeholders only — no real secrets.
+func writePresetFile(t *testing.T, dir, name, provider, apiKeyEnv string) string {
+	t.Helper()
+	manifest := map[string]interface{}{
+		"llm": map[string]interface{}{
+			"provider":    provider,
+			"model":       "test-model",
+			"api_key_env": apiKeyEnv,
+		},
+	}
+	doc := map[string]interface{}{
+		"description": map[string]interface{}{"summary": "test preset"},
+		"manifest":    manifest,
+	}
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal preset: %v", err)
+	}
+	path := filepath.Join(dir, name+".json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write preset: %v", err)
+	}
+	return path
+}
+
+// TestResolveRefs_ValidityGuard locks in the defensive rule: a preset is only
+// valid (HasKey) when its credential is actually configured. A preset with no
+// configured API key AND no Codex OAuth must NOT be valid. Concretely: a
+// keyed preset is valid only when its env var has a value; a codex preset
+// (OAuth, no api_key_env) is valid only when Codex OAuth is configured; a
+// preset with an empty api_key_env that is not codex is invalid.
+func TestResolveRefs_ValidityGuard(t *testing.T) {
+	dir := t.TempDir()
+	codexRef := writePresetFile(t, dir, "codex", "codex", "")
+	customRef := writePresetFile(t, dir, "custom", "custom", "")
+	keyedRef := writePresetFile(t, dir, "minimax", "minimax", "FOO_API_KEY")
+	missingRef := filepath.Join(dir, "nope.json")
+
+	keysWith := map[string]string{"FOO_API_KEY": "placeholder-value"}
+	keysEmpty := map[string]string{}
+
+	cases := []struct {
+		name       string
+		ref        string
+		keys       map[string]string
+		auth       AuthState
+		wantExists bool
+		wantHasKey bool
+	}{
+		{"codex no OAuth", codexRef, keysEmpty, AuthState{}, true, false},
+		{"codex with OAuth", codexRef, keysEmpty, AuthState{CodexOAuthConfigured: true}, true, true},
+		{"keyless non-codex is invalid", customRef, keysEmpty, AuthState{}, true, false},
+		{"keyed with key present", keyedRef, keysWith, AuthState{}, true, true},
+		{"keyed with key absent", keyedRef, keysEmpty, AuthState{}, true, false},
+		{"missing file", missingRef, keysEmpty, AuthState{}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveRefsWithAuth([]string{tc.ref}, tc.keys, tc.auth)
+			if len(got) != 1 {
+				t.Fatalf("expected 1 resolved ref, got %d", len(got))
+			}
+			rr := got[0]
+			if rr.Exists != tc.wantExists {
+				t.Errorf("Exists = %v, want %v", rr.Exists, tc.wantExists)
+			}
+			if rr.HasKey != tc.wantHasKey {
+				t.Errorf("HasKey = %v, want %v", rr.HasKey, tc.wantHasKey)
+			}
+		})
+	}
+}
+
+// TestResolveRefs_ConservativeDefault verifies the legacy ResolveRefs entry
+// point assumes no OAuth: a codex preset resolves to HasKey=false through it.
+func TestResolveRefs_ConservativeDefault(t *testing.T) {
+	dir := t.TempDir()
+	codexRef := writePresetFile(t, dir, "codex", "codex", "")
+	got := ResolveRefs([]string{codexRef}, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resolved ref, got %d", len(got))
+	}
+	if got[0].HasKey {
+		t.Errorf("codex via ResolveRefs: HasKey = true, want false (conservative default)")
+	}
+}
+
 func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 	withTempPresets(t, func() {
 		p := DefaultPreset()

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1463,21 +1463,29 @@ func ValidateCodexAuthOnStartup(globalDir string) string {
 	return ""
 }
 
+// codexOAuthConfigured reports whether ~/.lingtai-tui/codex-auth.json
+// parses and carries a non-empty refresh_token — the canonical "Codex OAuth
+// is usable" signal shared across the TUI (login.go, firstrun.go,
+// preset_editor.go all check the same shape). It reads no secret to the
+// screen; it only returns a bool. Pass the result into
+// preset.AuthState.CodexOAuthConfigured so the preset validity guard can
+// judge codex presets correctly without importing this package.
+func codexOAuthConfigured(globalDir string) bool {
+	data, err := os.ReadFile(filepath.Join(globalDir, "codex-auth.json"))
+	if err != nil {
+		return false
+	}
+	var tokens CodexTokens
+	return json.Unmarshal(data, &tokens) == nil && tokens.RefreshToken != ""
+}
+
 // validateCodexAuthForAgents scans all agent directories under projectDir
 // for init.json files whose active/default preset is codex. If any exist
 // but ~/.lingtai-tui/codex-auth.json is missing or invalid, returns a
 // warning string. Otherwise returns "".
 func validateCodexAuthForAgents(globalDir, projectDir string) string {
 	// Quick check: is codex-auth.json valid?
-	authPath := filepath.Join(globalDir, "codex-auth.json")
-	authOK := false
-	if data, err := os.ReadFile(authPath); err == nil {
-		var tokens CodexTokens
-		if json.Unmarshal(data, &tokens) == nil && tokens.RefreshToken != "" {
-			authOK = true
-		}
-	}
-	if authOK {
+	if codexOAuthConfigured(globalDir) {
 		return ""
 	}
 

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -520,7 +520,8 @@ func (m PropsModel) renderLeft(maxW int) string {
 
 			if len(allowedRefs) > 0 {
 				cfg, _ := config.LoadConfig(m.globalDir)
-				resolved := preset.ResolveRefs(allowedRefs, cfg.Keys)
+				auth := preset.AuthState{CodexOAuthConfigured: codexOAuthConfigured(m.globalDir)}
+				resolved := preset.ResolveRefsWithAuth(allowedRefs, cfg.Keys, auth)
 				lines = append(lines, "  "+labelStyle.Render(i18n.T("props.preset_allowed")+":"))
 				for _, rr := range resolved {
 					marker := lipgloss.NewStyle().Foreground(StateColor("ACTIVE")).Render("✓")


### PR DESCRIPTION
## Summary
- make preset health validity require an actually configured credential
- add `preset.ResolveRefsWithAuth(..., AuthState{CodexOAuthConfigured})` so Codex presets with empty `api_key_env` are valid only when Codex OAuth exists
- treat all non-Codex presets with empty `api_key_env` as invalid instead of silently valid
- thread Codex OAuth state from the TUI kanban/props path and reuse a shared `codexOAuthConfigured` helper
- add regression tests and update preset anatomy

## Behavior
| Preset credential state | Valid? |
| --- | --- |
| `api_key_env` set and key value configured | ✅ |
| `api_key_env` set but missing/empty | ❌ |
| `provider: codex` + Codex OAuth configured | ✅ |
| `provider: codex` + no Codex OAuth | ❌ |
| no `api_key_env` and not Codex | ❌ |

This matches the requested safeguard: a preset without an API key and without Codex OAuth is not considered valid.

## Tests
- `cd tui && go test ./internal/preset/ -run TestResolveRefs -v`
- `cd tui && go test ./internal/preset ./internal/tui`
- `cd tui && go build ./...`

Broader check:
- `cd tui && go test ./...` still has the existing environment-dependent `internal/config` `TestFindDevCheckouts*` failures on this machine because real LingTai dev checkouts are present under `$HOME`; all unrelated packages completed as before.

No secrets printed; OAuth is reduced to a boolean.
