### PR TITLE
refactor(tui): split portal guide references

### DIFF
--- a/tui/internal/preset/portal_guide_populate_test.go
+++ b/tui/internal/preset/portal_guide_populate_test.go
@@ -1,0 +1,43 @@
+package preset
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPopulateBundledLibrary_PortalGuideNestedReferences verifies that the
+// embedded utility-library copier preserves the portal guide's router and
+// nested reference files on disk.
+func TestPopulateBundledLibrary_PortalGuideNestedReferences(t *testing.T) {
+	globalDir := t.TempDir()
+	PopulateBundledLibrary("", globalDir)
+
+	utilitiesDir := filepath.Join(globalDir, "utilities", "lingtai-portal-guide")
+	for _, rel := range []string{
+		"SKILL.md",
+		"reference/overview/SKILL.md",
+		"reference/topology-and-api/SKILL.md",
+		"reference/lifecycle-and-recording/SKILL.md",
+	} {
+		if _, err := os.Stat(filepath.Join(utilitiesDir, rel)); err != nil {
+			t.Fatalf("expected bundled portal-guide file %s to be extracted: %v", rel, err)
+		}
+	}
+
+	rootBody, err := os.ReadFile(filepath.Join(utilitiesDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"name: portal-guide-overview",
+		"name: portal-guide-topology-and-api",
+		"name: portal-guide-lifecycle-and-recording",
+		".lingtai/.portal/port",
+	} {
+		if !strings.Contains(string(rootBody), want) {
+			t.Errorf("extracted portal-guide root missing %q", want)
+		}
+	}
+}

--- a/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
@@ -1,128 +1,41 @@
 ---
 name: lingtai-portal-guide
-description: Reference for the LingTai portal (lingtai-portal) internals. Read this to understand the portal's API endpoints, topology recording, replay system, and .portal/ directory structure. Useful when the human asks about visualization, network history, or the portal.
-version: 1.0.0
+description: Reference router for LingTai portal (lingtai-portal) internals. Read this to understand portal startup/opening, .portal/ files, topology/replay APIs, network response shape, and lifecycle/recording behavior. Useful when the human asks about visualization, network history, or the portal.
+version: 1.1.0
 ---
 
 # Portal Guide
 
-This is a reference document. It describes how the LingTai portal works internally. Do not take action based on this skill — use it to understand the portal's architecture.
+This is a reference router. It describes how the LingTai portal works internally. Do not take action based on this skill alone — use it to choose the focused reference that matches the portal question.
 
-## What Is the Portal
+## Quick orientation
 
-`lingtai-portal` is a Go binary that serves a web-based visualization of the agent network. It:
+`lingtai-portal` is a Go binary that serves a web visualization of the agent network. It reads the same `.lingtai/` directory as the TUI, records topology frames for replay, and exposes live/replay APIs on a random local port written to `.lingtai/.portal/port`.
 
-1. Reads the same `.lingtai/` directory as the TUI (filesystem-native, no separate database)
-2. Snapshots the network topology every 3 seconds into a JSONL tape
-3. Serves a web UI for live network visualization and historical replay
-4. Listens on a random port, stored in `.lingtai/.port`
+## Nested reference catalog
 
-## Opening the Portal
-
-Read `.lingtai/.port` to get the port number. Open `http://localhost:<port>` in a browser. If the file doesn't exist, the portal is not running — the user can start it with `lingtai-portal`.
-
-## .portal/ Directory
-
-```
-.lingtai/.portal/
-├── topology.jsonl              # Live tape — one JSON frame per line
-├── replay/
-│   ├── manifest.json           # Chunk metadata (start/end timestamps, frame counts)
-│   └── chunks/
-│       ├── <hour-bucket>.json.gz   # Delta-encoded, gzipped hourly chunks
-│       └── ...
-└── reconstruct.progress        # Transient: "current/total" during reconstruction
+```yaml
+- name: portal-guide-overview
+  location: reference/overview/SKILL.md
+  description: Portal purpose, how to open it, the `.lingtai/.portal/port` contract, and the `.lingtai/.portal/` directory layout.
+- name: portal-guide-topology-and-api
+  location: reference/topology-and-api/SKILL.md
+  description: `topology.jsonl` frame shape, replay chunk storage, API endpoints, and the live `Network` response schema.
+- name: portal-guide-lifecycle-and-recording
+  location: reference/lifecycle-and-recording/SKILL.md
+  description: Portal lifecycle-state interpretation, heartbeat/staleness rule, 3-second recording loop, and reconstruction behavior.
 ```
 
-### topology.jsonl
+## Routing table
 
-Each line is a `TapeFrame`:
+| Need | Read |
+|---|---|
+| Explain what the portal is, how to open it, or where portal files live | `reference/overview/SKILL.md` |
+| Inspect topology tape format, replay chunks, API endpoints, or network JSON | `reference/topology-and-api/SKILL.md` |
+| Explain agent lifecycle states in portal output or how recording/rebuild works | `reference/lifecycle-and-recording/SKILL.md` |
 
-```json
-{
-  "t": 1744567890123,
-  "net": {
-    "nodes": [...],
-    "avatar_edges": [...],
-    "contact_edges": [...],
-    "mail_edges": [...],
-    "stats": {
-      "active": 2,
-      "idle": 1,
-      "stuck": 0,
-      "asleep": 0,
-      "suspended": 3,
-      "total_mails": 42
-    }
-  }
-}
-```
+## Safety notes
 
-`t` is milliseconds since epoch.
-
-### Replay Chunks
-
-Historical data is stored as delta-encoded, keyframed, gzipped JSON chunks bucketed by hour. The manifest lists all available chunks with their time ranges and frame counts.
-
-## API Endpoints
-
-All endpoints are served at `http://localhost:<port>`.
-
-| Endpoint | Method | Response | Description |
-|----------|--------|----------|-------------|
-| `/api/network` | GET | `Network` JSON | Live network state (nodes, edges, stats) |
-| `/api/topology` | GET | JSON array of `TapeFrame` | Full topology tape (can be large) |
-| `/api/topology/manifest` | GET | `ReplayManifest` JSON | Chunk metadata for replay |
-| `/api/topology/chunk?start=<ms>&end=<ms>` | GET | Gzipped chunk | Compressed frames for a time range |
-| `/api/topology/progress` | GET | `"current/total"` | Reconstruction progress |
-| `/api/topology/rebuild` | GET | `"ok"` | Trigger tape reconstruction |
-
-### Network Response Shape
-
-```json
-{
-  "nodes": [
-    {
-      "address": "orchestrator",
-      "agent_name": "orchestrator",
-      "nickname": "小灵",
-      "state": "ACTIVE",
-      "alive": true,
-      "is_human": false,
-      "capabilities": ["avatar", "search"]
-    }
-  ],
-  "avatar_edges": [
-    {"parent": "orchestrator", "child": "avatar-1", "child_name": "avatar-1"}
-  ],
-  "contact_edges": [
-    {"owner": "orchestrator", "target": "human", "name": "human"}
-  ],
-  "mail_edges": [
-    {"sender": "orchestrator", "recipient": "human", "count": 5}
-  ],
-  "stats": {
-    "active": 2, "idle": 1, "stuck": 0,
-    "asleep": 0, "suspended": 3, "total_mails": 42
-  }
-}
-```
-
-### 5-State Lifecycle
-
-| State | Meaning |
-|-------|---------|
-| `ACTIVE` | Agent is running and processing |
-| `IDLE` | Agent is running but waiting for input |
-| `STUCK` | Agent encountered an error or is unresponsive |
-| `ASLEEP` | Agent is in sleep mode (`.sleep` signal or stamina exhausted) |
-| `SUSPENDED` | Agent process is not running (no heartbeat) |
-
-Note: if an agent has a state in `.agent.json` but its heartbeat is stale (> 3s old), it is effectively `SUSPENDED` regardless of the stored state.
-
-## Recording
-
-The portal starts recording immediately on launch. A background goroutine calls `BuildNetwork()` every 3 seconds and appends the result as a JSONL line to `topology.jsonl`. This tape grows indefinitely. On startup, if the tape needs reconstruction (missing, empty, or old format), the portal rebuilds it from replay chunks.
-
----
-> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.
+- Treat this skill as architecture reference, not an instruction to mutate portal state.
+- If you need to change portal code, use `lingtai-dev-guide` and `lingtai-tui-anatomy` first, then read the cited Go code.
+- If a portal URL, field name, or behavior here disagrees with the current code, load `lingtai-issue-report` and surface the stale documentation.

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: portal-guide-lifecycle-and-recording
+description: Nested lingtai-portal-guide reference for portal lifecycle-state interpretation, heartbeat staleness, recording, and tape reconstruction behavior.
+version: 1.0.0
+---
+
+# Lifecycle and recording
+
+This is a nested `lingtai-portal-guide` reference. It covers how the portal interprets agent lifecycle states and how it records/rebuilds topology history.
+
+## 5-state lifecycle
+
+| State | Meaning |
+|-------|---------|
+| `ACTIVE` | Agent is running and processing |
+| `IDLE` | Agent is running but waiting for input |
+| `STUCK` | Agent encountered an error or is unresponsive |
+| `ASLEEP` | Agent is in sleep mode (`.sleep` signal or stamina exhausted) |
+| `SUSPENDED` | Agent process is not running (no heartbeat) |
+
+Heartbeat is the portal's liveness ground truth. `BuildNetwork()` currently calls `IsAlive(..., 2.0)`, so if an agent has a state in `.agent.json` but its `.agent.heartbeat` is older than about 2 seconds, the portal reports it as `SUSPENDED` regardless of the stored state.
+
+## Recording
+
+The portal starts recording immediately on launch. A background goroutine calls `BuildNetwork()` every 3 seconds and appends the result as a JSONL line to `topology.jsonl`.
+
+This tape grows indefinitely.
+
+## Reconstruction
+
+On startup, if the tape needs reconstruction (missing, empty, or old format), the portal rebuilds it from replay chunks.
+
+During startup reconstruction, `.lingtai/.portal/reconstruct.progress` may contain a transient `current/total` progress string. The `/api/topology/progress` endpoint parses that value and exposes JSON such as `{ "current": N, "total": M }` to the browser UI, or `{}` when no progress file is present. Manual `/api/topology/rebuild` returns the rebuilt `ReplayManifest` after rewriting the replay chunks.

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/overview/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/overview/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: portal-guide-overview
+description: Nested lingtai-portal-guide reference for portal purpose, opening the browser view, and the `.portal/` directory layout.
+version: 1.0.0
+---
+
+# Portal overview
+
+This is a nested `lingtai-portal-guide` reference. It covers what the portal is, how to open it, and which files it writes under `.lingtai/.portal/`.
+
+## What is the portal
+
+`lingtai-portal` is a Go binary that serves a web-based visualization of the agent network. It:
+
+1. Reads the same `.lingtai/` directory as the TUI (filesystem-native, no separate database).
+2. Snapshots the network topology every 3 seconds into a JSONL tape.
+3. Serves a web UI for live network visualization and historical replay.
+4. Listens on a random port, stored in `.lingtai/.portal/port`.
+
+## Opening the portal
+
+Read `.lingtai/.portal/port` to get the port number. Open `http://localhost:<port>` in a browser.
+
+If `.lingtai/.portal/port` does not exist, the portal is not running — the user can start it with `lingtai-portal`.
+
+## `.portal/` directory
+
+```text
+.lingtai/.portal/
+├── topology.jsonl              # Live tape — one JSON frame per line
+├── replay/
+│   └── chunks/
+│       ├── manifest.json           # Chunk metadata (start/end timestamps, frame counts)
+│       ├── <hour-bucket>.json.gz   # Delta-encoded, gzipped hourly chunks
+│       └── ...
+└── reconstruct.progress        # Transient: "current/total" during reconstruction
+```
+
+Use the `topology-and-api` reference for the data formats inside those files.

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: portal-guide-topology-and-api
+description: Nested lingtai-portal-guide reference for topology tape frames, replay chunks, portal API endpoints, and the Network JSON response.
+version: 1.0.0
+---
+
+# Topology and API
+
+This is a nested `lingtai-portal-guide` reference. It covers the on-disk topology tape, replay chunks, HTTP endpoints, and live network JSON shape.
+
+## `topology.jsonl`
+
+Each line is a `TapeFrame`:
+
+```json
+{
+  "t": 1744567890123,
+  "net": {
+    "nodes": [...],
+    "avatar_edges": [...],
+    "contact_edges": [...],
+    "mail_edges": [...],
+    "stats": {
+      "active": 2,
+      "idle": 1,
+      "stuck": 0,
+      "asleep": 0,
+      "suspended": 3,
+      "total_mails": 42
+    }
+  }
+}
+```
+
+`t` is milliseconds since epoch.
+
+## Replay chunks
+
+Historical data is stored as delta-encoded, keyframed, gzipped JSON chunks bucketed by hour under `.lingtai/.portal/replay/chunks/`. The `manifest.json` in that chunks directory lists all available chunks with their time ranges and frame counts.
+
+## API endpoints
+
+All endpoints are served at `http://localhost:<port>`.
+
+| Endpoint | Method | Response | Description |
+|----------|--------|----------|-------------|
+| `/api/network` | GET | `Network` JSON | Live network state (nodes, edges, stats) |
+| `/api/topology` | GET | JSON array of `TapeFrame` | Full topology tape (can be large) |
+| `/api/topology/manifest` | GET | `ReplayManifest` JSON | Chunk metadata for replay |
+| `/api/topology/chunk?start=<hourMs>` | GET | Chunk JSON (optionally gzip-encoded when requested) | Frames for one hour-bucket start time |
+| `/api/topology/progress` | GET | JSON object such as `{ "current": N, "total": M }` (or `{}`) | Reconstruction progress parsed from `reconstruct.progress` |
+| `/api/topology/rebuild` | POST | `ReplayManifest` JSON | Trigger tape reconstruction from source data and rewrite replay chunks |
+
+## Network response shape
+
+```json
+{
+  "nodes": [
+    {
+      "address": "orchestrator",
+      "agent_name": "orchestrator",
+      "nickname": "小灵",
+      "state": "ACTIVE",
+      "alive": true,
+      "is_human": false,
+      "capabilities": ["avatar", "search"]
+    }
+  ],
+  "avatar_edges": [
+    {"parent": "orchestrator", "child": "avatar-1", "child_name": "avatar-1"}
+  ],
+  "contact_edges": [
+    {"owner": "orchestrator", "target": "human", "name": "human"}
+  ],
+  "mail_edges": [
+    {"sender": "orchestrator", "recipient": "human", "count": 5}
+  ],
+  "stats": {
+    "active": 2,
+    "idle": 1,
+    "stuck": 0,
+    "asleep": 0,
+    "suspended": 3,
+    "total_mails": 42
+  }
+}
+```

--- a/tui/internal/tui/portal_guide_nested_test.go
+++ b/tui/internal/tui/portal_guide_nested_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestBuildSkillFolderEntries_PortalGuideNestedReferences verifies that the
+// shipped portal guide is a router with nested reference SKILL.md files and
+// that the TUI drill-in view exposes those files under the reference group.
+func TestBuildSkillFolderEntries_PortalGuideNestedReferences(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	skillDir := filepath.Join(filepath.Dir(thisFile), "..", "preset", "skills", "lingtai-portal-guide")
+
+	entries := buildSkillFolderEntries(skillDir)
+	if len(entries) == 0 {
+		t.Fatal("no entries; is lingtai-portal-guide missing?")
+	}
+	if entries[0].Label != "SKILL.md" {
+		t.Errorf("first entry = %q, want SKILL.md", entries[0].Label)
+	}
+
+	rootBodyBytes, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootBody := string(rootBodyBytes)
+	for _, want := range []string{
+		"Nested reference catalog",
+		"name: portal-guide-overview",
+		"reference/overview/SKILL.md",
+		"name: portal-guide-topology-and-api",
+		"reference/topology-and-api/SKILL.md",
+		"name: portal-guide-lifecycle-and-recording",
+		"reference/lifecycle-and-recording/SKILL.md",
+		".lingtai/.portal/port",
+		"Routing table",
+	} {
+		if !strings.Contains(rootBody, want) {
+			t.Errorf("portal-guide root missing %q", want)
+		}
+	}
+
+	labels := make(map[string]MarkdownEntry)
+	for _, e := range entries {
+		labels[e.Label] = e
+	}
+	for _, want := range []string{
+		"overview/SKILL.md",
+		"topology-and-api/SKILL.md",
+		"lifecycle-and-recording/SKILL.md",
+	} {
+		e, ok := labels[want]
+		if !ok {
+			t.Fatalf("missing nested portal-guide entry %q", want)
+		}
+		if e.Group != "reference" {
+			t.Errorf("entry %q group = %q, want reference", want, e.Group)
+		}
+	}
+
+	for _, rel := range []string{
+		filepath.Join("reference", "overview", "SKILL.md"),
+		filepath.Join("reference", "topology-and-api", "SKILL.md"),
+		filepath.Join("reference", "lifecycle-and-recording", "SKILL.md"),
+	} {
+		childBodyBytes, err := os.ReadFile(filepath.Join(skillDir, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(childBodyBytes), "nested `lingtai-portal-guide` reference") {
+			t.Errorf("%s should identify itself as a nested lingtai-portal-guide reference", rel)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- split `lingtai-portal-guide` into a root router plus three nested references: overview, topology/API, lifecycle/recording
- add router `Nested reference catalog` YAML + routing table following the standard from recent skill refactors
- correct verified stale portal details while moving content: `.portal/port`, replay manifest location, rebuild POST/response, chunk query, progress JSON, heartbeat threshold
- add focused bundled-library extraction and TUI drill-in tests for the new nested reference layout

## Validation
- manual portal-guide router/stale-snippet validation PASS
- `(cd tui && go test -count=1 ./internal/preset ./internal/tui)` PASS
- `(env -u LINGTAI_DEV_ROOT bash -lc 'cd tui && go test -count=1 ./...')` PASS
- `git diff --check origin/main...HEAD` PASS

## Review gate
- GLM formal review: APPROVE
- DeepSeek review: APPROVE; follow-up APPROVE after code-verified stale-doc corrections, with one non-blocking progress endpoint note that is fixed in this head
- MiniMax review: APPROVE
- MiMo review: CHANGES_REQUESTED for child name prefixes + stale portal details; follow-up APPROVE after fixes