### PR TITLE
docs: add empirical writing data-drift anti-pattern

### DIFF
--- a/reports/pr-issue100-text-data-drift-explainer.html
+++ b/reports/pr-issue100-text-data-drift-explainer.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #100 — Anti-pattern: text-consistency drift in iterative empirical paper writing</title>
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #6b7280;
+    --bg: #ffffff;
+    --accent: #2563eb;
+    --rule: #e5e7eb;
+    --card-bg: #f9fafb;
+    --callout-bg: #fffbeb;
+    --callout-rule: #fbbf24;
+    --code-bg: #f3f4f6;
+    --good: #047857;
+    --bad: #b91c1c;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.6;
+    font-size: 16px;
+  }
+  .layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    gap: 2.5rem;
+  }
+  @media (max-width: 768px) {
+    .layout { grid-template-columns: 1fr; }
+    nav.toc { position: static; }
+  }
+  nav.toc { position: sticky; top: 1rem; align-self: start; font-size: 0.9rem; }
+  nav.toc h2 {
+    font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--muted); margin: 0 0 0.75rem;
+  }
+  nav.toc ol { list-style: none; padding: 0; margin: 0; }
+  nav.toc li { margin: 0.35rem 0; }
+  nav.toc a { color: var(--fg); text-decoration: none; border-bottom: 1px solid transparent; }
+  nav.toc a:hover { border-bottom-color: var(--accent); }
+  main { min-width: 0; }
+  header.report-header { border-bottom: 2px solid var(--rule); padding-bottom: 1rem; margin-bottom: 2rem; }
+  header.report-header h1 { margin: 0 0 0.5rem; font-size: 1.6rem; line-height: 1.25; }
+  header.report-header .meta { color: var(--muted); font-size: 0.9rem; }
+  header.report-header .meta span + span::before { content: " · "; margin: 0 0.3rem; }
+  section { margin: 2.5rem 0; }
+  section h2 { font-size: 1.3rem; margin: 0 0 0.75rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--rule); }
+  section h3 { font-size: 1.05rem; margin: 1.5rem 0 0.5rem; }
+  p { margin: 0.6rem 0; }
+  a { color: var(--accent); }
+  .card { background: var(--card-bg); border: 1px solid var(--rule); border-radius: 6px; padding: 1rem 1.2rem; margin: 1rem 0; }
+  .callout { background: var(--callout-bg); border-left: 4px solid var(--callout-rule); padding: 0.75rem 1rem; margin: 1rem 0; border-radius: 0 4px 4px 0; }
+  .callout strong { font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.95rem; }
+  th, td { padding: 0.55rem 0.7rem; border-bottom: 1px solid var(--rule); text-align: left; vertical-align: top; }
+  th { background: var(--card-bg); font-weight: 600; }
+  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-family: "SF Mono", Menlo, Consolas, monospace; font-size: 0.9em; }
+  pre { background: var(--code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.88rem; }
+  pre code { background: transparent; padding: 0; }
+  ul { margin: 0.5rem 0; }
+  .good { color: var(--good); font-weight: 600; }
+  .bad { color: var(--bad); font-weight: 600; }
+  hr { border: 0; border-top: 1px solid var(--rule); margin: 2.5rem 0; }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.85rem; }
+  @media print {
+    nav.toc { display: none; }
+    .layout { display: block; max-width: none; padding: 0; }
+    body { font-size: 11pt; }
+    section { page-break-inside: avoid; }
+    a { color: var(--fg); text-decoration: underline; }
+  }
+</style>
+</head>
+<body>
+<div class="layout">
+
+<nav class="toc" aria-label="Table of contents">
+  <h2>Contents</h2>
+  <ol>
+    <li><a href="#tldr">TL;DR</a></li>
+    <li><a href="#baseline">Baseline</a></li>
+    <li><a href="#changed">What changed</a></li>
+    <li><a href="#validation">Validation</a></li>
+    <li><a href="#risks">Risks</a></li>
+    <li><a href="#sources">Source index</a></li>
+  </ol>
+</nav>
+
+<main>
+
+<header class="report-header">
+  <h1>Issue #100 — Anti-pattern: text-consistency drift in iterative empirical paper writing</h1>
+  <div class="meta">
+    <span>Docs/skill change</span>
+    <span>Branch: fix/academic-text-data-drift</span>
+    <span>Source: tui/internal/preset/skills/swiss-knife/reference/academic-research/</span>
+  </div>
+</header>
+
+<section id="tldr">
+  <h2>TL;DR</h2>
+  <p>
+    When an empirical paper is written iteratively with reviewer agents, the prose
+    can become steadily more polished and internally consistent while quietly
+    drifting away from the data on disk. Reviewer agreement validates
+    <em>text consistency</em>, not <em>data correspondence</em> — so the draft can
+    read cleanly, pass every reviewer round, and still misdescribe what the
+    experiments actually did.
+  </p>
+  <p>
+    This change teaches the bundled <code>academic-research</code> skill to
+    recognize and prevent that failure mode: a new anti-pattern reference, a
+    pre-writing data-anchoring guard in the LaTeX pipeline, and routing from the
+    skill's index and Known caveats.
+  </p>
+  <div class="callout">
+    <strong>Scope:</strong> documentation/skill content only. No Go runtime
+    behavior changes; one bundling test gains an assertion for the new file.
+  </div>
+</section>
+
+<section id="baseline">
+  <h2>Baseline (the incident)</h2>
+  <p>
+    During iterative empirical-NLP paper writing, a writer agent plus reviewer
+    agents restructured the experimental framing across 9+ rounds without
+    re-verifying claims against the data on disk. The text grew more internally
+    consistent and more polished — but wrong.
+  </p>
+  <div class="card">
+    <p>
+      The draft described "Experiment 2" as a single-agent-with-tools setup. The
+      actual Exp 2 data lived in three sibling directories (a
+      <code>chat</code>/<code>tool</code>/<code>replaced</code> split, 21 model
+      pairs, <strong>no tools</strong>). Every reviewer round confirmed the draft
+      was consistent — and described an experiment that was never run.
+    </p>
+  </div>
+  <p>
+    Root cause: each editing round optimized the text <em>against itself</em>
+    rather than against the artifacts that produced it. Reviewer consensus was
+    treated as evidence the claims were correct, when it only ever measured
+    whether the prose hung together.
+  </p>
+</section>
+
+<section id="changed">
+  <h2>What changed</h2>
+
+  <h3>1. New anti-pattern reference</h3>
+  <p>
+    <code>reference/anti-pattern-text-consistency-vs-data-correspondence.md</code> —
+    an actionable guide covering: the <strong>trigger pattern</strong> (describing
+    experiments from memory/old drafts, fixing "confusing" feedback by rewriting
+    prose, reframing sections without re-opening data, treating reviewer agreement
+    as correctness); <strong>what to do instead</strong> (establish ground-truth
+    correspondence first — list data, inspect a real result file, read the runner
+    code, keep a claim → evidence map, re-derive on every reframe); <strong>why
+    review agents don't catch it</strong>; an explicit <strong>anti-fix</strong>
+    (don't rewrite for internal consistency); a <strong>detection checklist</strong>;
+    and <strong>Related</strong> links including the multi-agent echo-chamber family.
+  </p>
+
+  <h3>2. LaTeX pipeline guard</h3>
+  <p>
+    <code>reference/pipeline-latex-writing.md</code> gains a "Before you write"
+    block at the top — anchor prose to data before drafting and on every reframe —
+    plus a See Also cross-reference to the new anti-pattern.
+  </p>
+
+  <h3>3. Skill index + caveats routing</h3>
+  <p>
+    <code>SKILL.md</code> gains an escape-hatch quick-path
+    ("My empirical draft keeps getting reframed / reviewers 'agree'"), a Standalone
+    references entry, and a Known caveat bullet that routes paper-writing drift to
+    the new file.
+  </p>
+
+  <table>
+    <thead>
+      <tr><th>File</th><th>Change</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>academic-research/reference/anti-pattern-text-consistency-vs-data-correspondence.md</code></td><td>New file (the anti-pattern)</td></tr>
+      <tr><td><code>academic-research/SKILL.md</code></td><td>Quick-path + standalone-ref + Known caveat</td></tr>
+      <tr><td><code>academic-research/reference/pipeline-latex-writing.md</code></td><td>Pre-writing guard + See Also</td></tr>
+      <tr><td><code>tui/internal/preset/swiss_knife_populate_test.go</code></td><td>Assert new file is bundled</td></tr>
+      <tr><td><code>reports/pr-issue100-text-data-drift-explainer.html</code></td><td>This explainer</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="validation">
+  <h2>Validation</h2>
+  <ul>
+    <li>All relative links in the three Markdown files were checked to resolve to
+      existing files under <code>reference/</code>.</li>
+    <li>The new file's <code>Related</code> and the pipeline's <code>See Also</code>
+      point at files that exist (<code>pipeline-latex-writing.md</code>,
+      <code>pipeline-scholar-analysis.md</code>, the API/error references).</li>
+    <li><code>go test ./internal/preset/</code> run in <code>tui/</code> — the
+      swiss-knife populate test now asserts the new reference is extracted to disk.</li>
+  </ul>
+  <div class="callout">
+    <strong>Note:</strong> the multi-agent echo-chamber link is phrased
+    conditionally ("if available in your environment") because that reference is
+    not guaranteed to be bundled alongside this skill — it ships as a research
+    skill, not under <code>academic-research/</code>.
+  </div>
+</section>
+
+<section id="risks">
+  <h2>Risks</h2>
+  <ul>
+    <li><span class="good">Low blast radius.</span> Content-only change to a
+      bundled skill; no Go logic, schema, or migration touched.</li>
+    <li>The exact-path in the original issue
+      (<code>tui/internal/preset/skills/academic-research/…</code>) does not exist;
+      the skill actually lives under <code>swiss-knife/reference/academic-research/</code>.
+      Files were placed at the real location so they bundle and route correctly.</li>
+    <li>The private paths from the incident are used only as illustrative language
+      (one anonymized example), not as instructions.</li>
+    <li>Embedding is via <code>//go:embed skills</code> (recursive), so the new file
+      ships automatically; the test assertion guards against a future move silently
+      dropping it.</li>
+  </ul>
+</section>
+
+<section id="sources">
+  <h2>Source index</h2>
+  <ul>
+    <li><a href="https://github.com/Lingtai-AI/lingtai/issues/100">Lingtai-AI/lingtai#100</a> — original issue</li>
+    <li><code>tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md</code></li>
+    <li><code>tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/anti-pattern-text-consistency-vs-data-correspondence.md</code></li>
+    <li><code>tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/pipeline-latex-writing.md</code></li>
+    <li><code>tui/internal/preset/swiss_knife_populate_test.go</code></li>
+  </ul>
+</section>
+
+<footer>
+  <p>Generated by a LingTai agent for issue #100. Documentation/skill change — no runtime behavior modified.</p>
+</footer>
+
+</main>
+</div>
+</body>
+</html>

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
@@ -85,6 +85,7 @@ I need astrophysics         → reference/api-nasa-ads.md
 I need high-energy physics  → reference/api-inspire-hep.md
 I need biomedical           → reference/api-europe-pmc.md or api-pubmed.md
 I need to write/compile a paper → reference/pipeline-latex-writing.md
+My empirical draft keeps getting reframed / reviewers "agree" → reference/anti-pattern-text-consistency-vs-data-correspondence.md
 I hit an API error          → reference/error-handling.md
 ```
 
@@ -125,6 +126,7 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 - [publisher-page-extraction.md](reference/publisher-page-extraction.md) — Tier-5 manual escape hatch (Nature/APS/AIP/IOP/Cambridge → structured Markdown)
 - [libgen-fallback.md](reference/libgen-fallback.md) — Last-resort PDF source with legal/safety notes
 - [error-handling.md](reference/error-handling.md) — 429 backoff, 403 publisher blocks, timeout patterns
+- [anti-pattern-text-consistency-vs-data-correspondence.md](reference/anti-pattern-text-consistency-vs-data-correspondence.md) — empirical-writing failure mode: prose drifts from the data while reviewer rounds make it more polished. Trigger pattern, re-anchoring steps, detection checklist.
 
 ## Relationship to web-browsing
 
@@ -141,6 +143,7 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 - **arXiv enforces HTTPS** — HTTP requests are 301-redirected automatically.
 - **Library Genesis legality varies by jurisdiction** — use is the user's responsibility. Pass `--no-libgen` to opt out.
 - **Publisher-page extraction (Tier 5)** uses Playwright + pandoc; first invocation installs `zhiping0913/Download_paper` from git. Requires Chromium (`playwright install chromium`) and pandoc on `$PATH`. See [reference/publisher-page-extraction.md](reference/publisher-page-extraction.md).
+- **Writing an empirical paper iteratively can drift from the data** — reviewer rounds make prose more polished and internally consistent without verifying it still matches the experiments on disk. Reviewer agreement is text-consistency evidence, not data-correspondence evidence. Anchor every claim to data files/runner code *before* writing, and re-derive (don't just rewrite) when feedback flags confusion. See [reference/anti-pattern-text-consistency-vs-data-correspondence.md](reference/anti-pattern-text-consistency-vs-data-correspondence.md).
 
 ---
 > **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/anti-pattern-text-consistency-vs-data-correspondence.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/anti-pattern-text-consistency-vs-data-correspondence.md
@@ -1,0 +1,151 @@
+# Anti-pattern: Text-consistency drift vs. data correspondence
+
+> When writing an **empirical** paper iteratively — especially with reviewer
+> agents in the loop — prose can become more polished, more internally
+> consistent, and *wrong*. Each editing round optimizes the text against itself
+> instead of against the data on disk. The result reads cleanly and survives
+> reviewer agreement, but no longer describes what the experiments actually did.
+
+This is the academic-writing cousin of the multi-agent echo chamber: agreement
+among writers/reviewers measures **text consistency**, not **data correspondence**.
+
+---
+
+## Trigger pattern
+
+Watch for any of these during a writing session:
+
+- You are describing experiments, results, or methods from **memory or from an
+  earlier draft**, not from the data files and runner code in front of you.
+- A reviewer (human or agent) flags a section as "confusing" or "inconsistent,"
+  and your fix is to **rewrite the prose** until it reads smoothly again — without
+  re-opening the data.
+- The framing of an experiment has been **restructured several rounds in a row**
+  (renamed, re-numbered, re-grouped) and each round only touched `.tex`/`.md`,
+  never the `experiments/` tree.
+- Multiple reviewer agents **agree** the draft is consistent, and you treat that
+  agreement as evidence the *claims* are correct.
+- You cannot, right now, point to the exact directory / file / column that backs
+  the sentence you just wrote.
+
+If you notice any of these, you are at risk of drift. Stop polishing and
+re-anchor to data (below) before writing another paragraph.
+
+The original incident: over 9+ reviewer rounds an "Experiment 2" was described as
+a single-agent-with-tools setup. The actual Exp 2 data lived in three sibling
+directories (a chat/tool/replaced split, 21 model pairs, **no tools**). The text
+was self-consistent and reviewer-approved at every round — and described an
+experiment that was never run.
+
+---
+
+## What to do instead — establish ground-truth correspondence FIRST
+
+Before writing or revising any sentence that makes an empirical claim, anchor it
+to artifacts on disk. Do this *before* prose, and again whenever framing changes.
+
+1. **List the data.** Enumerate the experiment directories and result files, and
+   write down which paper section each one backs.
+   ```bash
+   # What experiments actually exist on disk?
+   ls -d experiments/*/ results/*/ runs/*/ 2>/dev/null
+   # How many runs / pairs / trials per condition?
+   find experiments -name '*.json' -o -name '*.csv' -o -name '*.parquet' | sort
+   ```
+2. **Inspect the result shape.** Open one real result file and confirm the
+   columns/keys, the units, and the count — don't infer them from the draft.
+   ```bash
+   head -c 2000 experiments/<condition>/results.json   # peek at one sample
+   # row / record count that a "N pairs" or "N trials" claim must match
+   wc -l experiments/<condition>/*.csv
+   ```
+3. **Read the runner code.** The script that produced the data is the source of
+   truth for *what the experiment was* — which conditions, whether tools were
+   enabled, how many agents, what was held fixed.
+   ```bash
+   ls experiments/<condition>/        # config / run script / logs
+   ```
+4. **Build a claim → evidence map.** For each numbered experiment and each
+   headline number in the abstract/results, record the backing path. Keep it
+   next to the draft (a table, a comment block, a `claims.md`). Every later edit
+   must keep this map true.
+
+   | Paper claim | Backing artifact | Verified value |
+   |-------------|------------------|----------------|
+   | "Exp 2: 21 model pairs, no tools" | `experiments/<c>_{chat,tool,replaced}/` | 21 dirs, configs show `tools: []` |
+
+5. **Re-derive on every reframe.** If an experiment gets renamed, renumbered, or
+   regrouped, re-run steps 1–4 for the affected sections. A reframe that touches
+   only prose is a red flag, not a checkpoint.
+
+---
+
+## Why review agents (and human reviewers) don't catch this
+
+Reviewers read the **manuscript**, not the **repository**. Their job, as usually
+prompted, is to judge whether the writing is clear, coherent, and internally
+consistent. A draft can be all three and still misdescribe the data:
+
+- Reviewer agreement converges on a *fixed point of the text*, not of the facts.
+  Each round removes friction in the prose, which can mean removing the very
+  roughness that hinted at a data mismatch.
+- Agents asked to "improve clarity" optimize toward a confident, smooth draft —
+  the opposite of the hedged, "let me check" tone that surfaces errors.
+- Unless a reviewer is explicitly given the data and told to verify
+  correspondence, **consensus is text-consistency evidence only.** Treat it that
+  way. (See the multi-agent echo-chamber failure mode in Related.)
+
+If you want a reviewer to catch data drift, you must hand them the data and
+the claim→evidence map and ask them to check claims *against the files*, not the
+prose against itself.
+
+---
+
+## Anti-fix — do NOT just rewrite for internal consistency
+
+When feedback says a section is confusing or inconsistent, the tempting fix is to
+edit until the words line up. **That is the failure mode, not the cure.**
+
+- ❌ Rewriting prose so two paragraphs stop contradicting each other — without
+  opening the data to learn *which* paragraph (if either) is right.
+- ❌ Renaming/renumbering experiments to make the narrative flow, then propagating
+  the new names through the draft as if that settled anything.
+- ❌ Accepting "all reviewers now agree" as the done signal for a results section.
+- ❌ Smoothing away a hedge ("it's unclear whether tools were used") instead of
+  resolving it from the runner code.
+
+The contradiction the reviewer felt is often a **true signal of data drift.**
+Re-derive from disk; let the data decide which sentence survives. Only after the
+claim→evidence map is true do you polish the wording.
+
+---
+
+## Detection checklist
+
+Run through this before declaring any empirical section "done":
+
+- [ ] Every numbered experiment maps to a specific directory/file on disk.
+- [ ] Every headline number (N pairs, N trials, % improvement) was re-counted
+      from the data this session, not copied from a prior draft.
+- [ ] The experimental setup described (tools on/off, single vs. multi-agent,
+      what's held fixed) matches the **runner code**, not just the draft's prose.
+- [ ] No experiment was renamed/renumbered this session without re-checking its
+      backing data.
+- [ ] Reviewer agreement is recorded as "text is consistent," not "claims are
+      correct."
+- [ ] You can point to the file/column behind each results sentence right now.
+- [ ] The claim→evidence map exists and is current.
+
+If any box is unchecked, you are reporting text consistency as if it were data
+correspondence. Re-anchor before shipping.
+
+---
+
+## Related
+
+- [pipeline-latex-writing.md](pipeline-latex-writing.md) — the writing workflow this guard wraps; see its pre-writing data-anchoring note.
+- **Multi-agent echo chamber / circular citation** — the general form: a group of
+  agents converging on a shared but unverified belief. If a `multi-agent-echo-chamber`
+  reference or skill is available in your environment, read it; the dynamics are
+  identical, only the artifact (manuscript vs. citation graph) differs.
+- [pipeline-scholar-analysis.md](pipeline-scholar-analysis.md) — when the claims are about *other* papers' results, verify against the source, not your summary of it.

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/pipeline-latex-writing.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/pipeline-latex-writing.md
@@ -2,6 +2,17 @@
 
 > Academic paper writing workflow — project setup, compilation, bibliography, figures, debugging, and submission verification. This is a **workflow guide**, not a LaTeX syntax tutorial.
 
+> **Before you write (empirical papers): anchor prose to data first.** For any
+> paper that reports experiments, establish ground-truth correspondence *before*
+> drafting and *again* whenever you reframe a section — list the experiment
+> directories, inspect a real result file's shape, read the runner code, and keep
+> a claim → evidence map. Over many editing/reviewer rounds, prose tends to drift
+> from the data: it gets more polished and internally consistent while quietly
+> ceasing to describe what was actually run, and reviewer agreement won't catch it
+> (it measures text consistency, not data correspondence). When feedback flags a
+> section as confusing, re-derive from the data — don't just rewrite for internal
+> consistency. Full guard: [anti-pattern-text-consistency-vs-data-correspondence.md](anti-pattern-text-consistency-vs-data-correspondence.md).
+
 ---
 
 ## 1. Project Structure
@@ -347,6 +358,7 @@ aspell -t -c main.tex
 
 ## See Also
 
+- [anti-pattern-text-consistency-vs-data-correspondence.md](anti-pattern-text-consistency-vs-data-correspondence.md) — keep an iterated empirical draft anchored to the data; why reviewer agreement doesn't catch drift
 - [pipeline-citation-tracking.md](pipeline-citation-tracking.md) — BibTeX generation from academic APIs
 - [api-crossref.md](api-crossref.md) — BibTeX export via DOI
 - [api-nasa-ads.md](api-nasa-ads.md) — BibTeX export for astrophysics

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -33,6 +33,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/academic-research/scripts/fetch_paper.py",
 		"reference/academic-research/reference/api-arxiv.md",
 		"reference/academic-research/reference/pipeline-latex-writing.md",
+		"reference/academic-research/reference/anti-pattern-text-consistency-vs-data-correspondence.md",
 		"reference/dj/SKILL.md",
 		"reference/token-usage/SKILL.md",
 		"reference/token-usage/scripts/cost_report.py",


### PR DESCRIPTION
## Summary
- add an `academic-research` anti-pattern for empirical paper drafts that become more text-consistent while drifting away from the data on disk
- route the LaTeX writing pipeline and academic-research skill index/known caveats to the new guard
- assert the new nested Swiss Knife reference is bundled
- include the required HTML explainer at `reports/pr-issue100-text-data-drift-explainer.html`

Fixes #100

## Testing
- custom relative-link check across the touched academic-research markdown files
- `cd tui && go test ./internal/preset/ -run 'SwissKnife|PopulateBundledLibrary'`
- `git diff --check`

## Notes
The issue referenced the old academic-research path. On current `main`, academic-research has moved under `tui/internal/preset/skills/swiss-knife/reference/academic-research/`, so this PR updates the live bundled path.
