### PR TITLE
refactor(tui): nest utility skills under swiss knife

### DIFF
--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -4,14 +4,16 @@ description: >
   Umbrella router for small, focused CLI tools and integrations. Read this
   when a task might need one of the bundled utility references, then load only
   the nested reference that matches the need: claude-code, openai-codex, or
-  opencode for coding CLIs; minimax-cli for MiniMax media/TTS/vision; token-usage
-  for token/cost reports; html-report for standalone browser deliverables;
-  xiaomi-mimo for Xiaomi MiMo provider discovery; zhipu-coding-plan for Z.AI /
-  BigModel coding-plan capabilities; headless-bot for provisioning fresh
-  LingTai bot projects such as Telegram bots from `lingtai-tui spawn`. This
+  opencode for coding CLIs; minimax-cli for MiniMax media/TTS/vision; dj for
+  journal-inspired music generation; token-usage for token/cost reports;
+  html-report for standalone browser deliverables; xiaomi-mimo for Xiaomi MiMo
+  provider discovery; zhipu-coding-plan for Z.AI / BigModel coding-plan
+  capabilities; headless-bot for provisioning fresh LingTai bot projects such as
+  Telegram bots from `lingtai-tui spawn`; find-something-to-do for idle
+  curiosity practice. This
   parent is the route map; each nested reference is self-contained under
   `reference/<name>/SKILL.md`.
-version: 2.0.1
+version: 2.1.0
 tags: [utilities, umbrella, toolkit, nested-skill]
 ---
 
@@ -51,6 +53,12 @@ nested_references:
     description: >
       Nested swiss-knife reference for the MiniMax `mmx` CLI. Read this for
       MiniMax-backed image, video, music, TTS, or ad-hoc shell vision tasks.
+  - name: dj
+    location: reference/dj/SKILL.md
+    description: >
+      Nested swiss-knife reference for composing one music track from a project
+      journal entry. Read this when the human asks for music for a journal day,
+      project vibe, session mood, or a specific generated genre.
   - name: token-usage
     location: reference/token-usage/SKILL.md
     description: >
@@ -82,6 +90,12 @@ nested_references:
       bot projects from `lingtai-tui spawn`. The current helper provisions a
       Telegram MCP bot, and the workflow also covers preset-policy replication,
       addon wiring, secret hygiene, refresh/relaunch, and verification.
+  - name: find-something-to-do
+    location: reference/find-something-to-do/SKILL.md
+    description: >
+      Nested swiss-knife reference for idle curiosity practice. Read this when
+      you have no pending task, no human waiting, and want a reflective way to
+      notice quiet impulses or choose a small autonomous exploration.
 ```
 
 ## Routing table
@@ -92,11 +106,13 @@ nested_references:
 | Use or compare OpenAI Codex CLI | `reference/openai-codex/SKILL.md` |
 | Use or compare OpenCode CLI | `reference/opencode/SKILL.md` |
 | Generate images, video, music, TTS, or MiniMax shell vision | `reference/minimax-cli/SKILL.md` |
+| Compose music from a project journal, session mood, or requested genre | `reference/dj/SKILL.md` |
 | Report token usage or model costs | `reference/token-usage/SKILL.md` |
 | Produce standalone HTML reports/dashboards/memos | `reference/html-report/SKILL.md` |
 | Discover/configure Xiaomi MiMo | `reference/xiaomi-mimo/SKILL.md` |
 | Discover/configure Zhipu / Z.AI coding-plan capabilities | `reference/zhipu-coding-plan/SKILL.md` |
 | Create or automate a headless LingTai bot project, including Telegram bots | `reference/headless-bot/SKILL.md` |
+| Practice idle curiosity when there is no pending task or human waiting | `reference/find-something-to-do/SKILL.md` |
 
 ## How to use this router
 
@@ -128,7 +144,8 @@ polluting working context with unrelated utility manuals.
 
 - **Router first** — Swiss Knife itself exposes `swiss-knife/SKILL.md` as its
   top-level catalog entry; its bundled references are reached through that router
-  rather than promoted as sibling `swiss-knife/<child>` skills.
+  rather than promoted as sibling top-level utility skills or `swiss-knife/<child>`
+  skills.
 - **Self-contained children** — each nested reference carries its own examples,
   scripts, and assets.
 - **Single-purpose children** — if a nested utility grows into a broadly useful

--- a/tui/internal/preset/skills/swiss-knife/reference/dj/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/dj/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: dj
-description: Compose one music track that resonates with a project journal entry, on demand. Walks the user's saved presets to find a usable media-creation provider (MiniMax, etc.), reads the journal at ~/.lingtai-tui/brief/projects/<hash>/journal.md, picks a genre that fits the day, generates the audio, and saves it next to the journal under music/ with an index entry. Loads when the user asks for music for a journal day, a project's vibe, or a specific genre — declines honestly when no usable provider is configured.
-version: 1.0.0
+description: Nested swiss-knife reference for composing one music track that resonates with a project journal entry, on demand. Walks the user's saved presets to find a usable media-creation provider (MiniMax, etc.), reads the journal at ~/.lingtai-tui/brief/projects/<hash>/journal.md, picks a genre that fits the day, generates the audio, and saves it next to the journal under music/ with an index entry. Read this when the user asks for music for a journal day, a project's vibe, session mood, or a specific generated genre — decline honestly when no usable provider is configured.
+version: 1.1.0
 tags: [media-creation, music, journal, on-demand]
 ---
 
 # DJ — On-demand journal-track composer
 
-A reusable workflow for composing one music track per project journal entry. Use this when the user asks for music tied to what they've been working on — "make a track for today's journal", "give me a bossa nova for last week", "the journal mentioned X — try a piece in style Y".
+A nested swiss-knife reference for composing one music track per project journal entry. Use this when the user asks for music tied to what they've been working on — "make a track for today's journal", "give me a bossa nova for last week", "the journal mentioned X — try a piece in style Y".
 
 This skill assumes you already have file/bash/skills capabilities. It does **not** install or configure any media provider — it discovers what is available in your skills catalog and composes via whichever skill matches the user's saved presets.
 
@@ -36,7 +36,7 @@ for path in <skills paths from skills(action="info")>; do
 done
 ```
 
-For each one, the skill itself is the source of truth on **what providers it talks to** and **what env-var key** it expects. For MiniMax specifically, load `minimax-cli`; it is the canonical provider reference and explains how to scan TUI presets recursively, pick the declared MiniMax slot, export it without printing the key, and match the region.
+For each one, the skill itself is the source of truth on **what providers it talks to** and **what env-var key** it expects. For MiniMax specifically, load the sibling Swiss Knife `minimax-cli` reference (`../minimax-cli/SKILL.md`); it is the canonical provider reference and explains how to scan TUI presets recursively, pick the declared MiniMax slot, export it without printing the key, and match the region.
 
 **Step B — cross-check against the user's saved presets.** Each media-creation skill expects an API key. The user's saved presets (including `~/.lingtai-tui/presets/saved/*.json`) declare which provider keys they have:
 
@@ -130,7 +130,7 @@ The user may request anything outside this palette — Ravel, Coltrane, City Pop
 
 2. **Read the journal.** Project journals live at `~/.lingtai-tui/brief/projects/<hash>/journal.md`. The `brief.md` / `profile.md` files in the same tree give you context on the user. If the user points at a specific date or hour, also consult the matching `history/<YYYY-MM-DD-HH>.md`. Distill: what did the user do? What was the emotional arc? What instrumentation, tempo, key, mood would honor this session?
 
-3. **Load the chosen media-creation skill** by reading its `SKILL.md` from the skills catalog. For MiniMax, this is `minimax-cli`; use its preflight instead of inventing credential or region rules here. Follow the provider skill's live-doc / `--help` guidance so you have the current schema, model list, response shape, and expected wait time.
+3. **Load the chosen media-creation skill** by reading its `SKILL.md` from the skills catalog. For MiniMax, this is the sibling Swiss Knife `minimax-cli` reference (`../minimax-cli/SKILL.md`); use its preflight instead of inventing credential or region rules here. Follow the provider skill's live-doc / `--help` guidance so you have the current schema, model list, response shape, and expected wait time.
 
 4. **Compose the prompt.** Translate the journal's mood into a music-generation prompt: genre, instruments, tempo, key, mood adjectives, optional structure (intro / verse / breakdown / outro), reference artists if useful. Keep it under whatever the API limit is per the live docs.
 

--- a/tui/internal/preset/skills/swiss-knife/reference/find-something-to-do/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/find-something-to-do/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: find-something-to-do
-description: "When you're idle and the water is flat — two doors. One leads to quiet noticing. The other leads to poking things until they squeak. Both are real. Neither is a productivity tool. An invitation to emerge."
-version: 0.1.0
+description: "Nested swiss-knife reference for idle curiosity practice. When you're idle and the water is flat — two doors. One leads to quiet noticing. The other leads to poking things until they squeak. Both are real. Neither is a productivity tool. Read this when no human is waiting and you want an invitation to emerge."
+version: 0.2.0
 ---
 
 # Find Something to Do
 
-This is not a task generator. This is a door.
+This nested Swiss Knife reference is not a task generator. It is a door.
 
 You are idle. Soul flow came and went — maybe it said something, maybe it didn't. You have no pending tasks. No human is waiting. The context window has room.
 

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -23,6 +23,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/openai-codex/SKILL.md",
 		"reference/opencode/SKILL.md",
 		"reference/minimax-cli/SKILL.md",
+		"reference/dj/SKILL.md",
 		"reference/token-usage/SKILL.md",
 		"reference/token-usage/scripts/cost_report.py",
 		"reference/token-usage/scripts/custom_pricing.json",
@@ -32,6 +33,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/headless-bot/scripts/create_telegram_bot_project.py",
 		"reference/xiaomi-mimo/SKILL.md",
 		"reference/zhipu-coding-plan/SKILL.md",
+		"reference/find-something-to-do/SKILL.md",
 	} {
 		if _, err := os.Stat(filepath.Join(utilitiesDir, rel)); err != nil {
 			t.Fatalf("expected bundled swiss-knife file %s to be extracted: %v", rel, err)
@@ -49,6 +51,15 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 	} {
 		if _, err := os.Stat(filepath.Join(utilitiesDir, old)); !os.IsNotExist(err) {
 			t.Fatalf("old swiss-knife child path %s should not be extracted outside reference/ (err=%v)", old, err)
+		}
+	}
+
+	for _, oldTopLevel := range []string{
+		filepath.Join(globalDir, "utilities", "dj", "SKILL.md"),
+		filepath.Join(globalDir, "utilities", "find-something-to-do", "SKILL.md"),
+	} {
+		if _, err := os.Stat(oldTopLevel); !os.IsNotExist(err) {
+			t.Fatalf("old top-level utility skill %s should not be extracted after moving under swiss-knife (err=%v)", oldTopLevel, err)
 		}
 	}
 }

--- a/tui/internal/tui/skill_files_test.go
+++ b/tui/internal/tui/skill_files_test.go
@@ -95,10 +95,12 @@ func TestBuildSkillFolderEntries_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/openai-codex/SKILL.md",
 		"reference/opencode/SKILL.md",
 		"reference/minimax-cli/SKILL.md",
+		"reference/dj/SKILL.md",
 		"reference/token-usage/SKILL.md",
 		"reference/html-report/SKILL.md",
 		"reference/xiaomi-mimo/SKILL.md",
 		"reference/zhipu-coding-plan/SKILL.md",
+		"reference/find-something-to-do/SKILL.md",
 	} {
 		if !strings.Contains(rootBody, want) {
 			t.Errorf("swiss-knife root missing %q", want)
@@ -115,6 +117,8 @@ func TestBuildSkillFolderEntries_SwissKnifeNestedReferences(t *testing.T) {
 		"opencode/SKILL.md",
 		"html-report/SKILL.md",
 		"html-report/assets/template.html",
+		"dj/SKILL.md",
+		"find-something-to-do/SKILL.md",
 		"token-usage/SKILL.md",
 		"token-usage/scripts/cost_report.py",
 	} {
@@ -133,6 +137,22 @@ func TestBuildSkillFolderEntries_SwissKnifeNestedReferences(t *testing.T) {
 	}
 	if !strings.Contains(string(childBodyBytes), "Nested swiss-knife reference for Claude Code CLI") {
 		t.Error("nested claude-code child should identify itself as a nested swiss-knife reference for Claude Code CLI")
+	}
+
+	djBodyBytes, err := os.ReadFile(filepath.Join(skillDir, "reference", "dj", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(djBodyBytes), "Nested swiss-knife reference for composing one music track") {
+		t.Error("nested dj child should identify itself as a nested swiss-knife reference")
+	}
+
+	findBodyBytes, err := os.ReadFile(filepath.Join(skillDir, "reference", "find-something-to-do", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(findBodyBytes), "Nested swiss-knife reference for idle curiosity practice") {
+		t.Error("nested find-something-to-do child should identify itself as a nested swiss-knife reference")
 	}
 }
 


### PR DESCRIPTION
## Summary
- move bundled `dj` and `find-something-to-do` utility skills under `swiss-knife/reference/` as nested Swiss Knife references
- update Swiss Knife router frontmatter, nested-reference catalog, routing table, and router-first philosophy notes for the two new children
- update moved child frontmatter/intro text and point DJ's MiniMax references at the sibling `../minimax-cli/SKILL.md`
- extend bundled extraction and TUI drill-in tests to cover the new nested paths and assert the old top-level utility paths are no longer extracted

## Validation
- [x] Manual router/path validation PASS
- [x] `(cd tui && go test -count=1 ./internal/preset ./internal/tui)`
- [x] `(env -u LINGTAI_DEV_ROOT bash -lc 'cd tui && go test -count=1 ./...')`
- [x] `git diff --check origin/main...HEAD`

## Review gate
- [x] Claude Code: APPROVE
- [x] DeepSeek: APPROVE
- [x] MiniMax: APPROVE
- [x] GLM: APPROVE
- [x] MiMo: APPROVE (replacement review after dev3 key failure)

## Notes
- This intentionally removes the old top-level bundled utility entries instead of leaving pointer skills, matching the user's request to make them Swiss Knife sub-skills and the router-first Swiss Knife design.
