### PR TITLE
feat(preset): adopt MiniMax-M3 as the MiniMax flagship model

### DIFF
--- a/examples/init.jsonc
+++ b/examples/init.jsonc
@@ -39,7 +39,7 @@
       "provider": "minimax",
 
       // Model name as recognized by the provider's API.
-      "model": "MiniMax-M2.7-highspeed",
+      "model": "MiniMax-M3",
 
       // API key — set to null and use api_key_env to read from environment (recommended).
       // Never hardcode secrets here.

--- a/portal/i18n/en.json
+++ b/portal/i18n/en.json
@@ -179,7 +179,7 @@
   "preset.saved": "Saved Presets",
   "preset.templates": "New Preset",
   "preset.name_minimax": "minimax (Recommended)",
-  "preset.desc_minimax": "MiniMax M2.7 — full multimodal (Token Plan)",
+  "preset.desc_minimax": "MiniMax M3 — full multimodal (Token Plan)",
   "preset.name_custom": "custom",
   "preset.desc_custom": "OpenAI / Anthropic compatible — web search + web browse",
   "presets.back": "back",

--- a/portal/i18n/wen.json
+++ b/portal/i18n/wen.json
@@ -179,7 +179,7 @@
   "preset.saved": "已存预设",
   "preset.templates": "新建预设",
   "preset.name_minimax": "minimax（荐）",
-  "preset.desc_minimax": "MiniMax M2.7 — 全模态（Token 计划）",
+  "preset.desc_minimax": "MiniMax M3 — 全模态（Token 计划）",
   "preset.name_custom": "custom",
   "preset.desc_custom": "OpenAI / Anthropic 兼容 — 网搜 + 网览",
   "presets.back": "返",

--- a/portal/i18n/zh.json
+++ b/portal/i18n/zh.json
@@ -179,7 +179,7 @@
   "preset.saved": "已保存预设",
   "preset.templates": "新建预设",
   "preset.name_minimax": "minimax（推荐）",
-  "preset.desc_minimax": "MiniMax M2.7 — 全模态（Token 计划）",
+  "preset.desc_minimax": "MiniMax M3 — 全模态（Token 计划）",
   "preset.name_custom": "custom",
   "preset.desc_custom": "OpenAI / Anthropic 兼容 — 网络搜索 + 网页浏览",
   "presets.back": "返回",

--- a/scripts/telegram_chat.py
+++ b/scripts/telegram_chat.py
@@ -52,7 +52,7 @@ WORKING_DIR = Path(__file__).resolve().parent.parent / "_telegram_agent"
 def main():
     svc = LLMService(
         provider="minimax",
-        model="MiniMax-M2.7-highspeed",
+        model="MiniMax-M3",
         api_key=os.environ["MINIMAX_API_KEY"],
         context_window=1_000_000,
     )

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -755,10 +755,10 @@ func minimaxPreset() Preset {
 	}
 	return Preset{
 		Name:        "minimax",
-		Description: PresetDescription{Summary: "MiniMax M2.7 — full multimodal capabilities"},
+		Description: PresetDescription{Summary: "MiniMax M3 — full multimodal capabilities"},
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
-				"provider": "minimax", "model": "MiniMax-M2.7-highspeed",
+				"provider": "minimax", "model": "MiniMax-M3",
 				"api_key": nil, "api_key_env": "MINIMAX_API_KEY",
 				"base_url": ProviderRegionURLs["minimax"][0].URL,
 			},

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -37,7 +37,7 @@
       "provider": "minimax",
 
       // Model name as recognized by the provider's API.
-      "model": "MiniMax-M2.7-highspeed",
+      "model": "MiniMax-M3",
 
       // API key — set to null and use api_key_env to read from environment (recommended).
       // Never hardcode secrets here.

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -117,7 +117,16 @@ var capabilityProviderOptions = map[string][]string{
 // new flagship ships, add it (and remove deprecated entries — agents
 // will hit 4xx if they pick a retired model).
 var providerModels = map[string][]string{
-	"minimax":  {"MiniMax-M3"},
+	// MiniMax: official supported LLM model IDs (API Overview), newest first.
+	// M3 is the current flagship/default; the older M2.x IDs remain supported
+	// and are kept as selectable fallbacks.
+	"minimax": {
+		"MiniMax-M3",
+		"MiniMax-M2.7", "MiniMax-M2.7-highspeed",
+		"MiniMax-M2.5", "MiniMax-M2.5-highspeed",
+		"MiniMax-M2.1", "MiniMax-M2.1-highspeed",
+		"MiniMax-M2",
+	},
 	"zhipu":    {"GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air"},
 	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-flash"},
 	"deepseek": {"deepseek-v4-flash", "deepseek-v4-pro"},
@@ -138,8 +147,19 @@ var providerModels = map[string][]string{
 // the user isn't blocked from enabling it on a model the editor
 // doesn't catalog.
 var modelHasVision = map[string]bool{
-	// MiniMax: M3 is the current flagship and accepts images.
-	"MiniMax-M3": true,
+	// MiniMax: keyed to the official supported LLM model IDs. Only the known
+	// multimodal entries auto-enable vision — M3 (current flagship) and the
+	// M2.7 variants, which prior code treated as image-capable. The older
+	// M2.5/M2.1/M2 IDs are marked false so the editor doesn't auto-enable
+	// vision for them when uncertain.
+	"MiniMax-M3":             true,
+	"MiniMax-M2.7":           true,
+	"MiniMax-M2.7-highspeed": true,
+	"MiniMax-M2.5":           false,
+	"MiniMax-M2.5-highspeed": false,
+	"MiniMax-M2.1":           false,
+	"MiniMax-M2.1-highspeed": false,
+	"MiniMax-M2":             false,
 	// Zhipu coding-plan models — current generation supports vision.
 	"GLM-5.1":     true,
 	"GLM-5-Turbo": true,

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -117,7 +117,7 @@ var capabilityProviderOptions = map[string][]string{
 // new flagship ships, add it (and remove deprecated entries — agents
 // will hit 4xx if they pick a retired model).
 var providerModels = map[string][]string{
-	"minimax":  {"MiniMax-M2.7-highspeed", "MiniMax-M2.7"},
+	"minimax":  {"MiniMax-M3"},
 	"zhipu":    {"GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air"},
 	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-flash"},
 	"deepseek": {"deepseek-v4-flash", "deepseek-v4-pro"},
@@ -138,9 +138,8 @@ var providerModels = map[string][]string{
 // the user isn't blocked from enabling it on a model the editor
 // doesn't catalog.
 var modelHasVision = map[string]bool{
-	// MiniMax: both M2.7 sizes accept images.
-	"MiniMax-M2.7-highspeed": true,
-	"MiniMax-M2.7":           true,
+	// MiniMax: M3 is the current flagship and accepts images.
+	"MiniMax-M3": true,
 	// Zhipu coding-plan models — current generation supports vision.
 	"GLM-5.1":     true,
 	"GLM-5-Turbo": true,
@@ -860,7 +859,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		m.llmMap()["provider"] = newProvider
 		// Reset model to the new provider's first canonical entry when the
 		// current model isn't valid for the new provider. Without this, a
-		// minimax→zhipu switch leaves "MiniMax-M2.7-highspeed" in model
+		// minimax→zhipu switch leaves "MiniMax-M3" in model
 		// and validation passes silently while the kernel later 4xxs.
 		if models, ok := providerModels[newProvider]; ok && len(models) > 0 {
 			currentModel := asString(m.llmMap()["model"])

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -23,7 +23,7 @@ func testPresetEditorPreset() preset.Preset {
 		Manifest: map[string]interface{}{
 			"llm": map[string]interface{}{
 				"provider":    "minimax",
-				"model":       "MiniMax-M2.7",
+				"model":       "MiniMax-M3",
 				"api_compat":  "openai",
 				"base_url":    "https://api.minimax.io/v1",
 				"api_key_env": "MINIMAX_API_KEY",

--- a/tui/scripts/setup-playground.sh
+++ b/tui/scripts/setup-playground.sh
@@ -31,7 +31,7 @@ cat > "$ORCH_DIR/init.json" << INITEOF
     "language": "en",
     "llm": {
       "provider": "minimax",
-      "model": "MiniMax-M2.7-highspeed",
+      "model": "MiniMax-M3",
       "api_key": ${API_KEY:+\"$API_KEY\"}${API_KEY:-null},
       "api_key_env": "MINIMAX_API_KEY",
       "base_url": null


### PR DESCRIPTION
## What

Updates the TUI/portal MiniMax settings to use **MiniMax-M3** — the current MiniMax flagship model id (released Jun 1 2026, confirmed against the official docs/release notes and `llms.txt`) — as the built-in default, while keeping the official older supported MiniMax model IDs selectable as fallbacks in the editor's model picker.

## Changes

- **`tui/internal/preset/preset.go`** — built-in `minimax` preset default model → `MiniMax-M3`; summary updated to "MiniMax M3".
- **`tui/internal/tui/preset_editor.go`** — `providerModels["minimax"]` lists the official supported LLM model IDs (MiniMax API Overview), newest first: `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2`. M3 is the default/flagship; the older IDs remain selectable fallbacks. `modelHasVision` auto-enables vision only for the known multimodal entries — `MiniMax-M3` and the `MiniMax-M2.7` variants (which prior code treated as image-capable); the older `M2.5`/`M2.1`/`M2` IDs are explicitly marked `false` so the editor doesn't auto-enable vision for them when uncertain. Comments updated to note this follows the official supported LLM model IDs.
- **`examples/init.jsonc`**, **`tui/internal/preset/templates/init.jsonc`**, **`tui/scripts/setup-playground.sh`**, **`scripts/telegram_chat.py`** — seed/example model → `MiniMax-M3`.
- **`portal/i18n/{en,zh,wen}.json`** — `preset.desc_minimax` description → "MiniMax M3".
- **`tui/internal/tui/preset_editor_test.go`** — fixture model literal → `MiniMax-M3`.

### Intentionally preserved

`tui/internal/migrate/m024_add_active_preset_test.go` keeps its `MiniMax-M2.7-highspeed` fixtures — that test asserts preset-block insertion on **historical** on-disk state, not current model matching, so the legacy literal is correct there.

## Validation

- `gofmt -l` on edited Go files — clean.
- `go test ./internal/tui ./internal/preset ./internal/migrate` — all pass.
- `go build ./...` (tui) — OK.
- Portal i18n JSON files re-validated as parseable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
