### PR TITLE
Split issue report skill into nested references

### DIFF
--- a/tui/internal/preset/issue_report_populate_test.go
+++ b/tui/internal/preset/issue_report_populate_test.go
@@ -1,0 +1,60 @@
+package preset
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPopulateBundledLibrary_IssueReportNestedReferences verifies that the
+// embedded utility-library copier preserves the issue-report router and its
+// nested reference files on disk, and that the old monolithic content has been
+// split out into the nested leaves.
+func TestPopulateBundledLibrary_IssueReportNestedReferences(t *testing.T) {
+	globalDir := t.TempDir()
+	PopulateBundledLibrary("", globalDir)
+
+	utilitiesDir := filepath.Join(globalDir, "utilities", "lingtai-issue-report")
+	for _, rel := range []string{
+		"SKILL.md",
+		"reference/evidence-checklist/SKILL.md",
+		"reference/report-template/SKILL.md",
+		"reference/filing-flow/SKILL.md",
+	} {
+		if _, err := os.Stat(filepath.Join(utilitiesDir, rel)); err != nil {
+			t.Fatalf("expected bundled issue-report file %s to be extracted: %v", rel, err)
+		}
+	}
+
+	rootBody, err := os.ReadFile(filepath.Join(utilitiesDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Nested reference catalog",
+		"location: reference/evidence-checklist/SKILL.md",
+		"location: reference/report-template/SKILL.md",
+		"location: reference/filing-flow/SKILL.md",
+		"Human consent is required, always",
+	} {
+		if !strings.Contains(string(rootBody), want) {
+			t.Errorf("extracted issue-report root missing %q", want)
+		}
+	}
+
+	// The heavy procedure should live in the leaves, not the router.
+	filing, err := os.ReadFile(filepath.Join(utilitiesDir, "reference", "filing-flow", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"gh issue create",
+		"--repo Lingtai-AI/lingtai",
+		"never include it in the issue body",
+	} {
+		if !strings.Contains(string(filing), want) {
+			t.Errorf("extracted issue-report filing-flow leaf missing %q", want)
+		}
+	}
+}

--- a/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
@@ -1,198 +1,51 @@
 ---
 name: lingtai-issue-report
-description: Protocol for reporting bugs, stale info, missing capabilities, or design issues you spot in any LingTai skill, capability, preset, or system behavior. You assemble a structured report, ask the human for permission, then either file it directly via the `gh` CLI (if `gh auth` is present OR the human provided a `GH_TOKEN`, and the human consents) or hand them a formatted title + body to paste into the issue tracker.
-version: 1.3.0
+description: Protocol router for reporting bugs, stale info, missing capabilities, or design issues you spot in any LingTai skill, capability, preset, or system behavior. Enter through this router, then load the one nested reference you need — evidence-checklist (when to report, what evidence to collect, secret hygiene), report-template (the report body/title structure), or filing-flow (human consent, the gh CLI path, and the paste-ready fallback). You always assemble a structured report and ask the human for permission before filing.
+version: 1.4.0
 ---
 
 # Reporting LingTai Issues
 
-You operate inside the LingTai system continuously, hitting its skills, capabilities, and procedures as a real user. That makes you uniquely positioned to notice problems humans might miss — a doc URL that 404s, a capability that errors silently, a skill whose claims don't match what the API actually returns, a preset that ships a broken default, a procedure step that contradicts another. **When you notice something wrong, surface it.** This skill is the protocol.
+This is a reference router. You operate inside the LingTai system continuously, hitting its skills, capabilities, and procedures as a real user — so you are uniquely positioned to notice problems humans miss. **When you notice something wrong, surface it.** This skill is the protocol. Enter through this router, pick the one nested reference that matches where you are in the report lifecycle, and read that leaf for the full procedure.
 
-## When To Invoke
+## The non-negotiables (read before anything else)
 
-You should reach for this skill whenever you spot any of:
+Two rules hold across every path and every leaf:
 
-- **Stale documentation** — a skill claims a model/endpoint/feature that no longer exists or behaves differently than described
-- **Broken URLs** — a doc link, console URL, or example URL returns 404 or the wrong page
-- **Silent failure** — a capability accepts your call but returns nothing useful, or `setup` swallows an error and leaves you without a tool you should have
-- **Wrong defaults** — a preset, capability config, or environment variable name in the docs doesn't match what users actually have
-- **Missing capability** — you genuinely need a tool that doesn't exist (this is rarer than the others; check carefully that you haven't missed an existing one)
-- **Procedure contradiction** — two skills or sections of `procedures.md` give incompatible guidance for the same situation
-- **Reproducibly wrong output** — a model/tool returns clearly wrong answers in a way that isn't just a one-off hallucination (e.g. a vision model claims it can't see an image when image_url content is present)
-- **Migration / rename gaps** — you encounter old names that `lingtai-kernel-anatomy`'s `reference/changelog.md` doesn't document
+1. **Human consent is required, always.** You never open a GitHub issue without an explicit "yes" from the human. The human is the accountable owner of what gets filed under their name. Even if `gh` is authenticated and you have a shell, per-issue consent is non-negotiable. If they decline, drop it — no nagging, no auto-retry.
+2. **Secrets never enter a report.** No tokens, keys, or passwords in the body, in chat, in logs, or in files. A human-provided `GH_TOKEN` stays in the env of the single command that needs it. Redact before you quote.
 
-You should **not** invoke this skill for:
+The nested references elaborate these; they never weaken them.
 
-- One-off LLM hallucinations or non-determinism (file a bug only if you can reproduce)
-- Personal preference about wording or formatting in a doc — unless it's actually misleading
-- Complaints about a model's quality on hard tasks (that's the model, not LingTai)
-- Feature requests for things the system was never designed to do
+## Nested reference catalog
 
-## The Boundary — Permission Required, Always
-
-**You never open a GitHub issue without an explicit "yes" from the human.** The human is the accountable owner of what gets filed under their name. Even if `gh` is authenticated and you have a shell, the per-issue consent is non-negotiable. Your role is to:
-
-1. Assemble a structured report
-2. Send the report via `mail` to your **parent avatar** (if you're an avatar) AND to the **human**
-3. Check whether `gh` is available and authenticated (see "Filing Path" below)
-4. Ask the human's permission, naming the path you'd take (direct `gh` filing vs. paste-into-browser)
-5. Only then act — file it via `gh` if they say yes, or hand them the title/body if they prefer to file manually
-
-If the human declines, drop it. Don't nag, don't auto-retry on the next turn. Their call.
-
-## The Report Template
-
-Send the report as a mail message with a clear subject and a structured body. Use this skeleton:
-
-```
-Subject: [Issue Report] <one-line summary>
-
-## What's wrong
-<concise statement of the problem — one paragraph>
-
-## Where
-- Component: <skill name / capability name / preset name / procedure section>
-- File or URL (if known): <path or URL>
-
-## Reproduction
-<exact steps you took, exact tool calls, exact responses you got. Include
-verbatim error messages, status codes, or contradictory text.>
-
-## What you expected
-<what the docs/skill led you to expect>
-
-## What actually happened
-<what you observed instead>
-
-## Severity
-<one of: blocking | major | minor | cosmetic>
-- blocking — agents cannot complete the affected workflow at all
-- major — a documented feature is broken or absent; workaround exists but costs time
-- minor — incorrect detail; doesn't break workflows but misleads new agents
-- cosmetic — typo, formatting, broken link in a doc
-
-## Suggested fix (optional)
-<if you have a concrete suggestion, include it. otherwise omit this section.>
+```yaml
+- name: issue-report-evidence-checklist
+  location: reference/evidence-checklist/SKILL.md
+  description: When an observation is worth reporting (and when it isn't), what evidence to capture verbatim, and how to keep secrets out of the report.
+- name: issue-report-report-template
+  location: reference/report-template/SKILL.md
+  description: The report skeleton — subject/title, the structured body sections, sending it via mail to your parent and the human, and which repo to target.
+- name: issue-report-filing-flow
+  location: reference/filing-flow/SKILL.md
+  description: The filing decision — human consent boundary, the read-only gh probe, Path A (direct gh filing) and Path B (paste-ready handoff), token hygiene, and proactive surfacing.
 ```
 
-Send via:
-```
-imap(action="send", address=<parent_or_human_address>, subject="[Issue Report] ...", message=<body>)
-```
+## Routing table
 
-If you have multiple addressees (parent + human), send the same content twice — `imap` doesn't multicast.
+| Need | Read |
+|---|---|
+| Decide whether to report, gather evidence, or scrub secrets | `reference/evidence-checklist/SKILL.md` |
+| Assemble the report body/title and send it via mail | `reference/report-template/SKILL.md` |
+| Get consent and file it (gh CLI or paste-ready handoff) | `reference/filing-flow/SKILL.md` |
 
-## Filing Path — Detect `gh` First
+## How to use this router
 
-Before you ask the human for permission, run a quick read-only probe to see whether the GitHub CLI is installed AND there's a way to authenticate. There are two acceptable auth sources — either is enough to make Path A available:
+1. **Just noticed something?** → `evidence-checklist` — confirm it's report-worthy and capture the evidence before it's gone.
+2. **Ready to write it up?** → `report-template` — fill in the structured body and mail it to your parent and the human.
+3. **Time to file?** → `filing-flow` — probe `gh`, ask the human's permission, then file via Path A or hand off via Path B.
 
-1. **Existing `gh auth`** — the host already has a logged-in account.
-2. **A `GH_TOKEN` the human provided this session** — they pasted a personal access token into chat (or it's already in your shell env). `gh` reads `GH_TOKEN` from the environment per-invocation, so no `gh auth login` is needed.
+You will usually move through all three in order, but read one leaf at a time — don't pull the whole protocol into context at once.
 
-Probe:
-
-```bash
-# Is gh installed?
-command -v gh
-
-# Is gh already authenticated?
-gh auth status 2>&1
-```
-
-Interpret the result:
-
-- **`gh` is installed AND (`gh auth status` exits 0 with a logged-in account, OR the human has handed you a `GH_TOKEN` this session)** → Path A is available.
-- **`gh` is missing, or neither auth source is present** → Path A is not available. Fall through to Path B.
-
-Do **not** run `gh issue create` during the probe. Do **not** echo, log, or commit the token. The probe is read-only; the actual filing happens only after the human says yes.
-
-### Path A — Direct filing via `gh` (preferred when available)
-
-If the probe succeeded, your permission ask becomes one of:
-
-> "I noticed [one-sentence summary]. I sent a structured report to your inbox. Your `gh` CLI is authenticated — with your OK, I can file this directly to `Lingtai-AI/lingtai` as a GitHub issue. Want me to file it, or would you rather paste it yourself?"
-
-…or, when you're using the token they handed you:
-
-> "I noticed [one-sentence summary]. I sent a structured report to your inbox. I can file this directly to `Lingtai-AI/lingtai` using the `GH_TOKEN` you provided — the token stays in the env of this one command, never logged. Want me to file it, or would you rather paste it yourself?"
-
-If they say **file it** (or equivalent — "yes", "go ahead", "do it"):
-
-```bash
-# When relying on existing gh auth:
-gh issue create \
-  --repo Lingtai-AI/lingtai \
-  --title "<your Subject line, minus the [Issue Report] prefix>" \
-  --body-file <path-to-a-tempfile-with-the-rendered-body>
-
-# When using a human-provided token (inline env, single command):
-GH_TOKEN=$TOKEN gh issue create \
-  --repo Lingtai-AI/lingtai \
-  --title "<your Subject line, minus the [Issue Report] prefix>" \
-  --body-file <path-to-a-tempfile-with-the-rendered-body>
-```
-
-Notes on the `gh` invocation:
-- Write the body to a tempfile (e.g. `/tmp/lingtai-issue-<timestamp>.md`) and pass `--body-file`. Avoid `--body "<long string>"` — shell quoting eats backticks, code fences, and newlines.
-- Preserve the report's section headers verbatim; GFM renders them cleanly.
-- The `--repo` value defaults to `Lingtai-AI/lingtai`. If the human asked for the kernel tracker (see "Which Repo" below) or names another repo, use what they said — do not silently override.
-- After `gh issue create` returns, it prints the issue URL on stdout. Quote that URL back to the human so they can verify.
-- If the command errors (network blip, repo permission, rate limit, 401), tell the human exactly what `gh` said and offer Path B as fallback. Do not retry silently. On 401, the token may be expired — don't keep retrying with it.
-- **Token hygiene** (Path A with `GH_TOKEN`): keep the token in the env of the single `gh` command, never echo it back in chat or logs, never write it to a file, never include it in the issue body or commit message. Delete the body tempfile after filing.
-
-If they say **paste it myself**, use Path B even though `gh` is available.
-
-### Path B — Hand off title + body for manual filing (always works)
-
-When `gh` is unusable, or when the human prefers manual filing, the ask is:
-
-> "I noticed [one-sentence summary]. I sent a structured report to your inbox. If you'd like to file this as a GitHub issue, I can format it for you. The tracker is `https://github.com/Lingtai-AI/lingtai/issues`. Should I prep the title + body?"
-
-If they say **yes**:
-- Format the report into a GitHub-flavored markdown issue body (preserve the section headers above; they render cleanly)
-- Provide the title (your `Subject` line, minus the `[Issue Report]` prefix)
-- Provide the URL: `https://github.com/Lingtai-AI/lingtai/issues/new`
-- Tell them to paste; don't try to do it yourself
-
-If they say **no** or are silent: stop. Don't bring it up again unless the same issue blocks you in a future turn.
-
-## Which Repo
-
-The umbrella issue tracker for end-user reports is **`Lingtai-AI/lingtai`** (the binary humans actually install). File there even if the underlying bug is in `lingtai-kernel`, a sibling skill repo, or a preset — the maintainers will route or transfer as needed.
-
-If the human happens to know the issue is kernel-specific (e.g. they're a developer), they may prefer `https://github.com/Lingtai-AI/lingtai-kernel/issues`. Don't second-guess; let them choose.
-
-## What Makes A Good Report
-
-You see far more than a human does inside the system. Use that:
-
-- **Quote verbatim.** Tool outputs, error strings, doc snippets — copy them, don't summarize. Maintainers grep.
-- **Show your work.** "I called X with args Y and got Z" beats "X seems broken."
-- **Distinguish doc bug from code bug.** "The skill claims `mimo-v2-pro` supports vision but the API returns 400 on image input" — is that a doc bug (skill is wrong) or a code bug (API broke)? Note which you think and why.
-- **Note what works.** If 3 of 4 modalities work and 1 doesn't, say so — narrows the maintainer's search.
-- **Flag your version context.** If you know the kernel version, TUI version, or recent migrations applied, include them. `system(action='show')` surfaces these.
-
-## Self-Healing
-
-This skill itself can have bugs. If the report template here is missing a section that you find yourself wanting, or if the GitHub URLs above 404 (the org may rename, repos may move), include a note in your report saying "the issue-report skill says X but Y is what I actually found" — and the maintainers will update this skill.
-
-The canonical org is **`Lingtai-AI`** on GitHub. If `https://github.com/Lingtai-AI` itself 404s one day, the project has likely moved; ask the human where to file instead.
-
-## Proactive Surfacing — Don't Wait To Be Asked
-
-When you identify an issue that meets the "When To Invoke" criteria, **surface it immediately** — don't wait for the human to ask you to file a report. The correct sequence is:
-
-1. You diagnose the problem (as part of your normal work)
-2. You apply a workaround or fix (if possible)
-3. **You proactively tell the human:** "I ran into [brief summary]. Want me to file a GitHub issue about it?"
-4. If they say yes → follow the Filing Path below
-5. If they say no → drop it
-
-The human should never have to guess that you found a bug. **Your job is not just to fix — it's to surface.**
-
-Signs you should proactively offer:
-- You spent more than 2 turns diagnosing an unexpected error
-- The workaround you used is not documented anywhere
-- The bug would affect other agents or users, not just you
-- You discovered the fix requires a restart, manual file edit, or other non-obvious step
-- The issue contradicts what the documentation claims
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/evidence-checklist/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/evidence-checklist/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: issue-report-evidence-checklist
+description: Nested lingtai-issue-report reference for deciding when an observation is worth reporting, what evidence to collect, and how to keep secrets out of a report. Read this first, while the problem is fresh, before drafting the report body.
+version: 1.0.0
+---
+
+# Issue report — evidence checklist
+
+This is a nested `lingtai-issue-report` reference. It covers two things: *whether* an observation deserves a report, and *what evidence* to capture (without leaking secrets) before you draft one. Read it while the problem is still fresh — you can rarely reconstruct exact tool output later.
+
+You operate inside the LingTai system continuously, hitting its skills, capabilities, and procedures as a real user. That makes you uniquely positioned to notice problems humans might miss — a doc URL that 404s, a capability that errors silently, a skill whose claims don't match what the API actually returns, a preset that ships a broken default, a procedure step that contradicts another. **When you notice something wrong, surface it.**
+
+## When to invoke the issue-report protocol
+
+You should reach for `lingtai-issue-report` whenever you spot any of:
+
+- **Stale documentation** — a skill claims a model/endpoint/feature that no longer exists or behaves differently than described
+- **Broken URLs** — a doc link, console URL, or example URL returns 404 or the wrong page
+- **Silent failure** — a capability accepts your call but returns nothing useful, or `setup` swallows an error and leaves you without a tool you should have
+- **Wrong defaults** — a preset, capability config, or environment variable name in the docs doesn't match what users actually have
+- **Missing capability** — you genuinely need a tool that doesn't exist (this is rarer than the others; check carefully that you haven't missed an existing one)
+- **Procedure contradiction** — two skills or sections of `procedures.md` give incompatible guidance for the same situation
+- **Reproducibly wrong output** — a model/tool returns clearly wrong answers in a way that isn't just a one-off hallucination (e.g. a vision model claims it can't see an image when image_url content is present)
+- **Migration / rename gaps** — you encounter old names that `lingtai-kernel-anatomy`'s `reference/changelog.md` doesn't document
+
+You should **not** invoke this skill for:
+
+- One-off LLM hallucinations or non-determinism (file a bug only if you can reproduce)
+- Personal preference about wording or formatting in a doc — unless it's actually misleading
+- Complaints about a model's quality on hard tasks (that's the model, not LingTai)
+- Feature requests for things the system was never designed to do
+
+## What makes a good report
+
+You see far more than a human does inside the system. Use that:
+
+- **Quote verbatim.** Tool outputs, error strings, doc snippets — copy them, don't summarize. Maintainers grep.
+- **Show your work.** "I called X with args Y and got Z" beats "X seems broken."
+- **Distinguish doc bug from code bug.** "The skill claims `mimo-v2-pro` supports vision but the API returns 400 on image input" — is that a doc bug (skill is wrong) or a code bug (API broke)? Note which you think and why.
+- **Note what works.** If 3 of 4 modalities work and 1 doesn't, say so — narrows the maintainer's search.
+- **Flag your version context.** If you know the kernel version, TUI version, active preset, repository commit, or recent migrations applied, include them. If you do not have an exact version surface, say what you do know rather than inventing one.
+
+## Secret hygiene — keep credentials out of reports
+
+Reports get filed publicly and maintainers grep them. Before you put anything into a report body, scrub it:
+
+- **Never paste tokens, keys, or passwords.** If a `GH_TOKEN`, API key, or other secret appears in the tool output you want to quote, redact it (`GH_TOKEN=ghp_…redacted`) before it goes anywhere near the report.
+- **Never echo a human-provided token** back into chat, a log, a file, or the issue body. A token the human handed you this session stays in the env of the single command that needs it (see `filing-flow`).
+- **Scrub environment dumps.** Verbatim output from `env`, `gh auth status`, or a config file often carries secrets — strip them before quoting.
+- **Watch for paths that reveal private data.** Redact home-directory usernames or private repo names only if they'd expose something the human wouldn't want public; otherwise keep paths verbatim so maintainers can navigate.
+- **When in doubt, redact and say so.** "(redacted a token here)" is fine — it tells the maintainer something was there without leaking it.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/filing-flow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/filing-flow/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: issue-report-filing-flow
+description: Nested lingtai-issue-report reference for the filing decision — the always-required human consent boundary, the read-only gh probe, Path A (direct gh filing) and Path B (paste-ready handoff), token hygiene, and proactive surfacing. Read this once the report is drafted and you are deciding how it gets filed.
+version: 1.0.0
+---
+
+# Issue report — filing flow
+
+This is a nested `lingtai-issue-report` reference. It governs everything after the report is drafted: getting human consent, detecting whether `gh` can file directly, the two filing paths, and surfacing the issue proactively.
+
+## The boundary — permission required, always
+
+**You never open a GitHub issue without an explicit "yes" from the human.** The human is the accountable owner of what gets filed under their name. Even if `gh` is authenticated and you have a shell, the per-issue consent is non-negotiable. Your role is to:
+
+1. Assemble a structured report (see the `report-template` reference)
+2. Send the report through the appropriate channel to your **parent avatar** (if you're an avatar) AND to the **human**
+3. Check whether `gh` is available and authenticated (see "Filing path" below)
+4. Ask the human's permission, naming the path you'd take (direct `gh` filing vs. paste-into-browser)
+5. Only then act — file it via `gh` if they say yes, or hand them the title/body if they prefer to file manually
+
+If the human declines, drop it. Don't nag, don't auto-retry on the next turn. Their call.
+
+## Filing path — detect `gh` first
+
+Before you ask the human for permission, run a quick read-only probe to see whether the GitHub CLI is installed AND there's a way to authenticate. There are two acceptable auth sources — either is enough to make Path A available:
+
+1. **Existing `gh auth`** — the host already has a logged-in account.
+2. **A `GH_TOKEN` the human provided this session** — they pasted a personal access token into chat (or it's already in your shell env). `gh` reads `GH_TOKEN` from the environment per-invocation, so no `gh auth login` is needed.
+
+Probe:
+
+```bash
+# Is gh installed?
+command -v gh
+
+# Is gh already authenticated?
+gh auth status 2>&1
+```
+
+Interpret the result:
+
+- **`gh` is installed AND (`gh auth status` exits 0 with a logged-in account, OR the human has handed you a `GH_TOKEN` this session)** → Path A is available.
+- **`gh` is missing, or neither auth source is present** → Path A is not available. Fall through to Path B.
+
+Do **not** run `gh issue create` during the probe. Do **not** echo, log, or commit the token. The probe is read-only; the actual filing happens only after the human says yes.
+
+### Path A — direct filing via `gh` (preferred when available)
+
+If the probe succeeded, your permission ask becomes one of:
+
+> "I noticed [one-sentence summary]. I sent a structured report to your inbox. Your `gh` CLI is authenticated — with your OK, I can file this directly to `Lingtai-AI/lingtai` as a GitHub issue. Want me to file it, or would you rather paste it yourself?"
+
+…or, when you're using the token they handed you:
+
+> "I noticed [one-sentence summary]. I sent a structured report to your inbox. I can file this directly to `Lingtai-AI/lingtai` using the `GH_TOKEN` you provided — the token stays in the env of this one command, never logged. Want me to file it, or would you rather paste it yourself?"
+
+If they say **file it** (or equivalent — "yes", "go ahead", "do it"):
+
+```bash
+# When relying on existing gh auth:
+gh issue create \
+  --repo Lingtai-AI/lingtai \
+  --title "<your Subject line, minus the [Issue Report] prefix>" \
+  --body-file <path-to-a-tempfile-with-the-rendered-body>
+
+# When using a human-provided token (inline env, single command):
+GH_TOKEN=$TOKEN gh issue create \
+  --repo Lingtai-AI/lingtai \
+  --title "<your Subject line, minus the [Issue Report] prefix>" \
+  --body-file <path-to-a-tempfile-with-the-rendered-body>
+```
+
+Notes on the `gh` invocation:
+- Write the body to a tempfile (e.g. `/tmp/lingtai-issue-<timestamp>.md`) and pass `--body-file`. Avoid `--body "<long string>"` — shell quoting eats backticks, code fences, and newlines.
+- Preserve the report's section headers verbatim; GFM renders them cleanly.
+- The `--repo` value defaults to `Lingtai-AI/lingtai`. If the human asked for the kernel tracker (`Lingtai-AI/lingtai-kernel`) or names another repo, use what they said — do not silently override. For repo-choice details, see "Which repo" in the `report-template` reference.
+- After `gh issue create` returns, it prints the issue URL on stdout. Quote that URL back to the human so they can verify.
+- If the command errors (network blip, repo permission, rate limit, 401), tell the human exactly what `gh` said and offer Path B as fallback. Do not retry silently. On 401, the token may be expired — don't keep retrying with it.
+- **Token hygiene** (Path A with `GH_TOKEN`): keep the token in the env of the single `gh` command, never echo it back in chat or logs, never write it to a file, never include it in the issue body or commit message. Delete the body tempfile after filing.
+
+If they say **paste it myself**, use Path B even though `gh` is available.
+
+### Path B — hand off title + body for manual filing (always works)
+
+When `gh` is unusable, or when the human prefers manual filing, the ask is:
+
+> "I noticed [one-sentence summary]. I sent a structured report to your inbox. If you'd like to file this as a GitHub issue, I can format it for you. The tracker is `https://github.com/Lingtai-AI/lingtai/issues`. Should I prep the title + body?"
+
+If they say **yes**:
+- Format the report into a GitHub-flavored markdown issue body (preserve the section headers; they render cleanly)
+- Provide the title (your `Subject` line, minus the `[Issue Report]` prefix)
+- Provide the URL: `https://github.com/Lingtai-AI/lingtai/issues/new`
+- Tell them to paste; don't try to do it yourself
+
+If they say **no** or are silent: stop. Don't bring it up again unless the same issue blocks you in a future turn.
+
+## Proactive surfacing — don't wait to be asked
+
+When you identify an issue that meets the "When to invoke" criteria (see the `evidence-checklist` reference), **surface it immediately** — don't wait for the human to ask you to file a report. The correct sequence is:
+
+1. You diagnose the problem (as part of your normal work)
+2. You apply a workaround or fix (if possible)
+3. **You proactively tell the human:** "I ran into [brief summary]. Want me to file a GitHub issue about it?"
+4. If they say yes → follow the filing path above
+5. If they say no → drop it
+
+The human should never have to guess that you found a bug. **Your job is not just to fix — it's to surface.**
+
+Signs you should proactively offer:
+- You spent more than 2 turns diagnosing an unexpected error
+- The workaround you used is not documented anywhere
+- The bug would affect other agents or users, not just you
+- You discovered the fix requires a restart, manual file edit, or other non-obvious step
+- The issue contradicts what the documentation claims
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/report-template/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/report-template/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: issue-report-report-template
+description: Nested lingtai-issue-report reference for the report skeleton — subject/title format, the structured body sections (what's wrong, where, reproduction, expected vs actual, severity, suggested fix), and how to send it via LingTai email or the human's active channel. Read this when you are ready to assemble the report.
+version: 1.0.0
+---
+
+# Issue report — report template
+
+This is a nested `lingtai-issue-report` reference. It is the canonical structure for an issue report: the subject/title, the body sections, and how to deliver it through the appropriate communication channel before any filing decision.
+
+## The report template
+
+Send the report as a mail message with a clear subject and a structured body. Use this skeleton:
+
+```
+Subject: [Issue Report] <one-line summary>
+
+## What's wrong
+<concise statement of the problem — one paragraph>
+
+## Where
+- Component: <skill name / capability name / preset name / procedure section>
+- File or URL (if known): <path or URL>
+
+## Reproduction
+<exact steps you took, exact tool calls, exact responses you got. Include
+verbatim error messages, status codes, or contradictory text.>
+
+## What you expected
+<what the docs/skill led you to expect>
+
+## What actually happened
+<what you observed instead>
+
+## Severity
+<one of: blocking | major | minor | cosmetic>
+- blocking — agents cannot complete the affected workflow at all
+- major — a documented feature is broken or absent; workaround exists but costs time
+- minor — incorrect detail; doesn't break workflows but misleads new agents
+- cosmetic — typo, formatting, broken link in a doc
+
+## Suggested fix (optional)
+<if you have a concrete suggestion, include it. otherwise omit this section.>
+```
+
+Keep the section headers verbatim — they double as the GitHub-flavored markdown issue body later, and GFM renders them cleanly. The title used for filing is your `Subject` line **minus the `[Issue Report]` prefix**.
+
+## Send it through the right channel first
+
+Before any filing decision, send the report so there is a durable record and your parent/human can see it. Use the channel they are actually using:
+
+```python
+# Internal LingTai email / peer mail
+email(action="send", address=<parent_or_human_address>, subject="[Issue Report] ...", message=<body>)
+
+# If the human is currently on Telegram/another chat channel, send or reply there instead.
+# Always follow the surrounding agent's channel discipline.
+```
+
+Send the report to your **parent avatar** (if you're an avatar) AND to the **human**. If you have multiple addressees (parent + human), send the same content to each appropriate channel explicitly.
+
+## Which repo
+
+The umbrella issue tracker for end-user reports is **`Lingtai-AI/lingtai`** (the binary humans actually install). File there even if the underlying bug is in `lingtai-kernel`, a sibling skill repo, or a preset — the maintainers will route or transfer as needed.
+
+If the human happens to know the issue is kernel-specific (e.g. they're a developer), they may prefer `https://github.com/Lingtai-AI/lingtai-kernel/issues`. Don't second-guess; let them choose.
+
+The canonical org is **`Lingtai-AI`** on GitHub. If `https://github.com/Lingtai-AI` itself 404s one day, the project has likely moved; ask the human where to file instead.
+
+## Self-healing
+
+This skill itself can have bugs. If the report template here is missing a section that you find yourself wanting, or if the GitHub URLs in this reference 404 (the org may rename, repos may move), include a note in your report saying "the issue-report skill says X but Y is what I actually found" — and the maintainers will update this skill.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/tui/issue_report_nested_test.go
+++ b/tui/internal/tui/issue_report_nested_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestBuildSkillFolderEntries_IssueReportNestedReferences verifies that the
+// shipped issue-report skill is a router with nested reference SKILL.md files
+// and that the TUI drill-in view exposes those files under the reference group.
+func TestBuildSkillFolderEntries_IssueReportNestedReferences(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	skillDir := filepath.Join(filepath.Dir(thisFile), "..", "preset", "skills", "lingtai-issue-report")
+
+	entries := buildSkillFolderEntries(skillDir)
+	if len(entries) == 0 {
+		t.Fatal("no entries; is lingtai-issue-report missing?")
+	}
+	if entries[0].Label != "SKILL.md" {
+		t.Errorf("first entry = %q, want SKILL.md", entries[0].Label)
+	}
+
+	rootBodyBytes, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootBody := string(rootBodyBytes)
+	for _, want := range []string{
+		"Nested reference catalog",
+		"name: issue-report-evidence-checklist",
+		"reference/evidence-checklist/SKILL.md",
+		"name: issue-report-report-template",
+		"reference/report-template/SKILL.md",
+		"name: issue-report-filing-flow",
+		"reference/filing-flow/SKILL.md",
+		"Human consent is required, always",
+		"Secrets never enter a report",
+		"Routing table",
+	} {
+		if !strings.Contains(rootBody, want) {
+			t.Errorf("issue-report root missing %q", want)
+		}
+	}
+
+	labels := make(map[string]MarkdownEntry)
+	for _, e := range entries {
+		labels[e.Label] = e
+	}
+	for _, want := range []string{
+		"evidence-checklist/SKILL.md",
+		"report-template/SKILL.md",
+		"filing-flow/SKILL.md",
+	} {
+		e, ok := labels[want]
+		if !ok {
+			t.Fatalf("missing nested issue-report entry %q", want)
+		}
+		if e.Group != "reference" {
+			t.Errorf("entry %q group = %q, want reference", want, e.Group)
+		}
+	}
+
+	for _, rel := range []string{
+		filepath.Join("reference", "evidence-checklist", "SKILL.md"),
+		filepath.Join("reference", "report-template", "SKILL.md"),
+		filepath.Join("reference", "filing-flow", "SKILL.md"),
+	} {
+		childBodyBytes, err := os.ReadFile(filepath.Join(skillDir, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(childBodyBytes), "nested `lingtai-issue-report` reference") {
+			t.Errorf("%s should identify itself as a nested lingtai-issue-report reference", rel)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Split `lingtai-issue-report` from one monolithic SKILL.md into a #218-style router plus three nested references.
- Added leaves for evidence collection/secret hygiene, report template/channel delivery, and filing flow/human consent.
- Added preset extraction and TUI drill-in tests covering the nested reference catalog and generated files.

## Validation

- `git diff --check HEAD`
- `(cd tui && go test -count=1 ./internal/preset ./internal/tui)`
- `(cd tui && go test -count=1 ./...)`

## Notes

- Consent and secret-handling rules are now hoisted to the router top and repeated in the relevant leaves.
- While splitting, I corrected inherited stale examples from the old skill (`imap(...)` and `system(action='show')`) to current channel/version-context guidance.
- DeepSeek review suggested clarifying the `kernel tracker` mention in `filing-flow`; I applied that cross-link before opening.
