### PR TITLE
Add Codex preset service tier option

### DIFF
--- a/reports/codex-service-tier-preset-20260605.html
+++ b/reports/codex-service-tier-preset-20260605.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Codex preset service tier option</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.55;margin:0;background:#f6f7fb;color:#20242a}.wrap{max-width:900px;margin:0 auto;padding:32px}section{background:white;border:1px solid #e3e6ee;border-radius:12px;padding:20px 24px;margin:16px 0;box-shadow:0 1px 3px rgba(0,0,0,.04)}h1{margin:0 0 8px}h2{margin-top:0}.pill{display:inline-block;border-radius:999px;padding:3px 10px;background:#e8f1ff;color:#174ea6;font-size:13px;font-weight:600}code{background:#f1f3f7;border-radius:5px;padding:1px 5px}.ok{color:#137333;font-weight:600}.warn{color:#b05a00;font-weight:600}ul{padding-left:22px}table{border-collapse:collapse;width:100%}td,th{border:1px solid #e3e6ee;padding:8px;text-align:left}th{background:#f8f9fb}</style>
+</head>
+<body><div class="wrap">
+<h1>Codex preset service tier option</h1>
+<div class="pill">PR explainer draft</div>
+<section>
+<h2>Conclusion</h2>
+<p>This change makes the Codex preset editor match Codex's two practical modes:</p>
+<ul>
+<li><strong>normal</strong>: omit <code>manifest.llm.service_tier</code>.</li>
+<li><strong>fast</strong>: write <code>manifest.llm.service_tier = "fast"</code>.</li>
+</ul>
+<p>It deliberately does <strong>not</strong> default to <code>flex</code>, because local live verification showed <code>flex</code> parsed in the CLI but the current backend rejected it.</p>
+</section>
+<section>
+<h2>What changed</h2>
+<table><tr><th>Area</th><th>Change</th></tr>
+<tr><td>Preset editor</td><td>Adds a Codex-only <code>service_tier</code> row rendered as <code>normal / fast</code>.</td></tr>
+<tr><td>Serialization</td><td>For Codex, <code>normal</code> removes <code>service_tier</code> and <code>fast</code> stores <code>"fast"</code>. Non-Codex providers keep any existing provider-specific <code>service_tier</code>.</td></tr>
+<tr><td>Built-in Codex preset</td><td>Tested to omit <code>service_tier</code> by default.</td></tr>
+<tr><td>i18n</td><td>Adds labels in English, Chinese, and Wenyan locales.</td></tr>
+</table>
+</section>
+<section>
+<h2>Validation</h2>
+<ul>
+<li><span class="ok">Passed</span>: <code>cd tui &amp;&amp; go test ./internal/preset ./internal/tui</code></li>
+<li><span class="ok">Passed</span>: <code>git diff --check</code></li>
+</ul>
+</section>
+<section>
+<h2>Risk notes</h2>
+<ul>
+<li>The option is Codex-only and hidden for other providers.</li>
+<li>For Codex, invalid values such as <code>default</code> or <code>flex</code> display as <code>normal</code> and are removed on commit.</li>
+<li>For non-Codex providers, existing <code>service_tier</code> values are preserved because they may be provider-specific.</li>
+<li>No global <code>~/.codex/config.toml</code> is modified.</li>
+</ul>
+</section>
+</div></body></html>

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -453,6 +453,7 @@
   "preset_editor.field_loses": "loses",
   "preset_editor.field_provider": "provider",
   "preset_editor.field_model": "model",
+  "preset_editor.field_service_tier": "service_tier",
   "preset_editor.field_api_compat": "api_compat",
   "preset_editor.field_base_url": "base_url",
   "preset_editor.field_api_key_env": "api_key_env",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -448,6 +448,7 @@
   "preset_editor.field_loses": "短板",
   "preset_editor.field_provider": "提供商",
   "preset_editor.field_model": "模型",
+  "preset_editor.field_service_tier": "服务层",
   "preset_editor.field_api_compat": "API 兼容",
   "preset_editor.field_base_url": "端点",
   "preset_editor.field_api_key_env": "密钥环境变量",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -448,6 +448,7 @@
   "preset_editor.field_loses": "短板",
   "preset_editor.field_provider": "提供商",
   "preset_editor.field_model": "模型",
+  "preset_editor.field_service_tier": "服务层级",
   "preset_editor.field_api_compat": "API 兼容",
   "preset_editor.field_base_url": "端点",
   "preset_editor.field_api_key_env": "密钥环境变量",

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -207,6 +207,41 @@ func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 	})
 }
 
+func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
+	p := codexPreset()
+	llm, ok := p.Manifest["llm"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("codex manifest.llm missing or wrong type: %T", p.Manifest["llm"])
+	}
+	if _, ok := llm["service_tier"]; ok {
+		t.Fatalf("codex preset default should omit llm.service_tier; got %#v", llm["service_tier"])
+	}
+
+	tmpDir := t.TempDir()
+	lingtaiDir := filepath.Join(tmpDir, ".lingtai")
+	globalDir := filepath.Join(tmpDir, "global")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatalf("create lingtai dir: %v", err)
+	}
+	if err := GenerateInitJSON(p, "codex-agent", "codex-agent", lingtaiDir, globalDir); err != nil {
+		t.Fatalf("GenerateInitJSON() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(lingtaiDir, "codex-agent", "init.json"))
+	if err != nil {
+		t.Fatalf("read init.json: %v", err)
+	}
+	var initJSON map[string]interface{}
+	if err := json.Unmarshal(data, &initJSON); err != nil {
+		t.Fatalf("parse init.json: %v", err)
+	}
+	manifest := initJSON["manifest"].(map[string]interface{})
+	generatedLLM := manifest["llm"].(map[string]interface{})
+	if _, ok := generatedLLM["service_tier"]; ok {
+		t.Fatalf("generated codex init.json should omit llm.service_tier; got %#v", generatedLLM["service_tier"])
+	}
+}
+
 func TestDelete_RemovesFile(t *testing.T) {
 	withTempPresets(t, func() {
 		p := DefaultPreset()

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -48,6 +48,7 @@ const (
 	feLoses
 	feProvider
 	feModel
+	feServiceTier
 	feAPICompat
 	feBaseURL
 	feAPIKey
@@ -76,7 +77,7 @@ var capFieldNames = map[editorField]string{
 // optional/provider-conditional capabilities appear as editable rows.
 var editorFieldOrder = []editorField{
 	feName, feSummary, feTier, feGains, feLoses,
-	feProvider, feModel, feAPICompat, feBaseURL, feAPIKey,
+	feProvider, feModel, feServiceTier, feAPICompat, feBaseURL, feAPIKey,
 	feCapWebSearch, feCapVision,
 	feSave,
 }
@@ -137,6 +138,8 @@ var providerModels = map[string][]string{
 	// served on the codex endpoint, so we omit it to avoid 4xx breakage).
 	"codex": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
 }
+
+var codexServiceTierOptions = []string{"normal", "fast"}
 
 // modelHasVision reports whether a given model accepts image input.
 // Drives both the disabled-row rendering and the model-switch default
@@ -603,6 +606,10 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 			m.input.Focus()
 			m.mode = emInline
 		}
+	case feServiceTier:
+		if m.isCodexProvider() {
+			m.cycleFocused(+1)
+		}
 	case feTier:
 		// Tier is an enum — Enter cycles like ←/→. No picker overlay.
 		m.cycleFocused(+1)
@@ -838,6 +845,38 @@ func (m *PresetEditorModel) applyInline(val string) {
 	}
 }
 
+func (m PresetEditorModel) isCodexProvider() bool {
+	return asString(m.llmMap()["provider"]) == "codex"
+}
+
+func (m PresetEditorModel) codexServiceTier() string {
+	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
+	if asString(llm["service_tier"]) == "fast" {
+		return "fast"
+	}
+	return "normal"
+}
+
+func (m *PresetEditorModel) setCodexServiceTier(tier string) {
+	llm := m.llmMap()
+	if asString(llm["provider"]) != "codex" || tier != "fast" {
+		delete(llm, "service_tier")
+		return
+	}
+	llm["service_tier"] = "fast"
+}
+
+func normalizeServiceTier(manifest map[string]interface{}) {
+	llm, _ := manifest["llm"].(map[string]interface{})
+	if llm == nil || asString(llm["provider"]) != "codex" {
+		return
+	}
+	if asString(llm["service_tier"]) == "fast" {
+		return
+	}
+	delete(llm, "service_tier")
+}
+
 // setExtra writes into Description.Extra, allocating the map on first
 // use. Empty string deletes the key.
 func (m *PresetEditorModel) setExtra(key, val string) {
@@ -922,6 +961,10 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feAPICompat:
 		opts := []string{"", "openai", "anthropic"}
 		m.llmMap()["api_compat"] = cycleString(opts, m.fieldString(f), dir)
+	case feServiceTier:
+		if m.isCodexProvider() {
+			m.setCodexServiceTier(cycleString(codexServiceTierOptions, m.codexServiceTier(), dir))
+		}
 	case feTier:
 		// Cycle ""→1→2→3→4→5→"" with → and reverse with ←. tierValues
 		// is ordered best-first ([5..1]) for the library's picker, so
@@ -993,6 +1036,7 @@ func (m PresetEditorModel) commit() (PresetEditorModel, tea.Cmd) {
 			delete(llm, "api_key_env")
 		}
 	}
+	normalizeServiceTier(committed.Manifest)
 	return m, func() tea.Msg {
 		return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 	}
@@ -1026,6 +1070,7 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 		m.mode = emBrowse
 		m.cloneNameInput.Blur()
 		committed := clonePresetForEditor(m.working)
+		normalizeServiceTier(committed.Manifest)
 		return m, func() tea.Msg {
 			return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 		}
@@ -1043,6 +1088,7 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 		m.mode = emBrowse
 		m.cloneNameInput.Blur()
 		committed := clonePresetForEditor(m.working)
+		normalizeServiceTier(committed.Manifest)
 		return m, func() tea.Msg {
 			return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 		}
@@ -1087,6 +1133,8 @@ func (m PresetEditorModel) fieldString(f editorField) string {
 	case feModel:
 		s, _ := llm["model"].(string)
 		return s
+	case feServiceTier:
+		return m.codexServiceTier()
 	case feAPICompat:
 		s, _ := llm["api_compat"].(string)
 		return s
@@ -1253,6 +1301,9 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
 	rows = append(rows, row(feProvider, m.row(feProvider, lbl("provider"), asString(llm["provider"]), width-4)))
 	rows = append(rows, row(feModel, m.row(feModel, lbl("model"), asString(llm["model"]), width-4)))
+	if m.fieldVisible(feServiceTier) {
+		rows = append(rows, row(feServiceTier, m.row(feServiceTier, lbl("service_tier"), m.codexServiceTier(), width-4)))
+	}
 	rows = append(rows, row(feAPICompat, m.row(feAPICompat, lbl("api_compat"), asString(llm["api_compat"]), width-4)))
 	rows = append(rows, row(feBaseURL, m.row(feBaseURL, lbl("base_url"), asString(llm["base_url"]), width-4)))
 	rows = append(rows, row(feAPIKey, m.row(feAPIKey, lbl("api_key"), m.fieldString(feAPIKey), width-4)))
@@ -1300,6 +1351,11 @@ func (m PresetEditorModel) row(f editorField, key, value string, width int) stri
 	}
 	if f == feModel {
 		if strip := m.modelRadioStrip(focused, valStyle); strip != "" {
+			return marker + keyStyle.Render(key) + strip
+		}
+	}
+	if f == feServiceTier {
+		if strip := m.serviceTierRadioStrip(focused, valStyle); strip != "" {
 			return marker + keyStyle.Render(key) + strip
 		}
 	}
@@ -1467,6 +1523,27 @@ func (m PresetEditorModel) modelRadioStrip(focused bool, valStyle lipgloss.Style
 	return strings.Join(parts, "  ")
 }
 
+func (m PresetEditorModel) serviceTierRadioStrip(focused bool, valStyle lipgloss.Style) string {
+	if !m.isCodexProvider() {
+		return ""
+	}
+	current := m.codexServiceTier()
+	subtle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	parts := make([]string, 0, len(codexServiceTierOptions))
+	for _, tier := range codexServiceTierOptions {
+		if tier == current {
+			if focused {
+				parts = append(parts, valStyle.Render("● "+tier))
+			} else {
+				parts = append(parts, "● "+tier)
+			}
+		} else {
+			parts = append(parts, subtle.Render("○ "+tier))
+		}
+	}
+	return strings.Join(parts, "  ")
+}
+
 // baseURLRadioStrip renders the base_url field as a horizontal radio
 // strip showing region labels (e.g. "● CN  ○ INTL") when the current
 // provider has regional endpoints. Returns "" when there's no region
@@ -1502,6 +1579,8 @@ func (m PresetEditorModel) isCyclable(f editorField) bool {
 	switch f {
 	case feProvider, feAPICompat, feTier:
 		return true
+	case feServiceTier:
+		return m.isCodexProvider()
 	case feModel:
 		provider := asString(m.llmMap()["provider"])
 		_, hasPicker := providerModels[provider]
@@ -1584,17 +1663,32 @@ func (m PresetEditorModel) renderPreview(width, height int) string {
 }
 
 func (m *PresetEditorModel) moveCursor(delta int) {
-	m.cursor += delta
-	if m.cursor < 0 {
-		m.cursor = 0
+	if delta == 0 {
+		m.normalizeCursor()
+		m.ensureFocusedVisible()
+		return
 	}
-	if m.cursor > saveFieldIndex {
-		m.cursor = saveFieldIndex
+	step := 1
+	if delta < 0 {
+		step = -1
+		delta = -delta
 	}
+	for i := 0; i < delta; i++ {
+		next := m.cursor + step
+		for next >= 0 && next <= saveFieldIndex && !m.fieldVisible(editorFieldOrder[next]) {
+			next += step
+		}
+		if next < 0 || next > saveFieldIndex {
+			break
+		}
+		m.cursor = next
+	}
+	m.normalizeCursor()
 	m.ensureFocusedVisible()
 }
 
 func (m *PresetEditorModel) ensureFocusedVisible() {
+	m.normalizeCursor()
 	if m.width == 0 || m.height == 0 {
 		return
 	}
@@ -1617,6 +1711,39 @@ func (m *PresetEditorModel) ensureFocusedVisible() {
 	}
 	if m.scrollOffset < 0 {
 		m.scrollOffset = 0
+	}
+}
+
+func (m PresetEditorModel) fieldVisible(f editorField) bool {
+	switch f {
+	case feServiceTier:
+		return m.isCodexProvider()
+	default:
+		return true
+	}
+}
+
+func (m *PresetEditorModel) normalizeCursor() {
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	if m.cursor > saveFieldIndex {
+		m.cursor = saveFieldIndex
+	}
+	if m.fieldVisible(editorFieldOrder[m.cursor]) {
+		return
+	}
+	for i := m.cursor + 1; i <= saveFieldIndex; i++ {
+		if m.fieldVisible(editorFieldOrder[i]) {
+			m.cursor = i
+			return
+		}
+	}
+	for i := m.cursor - 1; i >= 0; i-- {
+		if m.fieldVisible(editorFieldOrder[i]) {
+			m.cursor = i
+			return
+		}
 	}
 }
 

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -40,6 +40,30 @@ func testPresetEditorPreset() preset.Preset {
 	}
 }
 
+func testCodexPresetEditorPreset(serviceTier interface{}) preset.Preset {
+	llm := map[string]interface{}{
+		"provider":    "codex",
+		"model":       "gpt-5.5",
+		"api_key":     nil,
+		"api_key_env": "",
+		"base_url":    "https://chatgpt.com/backend-api/codex",
+	}
+	if serviceTier != nil {
+		llm["service_tier"] = serviceTier
+	}
+	return preset.Preset{
+		Name:        "codex-test",
+		Description: preset.PresetDescription{Summary: "Codex editor test preset"},
+		Manifest: map[string]interface{}{
+			"llm": llm,
+			"capabilities": map[string]interface{}{
+				"web_search": map[string]interface{}{"provider": "codex"},
+				"vision":     map[string]interface{}{"provider": "codex"},
+			},
+		},
+	}
+}
+
 func TestPresetEditorSmallHeightKeepsSaveVisible(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
 	var cmd tea.Cmd
@@ -115,10 +139,7 @@ func TestPresetEditorAPIKeyEditableWhenAlreadyStored(t *testing.T) {
 		t.Fatalf("expected existing key to render masked, got %q", got)
 	}
 
-	// Walk cursor to feAPIKey (index 9 in editorFieldOrder).
-	for i := 0; i < 9; i++ {
-		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	}
+	m.cursor = editorFieldOrderIndex(t, feAPIKey)
 	if editorFieldOrder[m.cursor] != feAPIKey {
 		t.Fatalf("expected cursor on feAPIKey, got %v", editorFieldOrder[m.cursor])
 	}
@@ -228,9 +249,7 @@ func TestPresetEditorAPIKeyEditableWhenNoStoredKey(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 
-	for i := 0; i < 9; i++ {
-		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	}
+	m.cursor = editorFieldOrderIndex(t, feAPIKey)
 	if editorFieldOrder[m.cursor] != feAPIKey {
 		t.Fatalf("expected cursor on feAPIKey, got %v", editorFieldOrder[m.cursor])
 	}
@@ -314,6 +333,125 @@ func TestPresetEditorCommitDoesNotInjectLegacyCoreCaps(t *testing.T) {
 	}
 }
 
+func TestPresetEditorCodexServiceTierFastAndNormal(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset(nil), "en", nil, "", false)
+	m.cursor = editorFieldOrderIndex(t, feServiceTier)
+
+	if !m.fieldVisible(feServiceTier) {
+		t.Fatalf("codex service tier row should be visible")
+	}
+	if got := m.fieldString(feServiceTier); got != "normal" {
+		t.Fatalf("empty llm.service_tier displays %q, want normal", got)
+	}
+
+	m.cycleFocused(+1)
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	if got, _ := llm["service_tier"].(string); got != "fast" {
+		t.Fatalf("cycling normal -> fast wrote service_tier=%#v, want fast", llm["service_tier"])
+	}
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if got, _ := committedLLM["service_tier"].(string); got != "fast" {
+		t.Fatalf("committed fast service_tier=%#v, want fast", committedLLM["service_tier"])
+	}
+
+	m.cycleFocused(+1)
+	if _, ok := llm["service_tier"]; ok {
+		t.Fatalf("cycling fast -> normal should remove llm.service_tier; got %#v", llm["service_tier"])
+	}
+	_, cmd = m.commit()
+	commit = cmd().(PresetEditorCommitMsg)
+	committedLLM = commit.Preset.Manifest["llm"].(map[string]interface{})
+	if _, ok := committedLLM["service_tier"]; ok {
+		t.Fatalf("committed normal service tier should omit llm.service_tier; got %#v", committedLLM["service_tier"])
+	}
+}
+
+func TestPresetEditorCodexServiceTierDisplayAndCommitNormalization(t *testing.T) {
+	cases := []struct {
+		name        string
+		serviceTier interface{}
+		wantDisplay string
+		wantSaved   bool
+	}{
+		{name: "absent", serviceTier: nil, wantDisplay: "normal"},
+		{name: "fast", serviceTier: "fast", wantDisplay: "fast", wantSaved: true},
+		{name: "unknown", serviceTier: "flex", wantDisplay: "normal"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset(tc.serviceTier), "en", nil, "", false)
+			if got := m.fieldString(feServiceTier); got != tc.wantDisplay {
+				t.Fatalf("service tier display = %q, want %q", got, tc.wantDisplay)
+			}
+			_, cmd := m.commit()
+			commit := cmd().(PresetEditorCommitMsg)
+			llm := commit.Preset.Manifest["llm"].(map[string]interface{})
+			got, saved := llm["service_tier"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("committed service_tier saved=%v, want %v; value=%#v", saved, tc.wantSaved, llm["service_tier"])
+			}
+			if saved && got != "fast" {
+				t.Fatalf("committed service_tier=%q, want fast", got)
+			}
+		})
+	}
+}
+
+func TestPresetEditorServiceTierHiddenForNonCodexAndPreserved(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+	view := m.View()
+
+	if m.fieldVisible(feServiceTier) {
+		t.Fatalf("service tier row should be hidden for non-codex provider")
+	}
+	if strings.Contains(view, "service_tier") {
+		t.Fatalf("non-codex editor should not render service_tier row; view:\n%s", view)
+	}
+
+	m.cursor = editorFieldOrderIndex(t, feModel)
+	m.moveCursor(+1)
+	if editorFieldOrder[m.cursor] == feServiceTier {
+		t.Fatalf("cursor landed on hidden service tier field for non-codex preset")
+	}
+	if editorFieldOrder[m.cursor] != feAPICompat {
+		t.Fatalf("cursor after model = %v, want feAPICompat", editorFieldOrder[m.cursor])
+	}
+
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	llm["service_tier"] = "provider-specific"
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if got, _ := committedLLM["service_tier"].(string); got != "provider-specific" {
+		t.Fatalf("non-codex commit should preserve llm.service_tier; got %#v", committedLLM["service_tier"])
+	}
+}
+
+func TestPresetEditorProviderSwitchPreservesServiceTier(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset("fast"), "en", nil, "", false)
+	m.cursor = editorFieldOrderIndex(t, feProvider)
+
+	m.cycleFocused(+1) // codex -> custom in provider picker order.
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	if got := llm["provider"]; got != "custom" {
+		t.Fatalf("provider after cycling from codex = %#v, want custom", got)
+	}
+	if got, _ := llm["service_tier"].(string); got != "fast" {
+		t.Fatalf("provider switch should preserve existing service_tier; got %#v", llm["service_tier"])
+	}
+
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if got, _ := committedLLM["service_tier"].(string); got != "fast" {
+		t.Fatalf("non-codex commit after provider switch should preserve service_tier; got %#v", committedLLM["service_tier"])
+	}
+}
+
 func TestPresetEditorViewShowsCoreAsInformational(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
@@ -329,6 +467,17 @@ func TestPresetEditorViewShowsCoreAsInformational(t *testing.T) {
 			t.Fatalf("view missing optional capability %q; view:\n%s", capName, view)
 		}
 	}
+}
+
+func editorFieldOrderIndex(t *testing.T, want editorField) int {
+	t.Helper()
+	for i, got := range editorFieldOrder {
+		if got == want {
+			return i
+		}
+	}
+	t.Fatalf("field %v missing from editorFieldOrder", want)
+	return -1
 }
 
 func renderedLineCount(s string) int {


### PR DESCRIPTION
## Summary

- add a Codex-only `service_tier` option to the preset editor with `normal` and `fast`
- represent Codex `normal` by omitting `manifest.llm.service_tier`; save Codex `fast` as `service_tier = "fast"`
- normalize invalid Codex values by removing `service_tier`, while preserving existing non-Codex `service_tier` values because they may be provider-specific
- add a self-contained explainer at `reports/codex-service-tier-preset-20260605.html`

## Why

Codex effectively has the user-facing modes the preset should expose:

- **normal**: no service-tier field in config
- **fast**: explicit `service_tier = "fast"`

The preset should not default to `flex`; current live verification showed `flex` can parse in the CLI but the Codex backend rejects it for the current route.

## Tests

- `cd tui && go test ./internal/preset ./internal/tui`
- `git diff --check`