### PR TITLE
refactor(tui): canonicalize minimax skill guidance

### DIFF
--- a/tui/internal/config/devmode_test.go
+++ b/tui/internal/config/devmode_test.go
@@ -29,15 +29,17 @@ func makeKernelCheckout(t *testing.T, base, rel string) string {
 func TestFindDevCheckoutsRequiresExplicitEnv(t *testing.T) {
 	home := t.TempDir()
 	makeKernelCheckout(t, home, filepath.Join("work", "GitHub"))
+	lookupEnv := func(string) (string, bool) { return "", false }
 
-	if _, ok := findDevCheckouts(home, nil); ok {
+	if _, ok := findDevCheckouts(home, lookupEnv); ok {
 		t.Fatalf("expected no dev checkouts without LINGTAI_DEV_ROOT")
 	}
 }
 
 func TestFindDevCheckoutsReturnsFalseWhenAbsent(t *testing.T) {
 	home := t.TempDir()
-	if _, ok := findDevCheckouts(home, nil); ok {
+	lookupEnv := func(string) (string, bool) { return "", false }
+	if _, ok := findDevCheckouts(home, lookupEnv); ok {
 		t.Fatalf("expected no dev checkouts in an empty home")
 	}
 }

--- a/tui/internal/preset/skills/dj/SKILL.md
+++ b/tui/internal/preset/skills/dj/SKILL.md
@@ -36,31 +36,72 @@ for path in <skills paths from skills(action="info")>; do
 done
 ```
 
-For each one, the skill itself is the source of truth on **what providers it talks to** (MiniMax, MiMo, etc.) and **what env-var key** it expects.
+For each one, the skill itself is the source of truth on **what providers it talks to** and **what env-var key** it expects. For MiniMax specifically, load `minimax-cli`; it is the canonical provider reference and explains how to scan TUI presets recursively, pick the declared MiniMax slot, export it without printing the key, and match the region.
 
-**Step B — cross-check against the user's saved presets.** Each media-creation skill expects an API key. The user's saved presets at `~/.lingtai-tui/presets/*.json` declare which provider keys they have:
+**Step B — cross-check against the user's saved presets.** Each media-creation skill expects an API key. The user's saved presets (including `~/.lingtai-tui/presets/saved/*.json`) declare which provider keys they have:
 
 ```bash
-for f in ~/.lingtai-tui/presets/*.json ~/.lingtai-tui/presets/*.jsonc; do
-  [ -f "$f" ] || continue
-  python3 -c "
-import json, re, sys
-text = open('$f').read()
-text = re.sub(r'//[^\n]*', '', text)
-try:
-    d = json.loads(text)
-    llm = d.get('manifest', {}).get('llm', {})
-    print(llm.get('provider'), '|', llm.get('api_key_env') or '(none)', '|', '$f')
-except Exception:
-    pass
-"
-done
+python3 - <<'PY'
+import glob, json, os
+
+def strip_jsonc(text: str) -> str:
+    # Remove comments outside strings; do not corrupt https:// base_url values.
+    out = []
+    i = 0
+    in_string = False
+    escape = False
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if ch == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2 if i + 1 < len(text) else 0
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+root = os.path.expanduser("~/.lingtai-tui/presets")
+paths = sorted(set(
+    glob.glob(os.path.join(root, "**", "*.json"), recursive=True)
+    + glob.glob(os.path.join(root, "**", "*.jsonc"), recursive=True)
+))
+for path in paths:
+    try:
+        d = json.loads(strip_jsonc(open(path, encoding="utf-8").read()))
+    except Exception:
+        continue
+    llm = d.get("manifest", {}).get("llm", {}) or {}
+    print(llm.get("provider"), "|", llm.get("api_key_env") or "(none)", "|", path)
+PY
 ```
 
-The saved keys themselves live in `~/.lingtai-tui/.env`:
+The saved keys themselves live in `~/.lingtai-tui/.env`. List key **names** only; never print values:
 
 ```bash
-grep -E '^[A-Z_]+_API_KEY=' ~/.lingtai-tui/.env | cut -d= -f1
+grep -E '^[A-Z0-9_]+_API_KEY=' ~/.lingtai-tui/.env | cut -d= -f1
 ```
 
 **Step C — intersect.** A media-creation skill is *usable* only if (a) its provider matches a saved preset's `provider` AND (b) its expected env-var key is present in `.env`. Build the list of usable providers.
@@ -68,7 +109,7 @@ grep -E '^[A-Z_]+_API_KEY=' ~/.lingtai-tui/.env | cut -d= -f1
 **Step D — decide.**
 
 - **Any usable provider exists** → pick one (prefer the user's stated provider; otherwise pick whichever matches a current preset they're using; otherwise pick the first). Load its skill, follow its instructions, compose.
-- **No usable provider** → reply plainly. Tell them what skills you found, which providers they imply, and which presets they'd need to add for those skills to work. Suggest concretely (e.g. "save a MiniMax preset via the TUI's preset library and paste your `sk-cp-…` key — this will populate the preset's slot in `~/.lingtai-tui/.env` and unlock the `minimax-cli` skill"). **Do not produce a fake track. Do not pretend.**
+- **No usable provider** → reply plainly. Tell them what skills you found, which providers they imply, and which presets they'd need to add for those skills to work. For MiniMax, suggest concretely: "save a MiniMax preset via the TUI preset library and paste your `sk-cp-…` key — this will populate that preset's slot in `~/.lingtai-tui/.env` and unlock the `minimax-cli` skill." **Do not produce a fake track. Do not pretend.**
 
 ## Genre palette
 
@@ -89,11 +130,11 @@ The user may request anything outside this palette — Ravel, Coltrane, City Pop
 
 2. **Read the journal.** Project journals live at `~/.lingtai-tui/brief/projects/<hash>/journal.md`. The `brief.md` / `profile.md` files in the same tree give you context on the user. If the user points at a specific date or hour, also consult the matching `history/<YYYY-MM-DD-HH>.md`. Distill: what did the user do? What was the emotional arc? What instrumentation, tempo, key, mood would honor this session?
 
-3. **Load the chosen media-creation skill** by reading its `SKILL.md` from the skills catalog. Follow its preflight and `curl` whatever live docs it points to so you have the current API schema. The skill knows: where the key lives, which region/host to use, which model to call, parameter shape, expected response shape, how long to wait.
+3. **Load the chosen media-creation skill** by reading its `SKILL.md` from the skills catalog. For MiniMax, this is `minimax-cli`; use its preflight instead of inventing credential or region rules here. Follow the provider skill's live-doc / `--help` guidance so you have the current schema, model list, response shape, and expected wait time.
 
 4. **Compose the prompt.** Translate the journal's mood into a music-generation prompt: genre, instruments, tempo, key, mood adjectives, optional structure (intro / verse / breakdown / outro), reference artists if useful. Keep it under whatever the API limit is per the live docs.
 
-5. **Call the API.** Use bash + curl per the skill. If the response is a URL, `curl -o` it down; if a base64 blob, decode to file. Save to `~/.lingtai-tui/brief/projects/<hash>/music/<YYYY-MM-DD>-<genre-slug>-<short-title-slug>.<ext>`. Create the `music/` folder if it doesn't exist. Do not overwrite an existing track for the same journal date — append a counter (`-2`, `-3`) if the user asks for another take.
+5. **Call the provider.** Use the provider skill's current mechanism (for MiniMax, normally `mmx music ...` via `minimax-cli`; for other providers, whatever their skill documents). If the response is a URL, `curl -o` it down; if a base64 blob, decode to file; if the CLI writes an output directory, move/copy the final audio into place. Save to `~/.lingtai-tui/brief/projects/<hash>/music/<YYYY-MM-DD>-<genre-slug>-<short-title-slug>.<ext>`. Create the `music/` folder if it doesn't exist. Do not overwrite an existing track for the same journal date — append a counter (`-2`, `-3`) if the user asks for another take.
 
 6. **Append the index entry.** `~/.lingtai-tui/brief/projects/<hash>/music/index.md`:
 

--- a/tui/internal/preset/skills/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/minimax-cli/SKILL.md
@@ -1,130 +1,49 @@
 ---
 name: minimax-cli
 description: >
-  Manual (not a tool). Points you at the official MiniMax CLI `mmx` —
-  one binary that, given a MiniMax key, handles every modality MiniMax
-  offers: text-to-image generation, text-to-video generation, music
-  generation (with-lyrics or instrumental), text-to-speech (TTS), and
-  vision (image understanding). This skill does NOT expose tools; it
-  tells you how to install `mmx-cli` (via npm), where the API key lives
-  in this environment, and which region flag to use. Once installed,
-  `mmx --help` / `mmx <subcommand> --help` is the source of truth for
-  syntax — not this manual. Read this skill when the human asks for any
-  of: image / video / music generation, TTS narration, or ad-hoc shell
-  vision (`mmx vision …`). Note: MiniMax-backed vision in LingTai has
-  two paths — this CLI route AND the kernel's built-in `vision` tool /
-  MCP `understand_image` route covered by the `vision` skill. Use this
-  for one-shot bash; use `vision` when the agent needs vision as a tool
-  call inside a reasoning loop.
-version: 2.0.0
-tags: [manual, cli, minimax, mmx, image, video, music, speech, tts, vision, media-generation]
+  Thin top-level entry point for MiniMax CLI work. Read this when the human asks
+  for MiniMax media generation, TTS, ad-hoc `mmx vision`, or when another skill
+  such as `dj` needs a MiniMax provider; then load the canonical procedure at
+  `../swiss-knife/reference/minimax-cli/SKILL.md` (the Swiss Knife nested
+  reference) so MiniMax credential, region, and CLI guidance has one maintained
+  home.
+version: 2.1.0
+canonical: ../swiss-knife/reference/minimax-cli/SKILL.md
+tags: [manual, cli, minimax, mmx, image, video, music, speech, tts, vision, media-generation, router]
 ---
 
-# minimax-cli
+# minimax-cli — top-level entry point
 
-> **This is a manual, not a tool.** It points you at the official MiniMax CLI (`mmx`). The CLI's own `--help` is the source of truth for syntax; the live docs are the source of truth for models and quotas. This file only covers the LingTai-specific glue: install, key, region.
+This top-level skill is a read-only pointer; edit the `canonical` nested reference instead of adding MiniMax command recipes here. It exists for discoverability: agents can find `minimax-cli`
+by bare name when a task mentions MiniMax, `mmx`, media generation, TTS, or
+one-shot shell vision.
 
-## 1. Install The CLI
+The maintained procedure lives in the Swiss Knife nested reference:
 
-The official CLI is **`mmx-cli`** on npm (source: [`MiniMax-AI/cli`](https://github.com/MiniMax-AI/cli)). Check first, install if missing:
-
-```bash
-command -v mmx >/dev/null || npm install -g mmx-cli
+```yaml
+canonical_reference:
+  name: minimax-cli
+  location: ../swiss-knife/reference/minimax-cli/SKILL.md
+  description: >
+    Canonical MiniMax `mmx` CLI guide: install `mmx-cli`, discover the correct
+    TUI-managed MiniMax preset/key slot without leaking secrets, match mainland
+    vs international regions, and route image/video/music/TTS generation or
+    one-shot shell vision.
 ```
 
-Requires `node` + `npm` on `PATH`. If neither is installed, ask the user to install Node — don't try to bootstrap a Node runtime yourself.
+## Routing table
 
-## 2. Source The API Key
-
-**Never hardcode the key in any committed file.** The TUI stores keys in `~/.lingtai-tui/.env` and tells each preset which slot to read via `manifest.llm.api_key_env`. Slots are per-preset, so a user with two MiniMax accounts (e.g. mainland + international) has two distinct env vars.
-
-Resolution: **scan presets, find MiniMax ones, read their declared slot.**
-
-```bash
-# Walk every preset; for each one whose provider is minimax, print
-# (slot-name, base_url) so you can pick the right account/region.
-python3 - <<'PY'
-import json, os, glob
-for path in glob.glob(os.path.expanduser("~/.lingtai-tui/presets/*.json")):
-    try:
-        with open(path) as f:
-            doc = json.load(f)
-    except Exception:
-        continue
-    llm = doc.get("manifest", {}).get("llm", {}) or {}
-    if llm.get("provider") != "minimax":
-        continue
-    slot = llm.get("api_key_env") or "MINIMAX_API_KEY"  # built-ins may leave it empty → legacy default
-    base = llm.get("base_url") or ""
-    print(f"{os.path.basename(path):30s}  slot={slot:30s}  base_url={base}")
-PY
-```
-
-Slot naming (per `tui/internal/preset/preset.go::AutoEnvVarName`):
-- New user-saved presets: `MINIMAX_<CN|INTL>_<N>_API_KEY` — region is read from `base_url` (`minimaxi.com` → CN, `minimax.io` → INTL); `N` is a per-region counter.
-- Built-in / legacy presets: leave `api_key_env` empty → fall back to plain `MINIMAX_API_KEY`.
-
-Once you've picked the right slot, export it as `MINIMAX_API_KEY` for `mmx`:
-
-```bash
-SLOT=MINIMAX_CN_1_API_KEY    # whichever slot the preset scan returned
-export MINIMAX_API_KEY=$(grep -E "^${SLOT}=" ~/.lingtai-tui/.env | cut -d= -f2- | tr -d ' ')
-```
-
-If multiple MiniMax presets exist and you can't infer which the human means, **ask** — don't guess. If no MiniMax preset exists at all, ask the human to save one through the TUI's preset library (the TUI will populate the slot for them).
-
-Token-plan keys have prefix `sk-cp-…`. Pay-as-you-go keys (`sk-…` without `cp`) work too but are billed per call.
-
-## 3. Pick The Region
-
-MiniMax runs two non-interchangeable ecosystems. The CLI defaults to **international** (`api.minimax.io`); for a mainland China key, override:
-
-```bash
-# TODO: verify endpoint — api.minimaxi.com 404s, no clearly-correct API host found yet (2026-05-05)
-export MINIMAX_BASE_URL=https://api.minimaxi.com   # mainland
-# (leave unset for international — that's the default)
-```
-
-The region is already encoded in the preset you picked in §2 — it's the `base_url` field. `minimaxi.com` → mainland, `minimax.io` → international. Match the env override to that. A region/key mismatch returns `2049 invalid api key`.
-
-## 4. Discover Subcommands
-
-Don't memorize syntax — ask the CLI:
-
-```bash
-mmx --help
-mmx <subcommand> --help     # e.g. mmx music --help, mmx video --help
-mmx doctor                  # health check (key, network, version)
-```
-
-As of this writing the CLI exposes `text`, `image`, `video`, `music`, `speech`, and `vision` subcommands. By default outputs land in `./minimax-output/`; most subcommands accept `--out <path>` to override. Verify against `--help` — flags evolve.
-
-Live docs (when `--help` isn't enough):
-[`platform.minimax.io/docs/token-plan/minimax-cli`](https://platform.minimax.io/docs/token-plan/minimax-cli) (international) · [`platform.minimaxi.com/docs/token-plan/minimax-cli`](https://platform.minimaxi.com/docs/token-plan/minimax-cli) (mainland).
-
-## 5. When To Use This Skill
-
-| Want to … | Use |
+| Need | Read |
 |---|---|
-| Generate music, video, image, or TTS | This skill — `mmx music/video/image/speech generate …` |
-| One-off image understanding from the shell | This skill — `mmx vision …` (cheap, scriptable, no MCP setup) |
-| Vision as a tool call inside a reasoning loop | The `vision` skill — uses the kernel's built-in `vision` tool or the `understand_image` MCP tool |
-| Transcribe speech / analyse music numerically | `listen` skill (local, no key needed) |
-| Plain text or code | Core capabilities, not this |
+| Install or troubleshoot `mmx-cli` | `../swiss-knife/reference/minimax-cli/SKILL.md` |
+| Find the right MiniMax key slot from TUI presets | `../swiss-knife/reference/minimax-cli/SKILL.md` |
+| Match mainland vs international MiniMax regions | `../swiss-knife/reference/minimax-cli/SKILL.md` |
+| Generate image, video, music, or TTS with MiniMax | `../swiss-knife/reference/minimax-cli/SKILL.md` |
+| Use `mmx vision` for ad-hoc shell image understanding | `../swiss-knife/reference/minimax-cli/SKILL.md` |
 
-**On vision specifically:** MiniMax can serve vision in two paths in LingTai. Path A — this CLI (`mmx vision …`) — is best for one-shot bash use. Path B — the `vision` skill, backed by either the kernel's built-in `vision` tool or the `understand_image` MCP tool — is best when an agent needs vision as a tool call inside a longer reasoning loop. Same backend, different shape.
-
-## 6. Failure Modes
-
-| Symptom | Look at |
-|---|---|
-| `mmx: command not found` | Re-run the install in §1; verify `npm bin -g` is on `PATH` |
-| `2049 invalid api key` | Region/host mismatch — check §3 |
-| `2056 usage limit exceeded` | Live docs — quotas |
-| Tool hangs 1–10 min | Normal for music/video — do not retry |
-| Anything else | `mmx doctor`, then the live docs |
-
-The MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists and is owned by the `mcp-manual` skill (kernel `mcp` capability). Prefer the CLI here — it's first-party, simpler, and one binary covers everything.
+Do not duplicate MiniMax command recipes here. Update the canonical nested
+reference instead, then keep this pointer current if the location changes.
 
 ---
-> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.
+> **Found a bug or issue?** If you encounter any problems with this skill, load
+> the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/reference/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/minimax-cli/SKILL.md
@@ -1,30 +1,34 @@
 ---
 name: minimax-cli
 description: >
-  Nested swiss-knife reference for the MiniMax `mmx` CLI. Manual (not a tool). Points you at the official MiniMax CLI `mmx` —
-  one binary that, given a MiniMax key, handles every modality MiniMax
-  offers: text-to-image generation, text-to-video generation, music
-  generation (with-lyrics or instrumental), text-to-speech (TTS), and
-  vision (image understanding). This skill does NOT expose tools; it
-  tells you how to install `mmx-cli` (via npm), where the API key lives
-  in this environment, and which region flag to use. Once installed,
-  `mmx --help` / `mmx <subcommand> --help` is the source of truth for
-  syntax — not this manual. Read this skill when the human asks for any
-  of: image / video / music generation, TTS narration, or ad-hoc shell
-  vision (`mmx vision …`). Note: MiniMax-backed vision in LingTai has
-  two paths — this CLI route AND the kernel's built-in `vision` tool /
-  MCP `understand_image` route covered by the `vision` skill. Use this
-  for one-shot bash; use `vision` when the agent needs vision as a tool
-  call inside a reasoning loop.
-version: 2.0.0
+  Nested swiss-knife reference for the MiniMax `mmx` CLI and the canonical
+  MiniMax CLI procedure shipped with the TUI: install `mmx-cli`, discover the
+  correct TUI-managed MiniMax preset/key slot without leaking secrets, match
+  mainland vs international regions, and route image/video/music/TTS generation
+  or one-shot shell vision.
+version: 2.1.0
 tags: [manual, cli, minimax, mmx, image, video, music, speech, tts, vision, media-generation]
 ---
 
 # minimax-cli
 
-> **This is a manual, not a tool.** It points you at the official MiniMax CLI (`mmx`). The CLI's own `--help` is the source of truth for syntax; the live docs are the source of truth for models and quotas. This file only covers the LingTai-specific glue: install, key, region.
+> **This is a manual, not a tool.** It points you at the official MiniMax CLI (`mmx`). The CLI's own `--help` is the source of truth for syntax; the live docs are the source of truth for models, quotas, regions, and evolving flags. This file covers the LingTai-specific glue: install, credential discovery, region matching, and when to route through this CLI instead of another capability.
 
-## 1. Install The CLI
+## 1. Scope and entry points
+
+Use this skill when a task needs MiniMax-backed media generation or one-shot shell vision:
+
+| Need | Primary route |
+|---|---|
+| Generate image, video, music, or TTS | `mmx image/video/music/speech ...` after reading the subcommand's `--help` |
+| Understand an image from a shell script | `mmx vision ...` for ad-hoc one-shots |
+| Vision as an in-turn tool call | Use the `vision` skill first; it may expose the kernel `vision` tool or a registered MCP |
+| Music tied to project journals | Use the `dj` skill for the workflow, then this skill for the MiniMax provider step |
+| Transcribe speech or analyze audio numerically | Use the `listen` skill (local, no MiniMax key needed) |
+
+This skill is the **canonical MiniMax CLI reference** shipped with the TUI. The top-level `minimax-cli` skill is only a discoverability pointer into this nested reference, so keep MiniMax command recipes and credential guidance here rather than duplicating them there.
+
+## 2. Install the CLI
 
 The official CLI is **`mmx-cli`** on npm (source: [`MiniMax-AI/cli`](https://github.com/MiniMax-AI/cli)). Check first, install if missing:
 
@@ -32,99 +36,208 @@ The official CLI is **`mmx-cli`** on npm (source: [`MiniMax-AI/cli`](https://git
 command -v mmx >/dev/null || npm install -g mmx-cli
 ```
 
-Requires `node` + `npm` on `PATH`. If neither is installed, ask the user to install Node — don't try to bootstrap a Node runtime yourself.
+Requires `node` + `npm` on `PATH`. If neither is installed, ask the user to install Node; do not bootstrap a Node runtime yourself inside the project.
 
-## 2. Source The API Key
-
-**Never hardcode the key in any committed file.** The TUI stores keys in `~/.lingtai-tui/.env` and tells each preset which slot to read via `manifest.llm.api_key_env`. Slots are per-preset, so a user with two MiniMax accounts (e.g. mainland + international) has two distinct env vars.
-
-Resolution: **scan presets, find MiniMax ones, read their declared slot.**
-
-```bash
-# Walk every preset; for each one whose provider is minimax, print
-# (slot-name, base_url) so you can pick the right account/region.
-python3 - <<'PY'
-import json, os, glob
-for path in glob.glob(os.path.expanduser("~/.lingtai-tui/presets/*.json")):
-    try:
-        with open(path) as f:
-            doc = json.load(f)
-    except Exception:
-        continue
-    llm = doc.get("manifest", {}).get("llm", {}) or {}
-    if llm.get("provider") != "minimax":
-        continue
-    slot = llm.get("api_key_env") or "MINIMAX_API_KEY"  # built-ins may leave it empty → legacy default
-    base = llm.get("base_url") or ""
-    print(f"{os.path.basename(path):30s}  slot={slot:30s}  base_url={base}")
-PY
-```
-
-Slot naming (per `tui/internal/preset/preset.go::AutoEnvVarName`):
-- New user-saved presets: `MINIMAX_<CN|INTL>_<N>_API_KEY` — region is read from `base_url` (`minimaxi.com` → CN, `minimax.io` → INTL); `N` is a per-region counter.
-- Built-in / legacy presets: leave `api_key_env` empty → fall back to plain `MINIMAX_API_KEY`.
-
-Once you've picked the right slot, export it as `MINIMAX_API_KEY` for `mmx`:
-
-```bash
-SLOT=MINIMAX_CN_1_API_KEY    # whichever slot the preset scan returned
-export MINIMAX_API_KEY=$(grep -E "^${SLOT}=" ~/.lingtai-tui/.env | cut -d= -f2- | tr -d ' ')
-```
-
-If multiple MiniMax presets exist and you can't infer which the human means, **ask** — don't guess. If no MiniMax preset exists at all, ask the human to save one through the TUI's preset library (the TUI will populate the slot for them).
-
-Token-plan keys have prefix `sk-cp-…`. Pay-as-you-go keys (`sk-…` without `cp`) work too but are billed per call.
-
-## 3. Pick The Region
-
-MiniMax runs two non-interchangeable ecosystems. The CLI defaults to **international** (`api.minimax.io`); for a mainland China key, override:
-
-```bash
-# TODO: verify endpoint — api.minimaxi.com 404s, no clearly-correct API host found yet (2026-05-05)
-export MINIMAX_BASE_URL=https://api.minimaxi.com   # mainland
-# (leave unset for international — that's the default)
-```
-
-The region is already encoded in the preset you picked in §2 — it's the `base_url` field. `minimaxi.com` → mainland, `minimax.io` → international. Match the env override to that. A region/key mismatch returns `2049 invalid api key`.
-
-## 4. Discover Subcommands
-
-Don't memorize syntax — ask the CLI:
+After install, verify the binary and let the CLI describe its current surface:
 
 ```bash
 mmx --help
-mmx <subcommand> --help     # e.g. mmx music --help, mmx video --help
-mmx doctor                  # health check (key, network, version)
+mmx doctor --help || true
 ```
 
-As of this writing the CLI exposes `text`, `image`, `video`, `music`, `speech`, and `vision` subcommands. By default outputs land in `./minimax-output/`; most subcommands accept `--out <path>` to override. Verify against `--help` — flags evolve.
+## 3. Discover credentials without leaking them
 
-Live docs (when `--help` isn't enough):
-[`platform.minimax.io/docs/token-plan/minimax-cli`](https://platform.minimax.io/docs/token-plan/minimax-cli) (international) · [`platform.minimaxi.com/docs/token-plan/minimax-cli`](https://platform.minimaxi.com/docs/token-plan/minimax-cli) (mainland).
+**Never print, commit, or paste MiniMax keys.** The TUI stores keys in `~/.lingtai-tui/.env`; presets declare which env slot they use through `manifest.llm.api_key_env`. Modern saved presets usually live under `~/.lingtai-tui/presets/saved/`, so scan recursively instead of only checking the top-level presets directory.
 
-## 5. When To Use This Skill
+Resolution order:
 
-| Want to … | Use |
+1. Find MiniMax presets and their declared key slot.
+2. Match the slot to `~/.lingtai-tui/.env` without printing the key value.
+3. Export the selected value as `MINIMAX_API_KEY` for `mmx`.
+4. Match the region/base URL to the preset; do not guess a host.
+
+List candidate presets (prints slot names and base URLs only, never secret values):
+
+```bash
+python3 - <<'PY'
+import glob, json, os
+
+root = os.path.expanduser("~/.lingtai-tui/presets")
+paths = sorted(set(
+    glob.glob(os.path.join(root, "**", "*.json"), recursive=True)
+    + glob.glob(os.path.join(root, "**", "*.jsonc"), recursive=True)
+))
+
+def strip_jsonc(text: str) -> str:
+    # Remove // and /* */ comments outside strings. A regex comment stripper
+    # would corrupt normal preset URLs such as "https://api.minimaxi.com/anthropic".
+    out = []
+    i = 0
+    in_string = False
+    escape = False
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if in_string:
+            out.append(ch)
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            i += 2
+            while i < len(text) and text[i] not in "\r\n":
+                i += 1
+            continue
+        if ch == "/" and nxt == "*":
+            i += 2
+            while i + 1 < len(text) and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2 if i + 1 < len(text) else 0
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+for path in paths:
+    try:
+        doc = json.loads(strip_jsonc(open(path, encoding="utf-8").read()))
+    except Exception:
+        continue
+    llm = doc.get("manifest", {}).get("llm", {}) or {}
+    if (llm.get("provider") or "").lower() != "minimax":
+        continue
+    slot = llm.get("api_key_env") or "MINIMAX_API_KEY"  # legacy/built-in fallback
+    base = llm.get("base_url") or "(default CLI region)"
+    region = "CN" if "minimaxi.com" in base else "INTL" if "minimax.io" in base else "unknown"
+    rel = os.path.relpath(path, os.path.expanduser("~/.lingtai-tui"))
+    print(f"{rel:55s} slot={slot:32s} region={region:7s} base_url={base}")
+PY
+```
+
+Export the chosen slot without echoing the key. Python is used here so quoted or whitespace-padded `.env` values are handled consistently; for ordinary API-key lines a simple `grep` extraction is also fine, but do not print the value:
+
+```bash
+SLOT=MINIMAX_CN_1_API_KEY  # replace with the slot printed above
+export MINIMAX_API_KEY="$({
+  python3 - "$SLOT" <<'PY'
+import os, sys
+slot = sys.argv[1]
+env_path = os.path.expanduser("~/.lingtai-tui/.env")
+value = None
+try:
+    with open(env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            if k == slot:
+                value = v.strip().strip('"').strip("'")
+                break
+except FileNotFoundError:
+    pass
+if not value:
+    raise SystemExit(f"missing {slot} in {env_path}")
+print(value)
+PY
+})"
+```
+
+If multiple MiniMax presets exist and the user did not specify which account/region to use, ask. If no MiniMax preset exists, ask the user to save one through the TUI preset library; the TUI will populate the appropriate slot in `~/.lingtai-tui/.env`.
+
+Token-plan keys often have prefix `sk-cp-...`; pay-as-you-go keys (`sk-...` without `cp`) may also work but are billed per call. Treat both as secrets.
+
+## 4. Match the region/base URL
+
+MiniMax has mainland China and international ecosystems. The credential, API host, and quota plan must match. The preset's `base_url` is the best local hint:
+
+- `minimaxi.com` -> mainland China account.
+- `minimax.io` -> international account.
+- Empty/unknown -> use the CLI default unless the user or live docs say otherwise.
+
+Do **not** hardcode an unverified host. If the CLI supports a region flag or `MINIMAX_BASE_URL`, set it from the preset's `base_url` or the current official docs, not from memory:
+
+```bash
+mmx doctor --help || true
+mmx --help | sed -n '1,120p'
+# If the CLI documents MINIMAX_BASE_URL and your selected preset has a base_url:
+# export MINIMAX_BASE_URL="<base_url from the selected preset>"
+```
+
+A region/key mismatch commonly appears as `2049 invalid api key`.
+
+## 5. Discover subcommands at call time
+
+Do not memorize command syntax. Ask the installed CLI immediately before generating:
+
+```bash
+mmx --help
+mmx image --help
+mmx video --help
+mmx music --help
+mmx speech --help
+mmx vision --help
+mmx doctor
+```
+
+As of this writing the CLI commonly exposes `text`, `image`, `video`, `music`, `speech`, and `vision` subcommands. Outputs usually land in `./minimax-output/`, and most subcommands have an output flag such as `--out`; verify the current flag with `--help` before every scripted use.
+
+Live docs when `--help` is not enough:
+
+- International: <https://platform.minimax.io/docs/token-plan/minimax-cli>
+- Mainland China: <https://platform.minimaxi.com/docs/token-plan/minimax-cli>
+
+## 6. Generation workflow
+
+1. **Confirm the requested modality and cost.** Media calls can take minutes and may consume paid quota. For ambiguous prompts, ask before calling.
+2. **Create an artifact directory** inside the project or requested destination, e.g. `artifacts/minimax/<task-slug>/`.
+3. **Run `mmx <subcommand> --help`** and build the command from the live flags.
+4. **Send a progress update** for human-facing long calls (>5 seconds) before waiting.
+5. **Save outputs explicitly** with an output flag/path when available; otherwise move files out of `./minimax-output/` after the call.
+6. **Report only paths and a concise summary.** Do not include keys, raw auth headers, or huge provider payloads.
+
+Skeleton:
+
+```bash
+mkdir -p artifacts/minimax/example
+mmx music --help
+# Build the real command from the help output; example flags may change:
+# mmx music generate --prompt "..." --out artifacts/minimax/example/
+```
+
+## 7. Vision-specific routing
+
+MiniMax vision can appear through multiple LingTai paths:
+
+- **Kernel `vision` tool**: best when present in the agent's tool list; use the `vision` skill's decision tree.
+- **MiniMax CLI (`mmx vision ...`)**: best for one-shot shell/OCR/image-description jobs.
+- **MCP vision tools**: only if an MCP is already registered; MCP setup belongs to `mcp-manual`.
+
+If a user asks for image understanding and you already have the built-in `vision` tool, use it first. Load this skill for CLI fallback or batch shell work.
+
+## 8. Failure modes
+
+| Symptom | Likely cause / action |
 |---|---|
-| Generate music, video, image, or TTS | This skill — `mmx music/video/image/speech generate …` |
-| One-off image understanding from the shell | This skill — `mmx vision …` (cheap, scriptable, no MCP setup) |
-| Vision as a tool call inside a reasoning loop | The `vision` skill — uses the kernel's built-in `vision` tool or the `understand_image` MCP tool |
-| Transcribe speech / analyse music numerically | `listen` skill (local, no key needed) |
-| Plain text or code | Core capabilities, not this |
+| `mmx: command not found` | Install `mmx-cli`; verify npm's global bin directory is on `PATH` |
+| No MiniMax preset found | Ask the user to save a MiniMax preset through the TUI preset library |
+| Slot printed by preset scan but missing from `.env` | Preset/key state is incomplete; ask the user to re-save the preset or add the key through the TUI |
+| `2049 invalid api key` | Region/key mismatch or wrong slot; re-check selected preset base URL and slot |
+| `2056 usage limit exceeded` | Quota/plan exhausted; stop and report plainly |
+| Media call appears to hang | Music/video can take 1-10 minutes; wait rather than retrying immediately |
+| CLI flags differ from examples | Trust `mmx <subcommand> --help`; update this skill if the drift is persistent |
 
-**On vision specifically:** MiniMax can serve vision in two paths in LingTai. Path A — this CLI (`mmx vision …`) — is best for one-shot bash use. Path B — the `vision` skill, backed by either the kernel's built-in `vision` tool or the `understand_image` MCP tool — is best when an agent needs vision as a tool call inside a longer reasoning loop. Same backend, different shape.
-
-## 6. Failure Modes
-
-| Symptom | Look at |
-|---|---|
-| `mmx: command not found` | Re-run the install in §1; verify `npm bin -g` is on `PATH` |
-| `2049 invalid api key` | Region/host mismatch — check §3 |
-| `2056 usage limit exceeded` | Live docs — quotas |
-| Tool hangs 1–10 min | Normal for music/video — do not retry |
-| Anything else | `mmx doctor`, then the live docs |
-
-The MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists and is owned by the `mcp-manual` skill (kernel `mcp` capability). Prefer the CLI here — it's first-party, simpler, and one binary covers everything.
+The older MCP-server route (`minimax-mcp`, `minimax-coding-plan-mcp`) still exists for MCP workflows and is owned by `mcp-manual`. Prefer the official CLI here when a shell command is sufficient: one binary covers media, speech, text, and ad-hoc vision.
 
 ---
 > **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/vision/SKILL.md
+++ b/tui/internal/preset/skills/vision/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Decision-tree skill for image understanding. Routes between three paths
   depending on what the agent has access to: (1) the built-in `vision` tool
   if the LLM provider supports image input, (2) the `minimax-cli` skill
-  if a MiniMax coding-plan key is available, or (3) a local Hugging Face
+  if a usable MiniMax preset/key slot is available, or (3) a local Hugging Face
   VLM via the bundled `scripts/describe.py` if neither — offline, free,
   slow. Read this when you need to describe, OCR, or critique an image
   and you're not sure which path applies.
@@ -20,9 +20,9 @@ version: 1.0.0
 ```
 Is `vision` tool in your tool list?
 ├── YES → use it directly, done.
-└── NO  → does the user have a MiniMax coding-plan key?
-         (check ~/.lingtai-tui/.env for MINIMAX_API_KEY)
-         ├── YES → see `minimax-cli` skill (`mmx vision …` from the shell, or the `understand_image` MCP tool if registered)
+└── NO  → does the user have a MiniMax preset/key slot?
+         (read `minimax-cli`; scan ~/.lingtai-tui/presets/** without printing keys)
+         ├── YES → use `minimax-cli` for `mmx vision …` from the shell, or an already-registered MCP tool
          └── NO  → fall back to local VLM:
                   bash python <skill-path>/scripts/describe.py <image>
                   See reference/local-models.md.
@@ -36,12 +36,12 @@ If your LLM provider supports image input (MiniMax, Gemini, Anthropic, OpenAI, Z
 
 ## Path 2 — MiniMax via `minimax-cli` Skill
 
-For text-only LLMs (DeepSeek, OpenRouter text-only, Codex) **with** a MiniMax coding-plan key. Two routes, same backend:
+For text-only LLMs (DeepSeek, OpenRouter text-only, Codex) **with** a usable MiniMax preset/key slot. Two routes can exist:
 
 - **Shell** — `mmx vision …` via the official CLI. No MCP registration needed; just install + key. Best for ad-hoc one-shots in bash.
-- **In-tool** — the `understand_image` MCP tool exposed by `minimax-coding-plan-mcp`. Best when the agent needs vision as a tool call inside a longer reasoning loop. MCP server registration is owned by `mcp-manual` (kernel `mcp` capability).
+- **In-tool** — an already-registered MiniMax MCP vision tool. Best when the agent needs vision as a tool call inside a longer reasoning loop. MCP server registration is owned by `mcp-manual` (kernel `mcp` capability).
 
-Read the **`minimax-cli`** skill — it covers install, credential sourcing, region selection, and pointers to live docs.
+Read the **`minimax-cli`** skill before using the shell route. It owns the canonical MiniMax credential discovery flow: scan TUI presets recursively, pick the declared slot, export it without printing the key, and match the preset region/base URL. Do not assume a bare `MINIMAX_API_KEY` is the only valid slot.
 
 ## Path 3 — Local VLM (offline, unlimited)
 

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -53,6 +53,40 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 	}
 }
 
+func TestPopulateBundledLibrary_MinimaxCliCanonicalReference(t *testing.T) {
+	globalDir := t.TempDir()
+	PopulateBundledLibrary("", globalDir)
+
+	topPath := filepath.Join(globalDir, "utilities", "minimax-cli", "SKILL.md")
+	topBodyBytes, err := os.ReadFile(topPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topBody := string(topBodyBytes)
+	if !strings.Contains(topBody, "../swiss-knife/reference/minimax-cli/SKILL.md") {
+		t.Error("top-level minimax-cli should point at the canonical swiss-knife nested reference")
+	}
+	if strings.Contains(topBody, "## 3. Discover credentials without leaking them") {
+		t.Error("top-level minimax-cli should not duplicate the canonical manual")
+	}
+
+	canonicalPath := filepath.Join(globalDir, "utilities", "swiss-knife", "reference", "minimax-cli", "SKILL.md")
+	canonicalBodyBytes, err := os.ReadFile(canonicalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalBody := string(canonicalBodyBytes)
+	for _, want := range []string{
+		"Nested swiss-knife reference for the MiniMax `mmx` CLI",
+		"~/.lingtai-tui/presets/saved/",
+		"Do **not** hardcode an unverified host",
+	} {
+		if !strings.Contains(canonicalBody, want) {
+			t.Errorf("canonical minimax-cli reference missing %q", want)
+		}
+	}
+}
+
 // TestPopulateBundledLibrary_WebBrowsingNestedReferences verifies that the
 // embedded utility-library copier preserves web-browsing's nested reference
 // router files alongside the existing deep-dive references and scripts.

--- a/tui/internal/tui/skill_files_test.go
+++ b/tui/internal/tui/skill_files_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -132,6 +133,118 @@ func TestBuildSkillFolderEntries_SwissKnifeNestedReferences(t *testing.T) {
 	}
 	if !strings.Contains(string(childBodyBytes), "Nested swiss-knife reference for Claude Code CLI") {
 		t.Error("nested claude-code child should identify itself as a nested swiss-knife reference for Claude Code CLI")
+	}
+}
+
+func TestBuildSkillFolderEntries_MinimaxCliCanonicalReference(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	skillsRoot := filepath.Join(filepath.Dir(thisFile), "..", "preset", "skills")
+
+	topBodyBytes, err := os.ReadFile(filepath.Join(skillsRoot, "minimax-cli", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	topBody := string(topBodyBytes)
+	for _, want := range []string{
+		"top-level entry point",
+		"canonical: ../swiss-knife/reference/minimax-cli/SKILL.md",
+		"../swiss-knife/reference/minimax-cli/SKILL.md",
+		"read-only pointer",
+		"Do not duplicate MiniMax command recipes here",
+	} {
+		if !strings.Contains(topBody, want) {
+			t.Errorf("top-level minimax-cli entry missing %q", want)
+		}
+	}
+	if strings.Contains(topBody, "## 3. Discover credentials without leaking them") {
+		t.Error("top-level minimax-cli should stay a thin pointer, not duplicate the canonical manual")
+	}
+
+	canonicalBodyBytes, err := os.ReadFile(filepath.Join(skillsRoot, "swiss-knife", "reference", "minimax-cli", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalBody := string(canonicalBodyBytes)
+	for _, want := range []string{
+		"Nested swiss-knife reference for the MiniMax `mmx` CLI",
+		"## 3. Discover credentials without leaking them",
+		"~/.lingtai-tui/presets/saved/",
+		"Do **not** hardcode an unverified host",
+	} {
+		if !strings.Contains(canonicalBody, want) {
+			t.Errorf("canonical swiss-knife minimax-cli reference missing %q", want)
+		}
+	}
+}
+
+func TestMinimaxCliPresetDiscoverySnippetPreservesHTTPSBaseURL(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available")
+	}
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	skillPath := filepath.Join(filepath.Dir(thisFile), "..", "preset", "skills", "swiss-knife", "reference", "minimax-cli", "SKILL.md")
+	bodyBytes, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(bodyBytes)
+	if strings.Contains(body, `re.sub(r"//`) || strings.Contains(body, `re.sub(r'//`) {
+		t.Fatal("MiniMax preset-discovery snippet must not use regex // stripping; it corrupts https:// URLs")
+	}
+
+	marker := "List candidate presets (prints slot names and base URLs only, never secret values):"
+	markerIdx := strings.Index(body, marker)
+	if markerIdx < 0 {
+		t.Fatal("missing MiniMax candidate-preset snippet marker")
+	}
+	start := strings.Index(body[markerIdx:], "python3 - <<'PY'\n")
+	if start < 0 {
+		t.Fatal("missing MiniMax candidate-preset python heredoc")
+	}
+	start += markerIdx + len("python3 - <<'PY'\n")
+	end := strings.Index(body[start:], "\nPY\n```")
+	if end < 0 {
+		t.Fatal("missing end of MiniMax candidate-preset python heredoc")
+	}
+	script := body[start : start+end]
+
+	home := t.TempDir()
+	presetDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(presetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	preset := `{
+  // JSONC comment before the LLM block
+  "manifest": {
+    "llm": {
+      "provider": "minimax",
+      "api_key_env": "MINIMAX_CN_1_API_KEY",
+      "base_url": "https://api.minimaxi.com/anthropic"
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(presetDir, "minimax.jsonc"), []byte(preset), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(python, "-c", script)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("MiniMax preset-discovery snippet failed: %v\n%s", err, out)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"presets/saved/minimax.jsonc",
+		"slot=MINIMAX_CN_1_API_KEY",
+		"region=CN",
+		"base_url=https://api.minimaxi.com/anthropic",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MiniMax preset-discovery snippet output missing %q; got:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- make top-level `minimax-cli` a thin discoverability pointer with machine-readable `canonical: ../swiss-knife/reference/minimax-cli/SKILL.md`
- move the maintained MiniMax CLI procedure to `swiss-knife/reference/minimax-cli/SKILL.md` and update it for recursive TUI preset discovery, JSONC-safe parsing, region matching, and secret-safe key export
- align `dj` and `vision` with the canonical MiniMax preset/key-slot guidance
- add regression coverage for bundled extraction, TUI drill-in, and executing the documented preset-discovery snippet against JSONC containing `https://api.minimaxi.com/anthropic`
- fix two devmode tests to use explicit env stubs so `LINGTAI_DEV_ROOT` from the developer shell cannot leak into `go test ./...`

## Validation
- `(cd tui && go test -count=1 ./internal/preset ./internal/tui ./internal/config)`
- `(cd tui && go test -count=1 ./...)`
- `git diff --check origin/main...HEAD`

## Review gate
- Claude planning review: recommended canonical nested reference + top-level pointer
- Claude follow-up review: APPROVE after JSONC/canonical-pointer fixes
- GLM formal review: APPROVE
- DeepSeek review: APPROVE with minor recommendations
- MiniMax review: initially CHANGES_REQUESTED for unsafe regex JSONC stripping/canonical wording; follow-up APPROVE after fixes
- MiMo review: CHANGES_REQUESTED only because `go test ./...` exposed env leakage in two unrelated devmode tests; fixed in this PR and full TUI suite now passes

Do not merge without explicit maintainer confirmation.
