### PR TITLE
fix(tui): preserve setup defaults and API key edits

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -448,7 +448,6 @@
   "preset_editor.field_api_key": "API key",
   "preset_editor.api_key_unset": "(not set — paste here)",
   "preset_editor.api_key_codex_readonly": "OAuth credential \u2014 manage on the preset picker page.",
-  "preset_editor.api_key_locked": "API key is locked for existing presets. Create a new preset to use a different key.",
   "preset_editor.field_edit": "edit",
   "preset_editor.field_streaming": "streaming",
   "preset_editor.field_karma": "karma",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -443,7 +443,6 @@
   "preset_editor.field_api_key": "API 钥",
   "preset_editor.api_key_unset": "（未设——粘于此）",
   "preset_editor.api_key_codex_readonly": "OAuth 凭据——于择预页管之。",
-  "preset_editor.api_key_locked": "已立之预，钥不可更。欲换钥者，另立新预。",
   "preset_editor.field_edit": "编辑",
   "preset_editor.field_streaming": "流式输出",
   "preset_editor.field_karma": "因果",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -443,7 +443,6 @@
   "preset_editor.field_api_key": "API 密钥",
   "preset_editor.api_key_unset": "（未设置——在此粘贴）",
   "preset_editor.api_key_codex_readonly": "OAuth 凭据 — 于预设选择页管理。",
-  "preset_editor.api_key_locked": "已存在的预设不可改 API 密钥。如需更换，请新建一个预设。",
   "preset_editor.field_edit": "编辑",
   "preset_editor.field_streaming": "流式输出",
   "preset_editor.field_karma": "因果",

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -475,6 +475,10 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 	m.setupOrchDir = orchDir
 	m.setupOrchName = orchName
 	m.step = stepPickPreset
+	// /setup should default to the virtual "keep current preset" row.
+	// Otherwise the first saved/template preset becomes selected and downstream
+	// defaults (capabilities, provider, key slot) appear to reset unexpectedly.
+	m.cursor = -1
 	m.presets, _ = preset.List()
 
 	// Load existing addons from orchestrator's init.json so they are preserved

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -326,6 +326,54 @@ func TestPickPreset_DelCancelsInFlightLogin(t *testing.T) {
 	}
 }
 
+func TestSetupModeDefaultsToKeepCurrentPreset(t *testing.T) {
+	baseDir := t.TempDir()
+	globalDir := t.TempDir()
+	orchDir := filepath.Join(baseDir, "mimo-1")
+	if err := os.MkdirAll(orchDir, 0o755); err != nil {
+		t.Fatalf("mkdir orchDir: %v", err)
+	}
+	initJSON := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"language": "zh",
+			"llm": map[string]interface{}{
+				"provider":    "deepseek",
+				"model":       "deepseek-v4-flash",
+				"api_key_env": "DEEPSEEK_API_KEY",
+			},
+			"capabilities": map[string]interface{}{
+				"web_search": map[string]interface{}{"provider": "duckduckgo"},
+				"vision":     map[string]interface{}{"provider": "inherit"},
+			},
+		},
+	}
+	data, err := json.Marshal(initJSON)
+	if err != nil {
+		t.Fatalf("marshal init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(orchDir, "init.json"), data, 0o644); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+
+	m := NewSetupModeModel(baseDir, globalDir, orchDir, "mimo-1")
+	if !m.setupMode {
+		t.Fatalf("expected setupMode=true")
+	}
+	if m.step != stepPickPreset {
+		t.Fatalf("expected setup mode to start at preset picker, got %v", m.step)
+	}
+	if m.cursor != -1 {
+		t.Fatalf("/setup should default to keep-current preset row; cursor=%d", m.cursor)
+	}
+	if got := m.getPresetProvider(m.currentPreset()); got != "deepseek" {
+		t.Fatalf("currentPreset should be synthesized from existing init.json, provider=%q", got)
+	}
+	caps, ok := m.currentPreset().Manifest["capabilities"].(map[string]interface{})
+	if !ok || caps["web_search"] == nil || caps["vision"] == nil {
+		t.Fatalf("currentPreset should preserve existing optional capabilities, caps=%#v", caps)
+	}
+}
+
 func TestSetupModeEnterOnKeepCurrentAdvancesToAgentPresets(t *testing.T) {
 	m := FirstRunModel{
 		setupMode: true,

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -268,21 +268,12 @@ type PresetEditorModel struct {
 	// API key state. existingKeys is the host's Config.Keys snapshot
 	// (env-var-name → value), used to prefill the api_key field when a
 	// matching env var is already populated. apiKey is the live edit
-	// buffer; apiKeySet flips true when the user types into it (so we
-	// know to emit it on commit even if the new value is empty/cleared).
-	//
-	// apiKeyLocked is set at construction when the preset opens with a
-	// key already stored for its api_key_env slot. Editing an existing
-	// preset's saved key from inside this editor was confusing — users
-	// expected the row to show what was there, not silently overwrite
-	// it. When locked, the inline-edit entry on the api_key row is a
-	// no-op (the codex/OAuth branch already behaves this way for a
-	// different reason). Newly created presets with no stored key
-	// remain freely editable so initial setup still works.
+	// buffer; apiKeySet flips true only when the user explicitly edits
+	// the row (so an untouched masked key remains unchanged on commit,
+	// while a pasted replacement is written by the host).
 	existingKeys map[string]string
 	apiKey       string
 	apiKeySet    bool
-	apiKeyLocked bool
 
 	// Status
 	saveErr string
@@ -295,9 +286,10 @@ type PresetEditorModel struct {
 // on-disk Source rather than its name (so a user-saved preset whose
 // name happens to match a template is correctly treated as editable).
 //
-// existingKeys is Config.Keys (env-var-name → value) so the editor can
-// prefill the api_key row when a key is already saved for this preset's
-// api_key_env. Pass nil when no key store is available (e.g. tests).
+// existingKeys is Config.Keys (env-var-name → value). For user-owned
+// presets, the editor uses it to display an already-saved key as masked.
+// Templates intentionally start with a blank key buffer so creating a new
+// preset never inherits the provider's old shared env slot by accident.
 func NewPresetEditorModel(p preset.Preset, lang string, existingKeys map[string]string, globalDir string) PresetEditorModel {
 	return NewPresetEditorModelWithBuiltinFlag(p, lang, existingKeys, globalDir, preset.IsTemplate(p))
 }
@@ -324,14 +316,17 @@ func NewPresetEditorModelWithBuiltinFlag(p preset.Preset, lang string, existingK
 	cn := textinput.New()
 	cn.CharLimit = 64
 	cn.SetWidth(30)
-	// Prefill the api_key buffer if the preset's declared env slot
-	// already holds a value. The buffer is the source of truth for the
-	// row's display; apiKeySet stays false so we don't emit on commit
-	// unless the user actually changed it.
+	// For saved/user-owned presets, prefill the api_key buffer if the
+	// declared env slot already holds a value; this lets the row render as
+	// masked and preserves the key when untouched. For templates, keep the
+	// buffer empty: editing a template creates a new preset, and that new
+	// preset must not silently inherit an old provider-wide key.
 	apiKey := ""
-	if llm, ok := p.Manifest["llm"].(map[string]interface{}); ok {
-		if envName, _ := llm["api_key_env"].(string); envName != "" {
-			apiKey = existingKeys[envName]
+	if !isBuiltin {
+		if llm, ok := p.Manifest["llm"].(map[string]interface{}); ok {
+			if envName, _ := llm["api_key_env"].(string); envName != "" {
+				apiKey = existingKeys[envName]
+			}
 		}
 	}
 	return PresetEditorModel{
@@ -347,7 +342,6 @@ func NewPresetEditorModelWithBuiltinFlag(p preset.Preset, lang string, existingK
 		existingKeys:   existingKeys,
 		globalDir:      globalDir,
 		apiKey:         apiKey,
-		apiKeyLocked:   apiKey != "",
 	}
 }
 
@@ -566,14 +560,6 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 		// page. API key field is read-only; no-op here.
 		if asString(m.llmMap()["provider"]) == "codex" && m.globalDir != "" {
 			m.saveErr = i18n.T("preset_editor.api_key_codex_readonly")
-			return *m, nil
-		}
-		// Preset opened with a key already stored for its api_key_env.
-		// Editing here was confusing — the row shows a masked value but
-		// pressing Enter blanked the buffer and silently overwrote the
-		// stored key on commit. Lock the row instead.
-		if m.apiKeyLocked {
-			m.saveErr = i18n.T("preset_editor.api_key_locked")
 			return *m, nil
 		}
 		// Edit the live key buffer, not the env-var-name. We start
@@ -822,8 +808,12 @@ func (m *PresetEditorModel) applyInline(val string) {
 	case feAPIKey:
 		// Store the raw key in the editor's buffer; the manifest
 		// itself only holds api_key_env (the slot name), assigned at
-		// commit time by the host's stampAutoEnvVar helper. Empty
-		// commit deletes any saved key (treated as "clear it").
+		// commit time by the host's stampAutoEnvVar helper. Opening the
+		// blank replacement editor and pressing Enter without typing is
+		// a no-op, not a clear; key clearing needs an explicit future UI.
+		if val == "" {
+			return
+		}
 		m.apiKey = val
 		m.apiKeySet = true
 	}

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -6,7 +6,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/anthropics/lingtai-tui/i18n"
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
 
@@ -101,18 +100,19 @@ func TestPresetEditorShortTerminalDoesNotWrapRowsPastHeight(t *testing.T) {
 	}
 }
 
-// TestPresetEditorAPIKeyLockedWhenAlreadyStored verifies that opening the
-// editor on a preset whose api_key_env slot already holds a value blocks
-// inline edit of the api_key row. Users were confused when the masked row
-// silently overwrote the stored key on commit. New presets (empty
-// existingKeys) must still be editable — covered by the next test.
-func TestPresetEditorAPIKeyLockedWhenAlreadyStored(t *testing.T) {
+// TestPresetEditorAPIKeyEditableWhenAlreadyStored verifies that opening the
+// editor on a preset whose api_key_env slot already holds a value still allows
+// an explicit replacement. The existing key is shown masked, Enter opens a
+// blank paste target, and commit emits APIKeySet only after the user edits.
+func TestPresetEditorAPIKeyEditableWhenAlreadyStored(t *testing.T) {
 	keys := map[string]string{"MINIMAX_API_KEY": "sk-existing-value"}
-	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", keys, "", false)
+	p := testPresetEditorPreset()
+	p.Source = preset.SourceSaved
+	m := NewPresetEditorModel(p, "en", keys, "")
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 
-	if !m.apiKeyLocked {
-		t.Fatalf("expected apiKeyLocked=true when preset opens with stored key")
+	if got := m.fieldString(feAPIKey); got == "" || got == "sk-existing-value" {
+		t.Fatalf("expected existing key to render masked, got %q", got)
 	}
 
 	// Walk cursor to feAPIKey (index 9 in editorFieldOrder).
@@ -125,28 +125,108 @@ func TestPresetEditorAPIKeyLockedWhenAlreadyStored(t *testing.T) {
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	if m.mode != emBrowse {
-		t.Fatalf("expected to stay in browse mode after Enter on locked api_key, got mode=%v", m.mode)
+	if m.mode != emInline {
+		t.Fatalf("expected emInline after Enter on api_key with stored key, got mode=%v", m.mode)
 	}
-	if m.saveErr == "" {
-		t.Fatalf("expected a saveErr message explaining the lock; got empty")
+	if got := m.input.Value(); got != "" {
+		t.Fatalf("api_key replacement input should start blank for easy paste, got %q", got)
 	}
-	want := i18n.T("preset_editor.api_key_locked")
-	if m.saveErr != want {
-		t.Fatalf("expected lock message %q; got %q", want, m.saveErr)
+
+	m.input.SetValue("sk-replacement-value")
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !m.apiKeySet || m.apiKey != "sk-replacement-value" {
+		t.Fatalf("expected replacement key to be staged; apiKeySet=%v apiKey=%q", m.apiKeySet, m.apiKey)
 	}
 }
 
-// TestPresetEditorAPIKeyEditableWhenNoStoredKey is the inverse: a preset
+func TestPresetEditorAPIKeyUnchangedWhenStoredKeyUntouched(t *testing.T) {
+	keys := map[string]string{"MINIMAX_API_KEY": "sk-existing-value"}
+	p := testPresetEditorPreset()
+	p.Source = preset.SourceSaved
+	m := NewPresetEditorModel(p, "en", keys, "")
+
+	_, cmd := m.commit()
+	if cmd == nil {
+		t.Fatalf("commit returned nil cmd")
+	}
+	msg := cmd()
+	commit, ok := msg.(PresetEditorCommitMsg)
+	if !ok {
+		t.Fatalf("commit cmd returned %T, want PresetEditorCommitMsg", msg)
+	}
+	if commit.APIKeySet {
+		t.Fatalf("untouched stored API key should not be emitted as a replacement")
+	}
+}
+
+func TestPresetEditorAPIKeyBlankEditKeepsStoredKey(t *testing.T) {
+	keys := map[string]string{"MINIMAX_API_KEY": "sk-existing-value"}
+	p := testPresetEditorPreset()
+	p.Source = preset.SourceSaved
+	m := NewPresetEditorModel(p, "en", keys, "")
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	for i := 0; i < 9; i++ {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	if editorFieldOrder[m.cursor] != feAPIKey {
+		t.Fatalf("expected cursor on feAPIKey, got %v", editorFieldOrder[m.cursor])
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.mode != emInline {
+		t.Fatalf("expected emInline after opening api_key row, got mode=%v", m.mode)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.apiKeySet {
+		t.Fatalf("blank API key edit should be a no-op, not stage a clear")
+	}
+
+	_, cmd := m.commit()
+	if cmd == nil {
+		t.Fatalf("commit returned nil cmd")
+	}
+	commit, ok := cmd().(PresetEditorCommitMsg)
+	if !ok {
+		t.Fatalf("commit cmd returned non-commit msg")
+	}
+	if commit.APIKeySet {
+		t.Fatalf("blank API key edit should not emit APIKeySet=true")
+	}
+}
+
+func TestPresetEditorTemplateDoesNotInheritStoredProviderKey(t *testing.T) {
+	keys := map[string]string{"MINIMAX_API_KEY": "sk-existing-value"}
+	p := testPresetEditorPreset()
+	p.Source = preset.SourceTemplate
+	m := NewPresetEditorModel(p, "en", keys, "")
+
+	if m.apiKey != "" {
+		t.Fatalf("template editor should not preload old provider key, apiKey=%q", m.apiKey)
+	}
+	if got := m.fieldString(feAPIKey); got == "sk-existing-value" {
+		t.Fatalf("template editor should not render old provider key, got %q", got)
+	}
+
+	_, cmd := m.commit()
+	if cmd == nil {
+		t.Fatalf("commit returned nil cmd")
+	}
+	commit, ok := cmd().(PresetEditorCommitMsg)
+	if !ok {
+		t.Fatalf("commit cmd returned non-commit msg")
+	}
+	if commit.APIKeySet || commit.APIKey != "" {
+		t.Fatalf("untouched template key should not emit old provider key; APIKeySet=%v APIKey=%q", commit.APIKeySet, commit.APIKey)
+	}
+}
+
+// TestPresetEditorAPIKeyEditableWhenNoStoredKey verifies that a preset
 // with no stored key (typical for first-run flow on a fresh template)
-// must still allow inline edit so initial setup works.
+// allows inline edit so initial setup works.
 func TestPresetEditorAPIKeyEditableWhenNoStoredKey(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
-
-	if m.apiKeyLocked {
-		t.Fatalf("expected apiKeyLocked=false when no stored key")
-	}
 
 	for i := 0; i < 9; i++ {
 		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})


### PR DESCRIPTION
## Summary
- default `/setup` to the virtual keep-current preset row so existing provider/capability/key settings are not reset
- remove the preset-editor API key lock so saved/user-owned presets can explicitly replace stored keys
- avoid preloading provider keys when editing builtin/template presets so new presets do not inherit old API keys
- keep user-editable capabilities limited to `web_search` and `vision`; core capabilities remain runtime floor defaults

## Tests
- `cd tui && go test ./internal/tui ./internal/preset`
- `cd tui && make build`
