### PR TITLE
feat(academic-research): add authorized publisher PDF tier

### DIFF
--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
@@ -6,7 +6,8 @@ description: >
   **First action for any "get me this paper" request:**
   `python3 <skill-path>/scripts/fetch_paper.py <DOI|arXiv-ID|PMID>` — walks
   arXiv → Unpaywall → Europe PMC → CORE → publisher-page extraction (Nature/APS/AIP/IOP/Cambridge)
-  → LibGen and saves the paper, metadata, and a resumable manifest under `papers/{slug}/`.
+  → authorized institutional publisher → LibGen and saves the paper, metadata, and a resumable
+  manifest under `papers/{slug}/`.
   Read the body when you need to escape the script: custom query shapes, citation networks,
   scholar analysis, LaTeX writing, or a tier-specific API call. Indexes 12 deep-dive API
   references and 6 pipeline workflows under `reference/`.
@@ -40,6 +41,12 @@ python3 <skill-path>/scripts/fetch_paper.py 10.1038/nature12373 --dry-run
 
 # Skip LibGen (e.g. legal-sensitive environment)
 python3 <skill-path>/scripts/fetch_paper.py <id> --no-libgen
+
+# Skip the authorized-publisher probe (off-network / legal-sensitive)
+python3 <skill-path>/scripts/fetch_paper.py <id> --no-institutional
+
+# Most conservative: OA only, no institutional probe, no LibGen
+python3 <skill-path>/scripts/fetch_paper.py <id> --no-institutional --no-libgen
 ```
 
 **Output layout** (idempotent — re-runs skip entries with `status: ok`):
@@ -60,6 +67,7 @@ papers/{first-author-year-firstword}/
 | 3 | Europe PMC | Biomedical full-text + PMC mirror |
 | 4 | CORE | Institutional repositories (needs `$CORE_API_KEY`) |
 | 5 | Publisher-page extract | Nature/APS/AIP/IOP/Cambridge → structured Markdown with LaTeX preserved (auto-installs [zhiping0913/Download_paper](https://github.com/zhiping0913/Download_paper) on first use) |
+| 5b | Authorized publisher | **Licensed/institutional access only** — official DOI landing page → same-host publisher PDF → `%PDF-` validation, full provenance. Recovers paywalled-but-subscribed papers without shadow libraries. Never bypasses paywalls or handles credentials. Opt out with `--no-institutional`. See [authorized-publisher-access.md](reference/authorized-publisher-access.md) |
 | 6 | LibGen | Last resort; opt out with `--no-libgen` |
 
 **Set `$LINGTAI_RESEARCH_EMAIL` to a real address** before first use — Unpaywall
@@ -80,6 +88,7 @@ I only have keywords        → reference/decision-tree.md → pick API by disci
 I need a citation network   → reference/api-semantic-scholar.md or api-openalex.md
 I need to override the PDF ladder → reference/pipeline-obtain-pdf.md
 Tier-5 publisher-extract failed and I want to retry it manually → reference/publisher-page-extraction.md
+Paper is paywalled but I'm on a licensed network → reference/authorized-publisher-access.md (Tier 5b)
 All OA chains failed        → reference/libgen-fallback.md (last resort)
 I need astrophysics         → reference/api-nasa-ads.md
 I need high-energy physics  → reference/api-inspire-hep.md
@@ -124,6 +133,7 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 ### Standalone references
 
 - [publisher-page-extraction.md](reference/publisher-page-extraction.md) — Tier-5 manual escape hatch (Nature/APS/AIP/IOP/Cambridge → structured Markdown)
+- [authorized-publisher-access.md](reference/authorized-publisher-access.md) — Tier-5b authorized institutional publisher PDF access: official DOI landing → same-host PDF → validation, with hard policy boundaries (no paywall bypass, no credential/cookie handling)
 - [libgen-fallback.md](reference/libgen-fallback.md) — Last-resort PDF source with legal/safety notes
 - [error-handling.md](reference/error-handling.md) — 429 backoff, 403 publisher blocks, timeout patterns
 - [anti-pattern-text-consistency-vs-data-correspondence.md](reference/anti-pattern-text-consistency-vs-data-correspondence.md) — empirical-writing failure mode: prose drifts from the data while reviewer rounds make it more polished. Trigger pattern, re-anchoring steps, detection checklist.
@@ -141,6 +151,7 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 - **Semantic Scholar free tier is very tight** (~100 reqs / 5 min). Request a key for any serious citation-network work.
 - **Google Scholar requires a stealth browser** (camoufox or playwright-stealth v2); legacy `playwright_stealth` API does not work.
 - **arXiv enforces HTTPS** — HTTP requests are 301-redirected automatically.
+- **Authorized-publisher tier (5b) only uses access you already have** — it follows the official DOI landing page and grabs a same-host publisher PDF, validating `%PDF-` bytes and Content-Type before saving. It never bypasses paywalls/CAPTCHAs and never reads, stores, or replays cookies/credentials; most institutional access is IP-based, so on a licensed network a plain HTTP GET just works. Off-network it harmlessly misses. Pass `--no-institutional` to disable in legal-sensitive environments. Cookies/auth headers are never written to provenance. See [reference/authorized-publisher-access.md](reference/authorized-publisher-access.md).
 - **Library Genesis legality varies by jurisdiction** — use is the user's responsibility. Pass `--no-libgen` to opt out.
 - **Publisher-page extraction (Tier 5)** uses Playwright + pandoc; first invocation installs `zhiping0913/Download_paper` from git. Requires Chromium (`playwright install chromium`) and pandoc on `$PATH`. See [reference/publisher-page-extraction.md](reference/publisher-page-extraction.md).
 - **Writing an empirical paper iteratively can drift from the data** — reviewer rounds make prose more polished and internally consistent without verifying it still matches the experiments on disk. Reviewer agreement is text-consistency evidence, not data-correspondence evidence. Anchor every claim to data files/runner code *before* writing, and re-derive (don't just rewrite) when feedback flags confusion. See [reference/anti-pattern-text-consistency-vs-data-correspondence.md](reference/anti-pattern-text-consistency-vs-data-correspondence.md).

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/authorized-publisher-access.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/authorized-publisher-access.md
@@ -1,0 +1,217 @@
+# Authorized Institutional Publisher Access (Tier 5b)
+
+> **Read this when** OA routes (arXiv / Unpaywall / Europe PMC / CORE) and the
+> Tier-5 publisher-page extractor all miss, the paper is *not* open access, and
+> the user is running inside a network that **already** has legitimate
+> subscription access to the publisher (a university/library IP range, an
+> authenticated library proxy session, etc.).
+>
+> This tier sits **after** OA and publisher-extract, and **before** LibGen. It
+> recovers PDFs that are paywalled-but-licensed-to-you, with heavy provenance,
+> so an agent can honestly say: *"I tried OA first; where the user had
+> authorized institutional access I used the official publisher URL with full
+> provenance; I did not use LibGen / Sci-Hub / any shadow library."*
+
+---
+
+## What this tier IS
+
+A conservative probe that:
+
+1. Resolves `https://doi.org/<doi>` with a normal HTTP client and a polite
+   User-Agent, following redirects to the **official publisher landing page**.
+2. Parses that landing page for a publisher-provided PDF URL:
+   - `<meta name="citation_pdf_url" content="...">` (the Highwire/Google
+     Scholar convention most publishers emit), and/or
+   - `.pdf` anchors that live on the **same official host / subdomain**.
+3. Validates *before saving*:
+   - final HTTP status is `200`;
+   - the final (post-redirect) URL is still on the landing host, its `www.`
+     alias, or a **subdomain** of it — never a sibling public-suffix domain;
+   - `Content-Type` starts with `application/pdf`;
+   - the response body starts with the `%PDF-` magic bytes;
+   - size sanity (non-empty, under a hard cap).
+4. Records full provenance: DOI, landing URL, candidate PDF URL, final URL,
+   HTTP status, content type, byte length, timestamp, and `route:
+   authorized_publisher`.
+
+This is exactly the access path your browser would take if you clicked the
+"PDF" button on the article page while on your institution's network. The probe
+adds nothing to that — it only *follows official links you can already reach*.
+
+## What this tier is NOT — hard boundaries
+
+This tier **must never**:
+
+- bypass or solve a paywall, CAPTCHA, or Cloudflare/anti-bot challenge;
+- capture, store, replay, guess, or forge credentials, cookies, session
+  tokens, or bearer headers;
+- inject institutional-proxy URL rewriting (e.g. EZproxy host-mangling) that
+  the user has not already established in their own session;
+- guess sibling/alternate domains or "mirror" hosts for a publisher;
+- fall back to LibGen, Sci-Hub, or any shadow library — those are a *different*
+  tier with their own (stricter) gate.
+
+If access isn't already present in the environment, this tier simply **misses**
+and the ladder falls through. It is not a way to *obtain* access; it is a way to
+*use access you already have*, auditably.
+
+### Why no cookie/session handling
+
+It is tempting to "just forward the user's library cookies." Don't build that
+into the skill:
+
+- **Credential surface.** A skill that reads, stores, or replays session
+  cookies turns every fetch into a credential-handling operation. That is a
+  security liability (cookies leak into manifests, logs, subagent prompts) and
+  a policy liability (you are now acting as the user's authenticated agent
+  against the publisher's ToS in ways the user may not have intended).
+- **It is usually unnecessary.** Most institutional access is **IP-based**: if
+  the process runs on the campus/library network, `requests` already resolves
+  the licensed PDF with no cookie at all. That is the only mode this tier
+  supports.
+- **Proxy sessions are the user's to own.** If a user genuinely needs an
+  authenticated EZproxy/OpenAthens session, they should establish it at the OS
+  / browser / network layer and let the IP or transparent proxy carry it. The
+  skill stays cookie-agnostic and never persists session state.
+
+The single allowed concession: the probe honors an **already-exported**
+`$HTTPS_PROXY` / `$HTTP_PROXY` (standard `requests` behavior). That is the
+user's network configuration, not a credential the skill manufactured. The
+skill does not read cookie jars, does not write them, and does not log any
+`Set-Cookie` / `Authorization` values into provenance.
+
+---
+
+## Where it fits in the ladder
+
+```
+arXiv → Unpaywall → Europe PMC → CORE → publisher-extract (Tier 5)
+                                          → authorized-publisher (Tier 5b)   ← this file
+                                          → LibGen (last resort)
+```
+
+- **vs. Tier 5 (publisher-page extraction, `Download_paper`):** Tier 5 renders
+  the *article HTML* into Markdown-with-LaTeX and needs Chromium + pandoc; it is
+  great for math-heavy papers but currently brittle to install (issue #136).
+  Tier 5b instead grabs the **publisher's own PDF** via a plain HTTP client — no
+  browser, no pandoc — and is the right tool when you just need the canonical
+  PDF and you already have access.
+- **vs. LibGen:** LibGen is a shadow library of unclear copyright status; Tier 5b
+  is the *licensed* publisher copy. Always prefer 5b. The two never share code
+  or fall into each other automatically except through the normal ladder order.
+
+---
+
+## Using it via `fetch_paper.py`
+
+The tier is **on by default** but only ever succeeds where licensed access
+already exists, so it is safe to leave enabled:
+
+```bash
+# Normal run — authorized-publisher probe runs automatically between
+# publisher-extract and LibGen.
+python3 <skill-path>/scripts/fetch_paper.py 10.1007/s11214-020-00743-1
+
+# Legal-sensitive / off-network environment: turn the probe off explicitly.
+python3 <skill-path>/scripts/fetch_paper.py <doi> --no-institutional
+
+# Belt-and-braces conservative run: OA only, no institutional probe, no LibGen.
+python3 <skill-path>/scripts/fetch_paper.py <doi> --no-institutional --no-libgen
+```
+
+A successful hit writes `manifest.json` with:
+
+```json
+{
+  "status": "ok",
+  "tier": "authorized_publisher",
+  "source": "paper.pdf",
+  "route": "authorized_publisher",
+  "provenance": {
+    "doi": "10.1007/s11214-020-00743-1",
+    "landing_url": "https://link.springer.com/article/10.1007/s11214-020-00743-1",
+    "pdf_url": "https://link.springer.com/content/pdf/10.1007/s11214-020-00743-1.pdf",
+    "final_url": "https://link.springer.com/content/pdf/10.1007/s11214-020-00743-1.pdf",
+    "http_status": 200,
+    "content_type": "application/pdf",
+    "bytes": 4123456,
+    "host_check": "same-host"
+  }
+}
+```
+
+Cookie/session values are **never** written to provenance.
+
+---
+
+## Host-validation rules (the core safety check)
+
+Given the landing host `H` (the host of the final DOI-resolved URL), a candidate
+PDF URL's final host `F` is accepted only if:
+
+| Relationship | Example (`H = link.springer.com`) | Accept? |
+|---|---|---|
+| Exact same host | `link.springer.com` | ✅ |
+| `www.` alias either direction | `www.link.springer.com` ↔ `link.springer.com` | ✅ |
+| Subdomain of `H` | `cdn-pdf.link.springer.com` | ✅ |
+| Registrable parent / sibling | `springer.com`, `springeropen.com` | ❌ |
+| Unrelated host | `dl.example-cdn.net` | ❌ |
+
+The rule is deliberately strict: we accept the host the user actually landed on
+and things strictly *under* it, and reject everything else — including the
+registrable parent — because a publisher's licensed PDF is virtually always
+served from the same host that served the article page. Being conservative here
+costs an occasional miss (fall through to the next tier) and buys a strong
+guarantee that we never wander onto an unlicensed or spoofed host.
+
+> Implementation note: the `_same_publisher_host()` helper in `fetch_paper.py`
+> compares `H` and `F` after stripping a leading `www.` from each, then accepts
+> iff `F == H` or `F.endswith("." + H)`.
+
+---
+
+## Manual workflow (when escaping the script)
+
+If you need to run the probe by hand (debugging, custom queue, batch over a
+project-local acquisition store):
+
+1. **Select candidates.** Only DOIs that already failed every OA tier. Don't
+   re-probe rows already `fetched`.
+2. **Resolve landing.** `GET https://doi.org/<doi>`, follow redirects, keep the
+   final URL → `landing_url`, its host → `H`.
+3. **Find a PDF URL.** Prefer `meta[name=citation_pdf_url]`; else same-host
+   `.pdf` anchors. Skip anything that fails the host rule.
+4. **Dry-run first.** Record `landing_url`, `pdf_url`, status, content type,
+   source — **mutate nothing**.
+5. **Download only on explicit opt-in.** Re-GET the PDF URL, follow redirects,
+   then gate on: status 200 **and** host rule **and** `application/pdf`
+   **and** `%PDF-` magic bytes **and** size sane. Only then write the file.
+6. **Promote atomically.** Write to a temp path, fsync/rename into place, and
+   update queue/CSV mirrors *after* the bytes are on disk — never mark a row
+   `fetched` before the PDF exists.
+7. **Log provenance per attempt**, never including cookies or auth headers.
+
+This mirrors the validated project-local pattern from the HelioSI acquisition
+store (`scripts/probe_authorized_fulltext.py`) that motivated issue #140.
+
+---
+
+## Failure modes
+
+| Symptom | Cause | What to do |
+|---|---|---|
+| Landing resolves but no `citation_pdf_url` and no same-host `.pdf` | Publisher emits the PDF link only behind JS | Miss; fall through. Optionally Tier 5 (`Download_paper`) for the article HTML. |
+| PDF URL returns HTML, not `application/pdf` | You are *not* on a licensed network — got an interstitial/login page | Correct behavior: magic-byte check rejects it, tier misses. Do **not** try to parse the login page. |
+| `403` / `401` on the PDF URL | No institutional access in this environment | Miss; fall through. This tier never tries to defeat the 403. |
+| Final URL is a sibling/parent domain | Publisher served PDF off a different registrable domain | Host rule rejects; miss. (Conservative by design — accept the occasional false negative.) |
+| `%PDF-` present but body tiny (<1 KB) | Truncated / error stub | Size check deletes it; miss. |
+
+---
+
+## See also
+
+- [pipeline-obtain-pdf.md](pipeline-obtain-pdf.md) — the full acquisition ladder
+- [publisher-page-extraction.md](publisher-page-extraction.md) — Tier 5, the HTML→Markdown extractor (issue #136 install caveat)
+- [libgen-fallback.md](libgen-fallback.md) — the tier *below* this one, with its own (stricter) legal gate
+- [api-unpaywall.md](api-unpaywall.md) — always try OA first

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/decision-tree.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/decision-tree.md
@@ -72,7 +72,9 @@ What is your input?
 │   │   ├── Extract DOI (meta[name="citation_doi"]) → follow DOI workflow
 │   │   └── camoufox render (domcontentloaded, not networkidle)
 │   ├── Major paid publishers (Wiley/Elsevier/Science)
-│   │   └── API is the only option; do not attempt direct scraping
+│   │   ├── No access → API metadata only; do not attempt direct scraping or paywall bypass
+│   │   └── On a licensed institutional network → authorized-publisher tier
+│   │       (official landing → same-host PDF → %PDF- check; see authorized-publisher-access.md)
 │   ├── All OA channels failed (Unpaywall/CORE/Europe PMC/arXiv)
 │   │   └── LibGen fallback → see libgen-fallback.md (last resort)
 │   └── Other URLs
@@ -155,7 +157,7 @@ Key integration points:
 
 1. **Google Scholar max 1 request per session** — 429 risk is very high; on 429, fall back to OpenAlex
 2. **Nature/Springer always use `domcontentloaded`** — `networkidle` causes infinite loading timeouts
-3. **Major paid publishers return 403** — Wiley/Elsevier/Science/PNAS almost always 403; API is the only option
+3. **Major paid publishers return 403** — Wiley/Elsevier/Science/PNAS almost always 403 *without access*; API is the only anonymous option. On a **licensed institutional network**, the authorized-publisher tier ([authorized-publisher-access.md](authorized-publisher-access.md)) can fetch the official PDF using access you already have — it never bypasses the paywall or handles credentials
 4. **arXiv PDF has no direct link** — No direct PDF link on the page; derive `/pdf/{ID}.pdf` from the ID
 5. **Playwright stealth is outdated** — Use camoufox or playwright-stealth v2 instead of the old API
 6. **Scanned PDFs** — PyMuPDF cannot extract text; OCR is needed (tesseract / ocrmypdf)

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/libgen-fallback.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/libgen-fallback.md
@@ -2,7 +2,7 @@
 
 > **This is the last-resort fallback.** Use only after Unpaywall, CORE, Europe PMC, and arXiv have all failed. See [pipeline-obtain-pdf.md](pipeline-obtain-pdf.md) for the full acquisition chain.
 
-> **Legal notice**: LibGen hosts content of unclear copyright status in many jurisdictions. Use is solely the user's responsibility. Always prefer legitimate open-access channels first. In sensitive jurisdictions, consider using Tor or a VPN.
+> **Legal notice**: LibGen hosts content of unclear copyright status in many jurisdictions. Use is solely the user's responsibility. Always prefer legitimate open-access channels first. If the paper is paywalled but you have **licensed institutional access**, use the authorized-publisher tier ([authorized-publisher-access.md](authorized-publisher-access.md)) *before* this one — it fetches the official, licensed PDF. In sensitive jurisdictions, consider using Tor or a VPN.
 
 ---
 
@@ -177,15 +177,16 @@ If one pattern fails, try the next. The detail page (`ads.php?md5=...`) usually 
 LibGen sits at the end of the acquisition chain:
 
 ```
-Unpaywall → CORE → Europe PMC → arXiv → Publisher OA → LibGen (last resort)
+Unpaywall → CORE → Europe PMC → arXiv → Publisher OA → Authorized publisher (if licensed) → LibGen (last resort)
 ```
 
-**Before trying LibGen**, confirm you have exhausted all legitimate OA channels:
+**Before trying LibGen**, confirm you have exhausted all legitimate channels:
 1. Unpaywall: no OA version found
 2. CORE: no repository copy
 3. Europe PMC: not in PMC (or not biomedical)
 4. arXiv: no preprint version
 5. Publisher page: no free access
+6. Authorized publisher: no licensed institutional access available (or `--no-institutional` set) — see [authorized-publisher-access.md](authorized-publisher-access.md)
 
 Only then proceed to LibGen.
 

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/pipeline-obtain-pdf.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/pipeline-obtain-pdf.md
@@ -16,6 +16,7 @@ Given a DOI / arXiv ID / paper URL, retrieve the paper's full text (PDF or plain
 3. **Find free PDF** — Unpaywall / arXiv direct link / PMC.
 4. **Download PDF** — Direct download via curl / requests.
 5. **(If OA channels fail, DOI is a supported publisher) Publisher-page extraction** — Nature/APS/AIP/IOP/Cambridge → structured Markdown with LaTeX preserved. See [publisher-page-extraction.md](publisher-page-extraction.md).
+5b. **(If paywalled but you have licensed access) Authorized institutional publisher** — official DOI landing page → same-host publisher PDF → validate `%PDF-` bytes + Content-Type → save with provenance. No paywall bypass, no credential/cookie handling. See [authorized-publisher-access.md](authorized-publisher-access.md).
 6. **(If all of the above fail) LibGen fallback** — See [libgen-fallback.md](libgen-fallback.md) for live mirror discovery and download.
 6. **(If web page, not PDF) Extract web page body** — Select BeautifulSoup or Camoufox based on the site.
 7. **Extract text from PDF** — PyMuPDF text extraction.
@@ -34,7 +35,7 @@ What is the input?
 │   ├─ CrossRef resolve metadata
 │   ├─ Unpaywall find free PDF
 │   │   ├─ Found → Download PDF → Extract text
-│   │   └─ Not found → CORE → Europe PMC → arXiv → publisher-page extract (see publisher-page-extraction.md) → LibGen (last resort, see libgen-fallback.md)
+│   │   └─ Not found → CORE → Europe PMC → arXiv → publisher-page extract (see publisher-page-extraction.md) → authorized institutional publisher (if licensed, see authorized-publisher-access.md) → LibGen (last resort, see libgen-fallback.md)
 │   └─ OpenAlex supplementary metadata
 │
 ├─ arXiv ID (e.g. 2301.00001)
@@ -272,12 +273,13 @@ print(f"Status: {status}, Path: {path}")
 | Scenario | Symptom | Fallback Strategy |
 |----------|---------|-------------------|
 | Unpaywall has no free version | `free: False` | Return landing page URL, prompt user to obtain manually |
-| PDF download returns 403 | `raise_for_status` fails | ① Try downloading via Camoufox browser ② Switch source (PMC / Sci-Hub) |
+| PDF download returns 403 | `raise_for_status` fails | ① Switch OA source (PMC, CORE, arXiv mirror) ② If you have licensed institutional access, use the authorized-publisher tier ([authorized-publisher-access.md](authorized-publisher-access.md)) — it does not defeat the 403, it uses access you already have |
 | PDF is a scanned copy (image format) | PyMuPDF extracts empty text | Requires OCR (pytesseract / Tesseract), outside the scope of this pipeline |
 | Web Tier 2 extraction returns empty | BeautifulSoup finds no match | Fall back to Tier 3: Camoufox browser rendering |
 | Nature/Springer timeout | `networkidle` waits indefinitely | Use `domcontentloaded` event instead (see code comment) |
 | Scholar IP ban | 429 error | ① Wait 60s ② Switch API (OpenAlex) ③ Camoufox + proxy |
-| Major publishers fully block (Wiley/Elsevier) | Cannot download | Only metadata available via API; full text requires institutional access |
+| Major publishers fully block (Wiley/Elsevier) | Cannot download anonymously | If you have **licensed institutional access** (campus/library IP), try the authorized-publisher tier — see [authorized-publisher-access.md](authorized-publisher-access.md). Otherwise only metadata is available via API. |
+| OA fails but you're on a licensed network | Paywalled but subscribed | Authorized institutional publisher tier (5b) — official landing → same-host PDF → `%PDF-` validation, full provenance. See [authorized-publisher-access.md](authorized-publisher-access.md). No paywall bypass, no credential handling. |
 | All OA channels exhausted | Unpaywall + CORE + Europe PMC + arXiv all fail | LibGen fallback — see [libgen-fallback.md](libgen-fallback.md) for live mirror discovery (last resort; legal status varies by jurisdiction) |
 
 ---
@@ -314,4 +316,5 @@ def auto_select_tier(url: str) -> tuple[int, str]:
 - Paper discovery (from keywords/authors) → See [pipeline-discovery.md](pipeline-discovery.md)
 - Citation network & trend analysis → See [pipeline-scholar-analysis.md](pipeline-scholar-analysis.md)
 - Format references → See [pipeline-citation-tracking.md](pipeline-citation-tracking.md)
+- Authorized institutional publisher access (Tier 5b) → See [authorized-publisher-access.md](authorized-publisher-access.md)
 - Comprehensive entry point: What information do I have, and which API should I use? → See [decision-tree.md](decision-tree.md)

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/scripts/fetch_paper.py
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/scripts/fetch_paper.py
@@ -19,6 +19,9 @@ Tier ladder (stops at first success):
     4. CORE           (institutional repository aggregator)
     5. Publisher-page extraction (zhiping0913/Download_paper) for
        10.1038 / 10.1103 / 10.1063 / 10.1088 / 10.1017
+    5b. Authorized publisher (institutional/licensed access — official DOI
+        landing page → same-host PDF → %PDF- validation; opt-out with
+        --no-institutional). Never bypasses paywalls or handles credentials.
     6. LibGen         (last resort, opt-out with --no-libgen)
 
 Output (per paper):
@@ -45,7 +48,7 @@ import sys
 import time
 from pathlib import Path
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urljoin, urlparse
 
 import requests
 
@@ -335,6 +338,146 @@ def tier_publisher_extract(meta: dict, out_dir: Path) -> Optional[Path]:
     return None
 
 
+def _same_publisher_host(landing_host: str, candidate_host: str) -> bool:
+    """True iff candidate_host is the landing host, its www. alias, or a
+    subdomain of it. Sibling/parent registrable domains are rejected.
+
+    Deliberately strict (see reference/authorized-publisher-access.md): a
+    publisher's licensed PDF is virtually always on the same host that served
+    the article page, so we accept only that host and things strictly under it.
+    """
+    h = (landing_host or "").lower().lstrip(".")
+    c = (candidate_host or "").lower().lstrip(".")
+    if not h or not c:
+        return False
+    if h.startswith("www."):
+        h = h[4:]
+    if c.startswith("www."):
+        c = c[4:]
+    return c == h or c.endswith("." + h)
+
+
+def tier_authorized_publisher(meta: dict, email: str, out_dir: Path) -> Optional[Path]:
+    """Tier 5b — authorized institutional publisher access.
+
+    Conservative, provenance-heavy probe for paywalled-but-licensed PDFs: it
+    follows the official DOI landing page, looks for a publisher-provided PDF
+    URL on the *same host*, and saves it only after validating
+    same-host/subdomain, Content-Type, and %PDF- magic bytes.
+
+    It NEVER bypasses a paywall/CAPTCHA, captures/replays cookies or
+    credentials, guesses sibling domains, or touches a shadow library. If the
+    environment does not already have licensed access, this tier simply misses
+    and the ladder falls through. See reference/authorized-publisher-access.md.
+    """
+    doi = meta.get("doi")
+    if not doi:
+        return None
+
+    headers = {"User-Agent": UA.format(email=email)}
+    try:
+        landing = requests.get(
+            f"https://doi.org/{doi}", headers=headers,
+            timeout=30, allow_redirects=True,
+        )
+    except requests.RequestException as e:
+        print(f"  [tier-5b] landing resolve failed: {e}", file=sys.stderr)
+        return None
+    if landing.status_code != 200:
+        print(f"  [tier-5b] landing HTTP {landing.status_code}", file=sys.stderr)
+        return None
+
+    landing_url = landing.url
+    landing_host = urlparse(landing_url).hostname or ""
+
+    # 1) Prefer the Highwire/Scholar citation_pdf_url meta tag.
+    pdf_url: Optional[str] = None
+    if m := re.search(
+        r'<meta[^>]+name=["\']citation_pdf_url["\'][^>]+content=["\']([^"\']+)["\']',
+        landing.text, re.IGNORECASE,
+    ):
+        pdf_url = urljoin(landing_url, m.group(1))
+    elif m := re.search(
+        r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+name=["\']citation_pdf_url["\']',
+        landing.text, re.IGNORECASE,
+    ):
+        pdf_url = urljoin(landing_url, m.group(1))
+
+    # 2) Else: a same-host .pdf anchor on the landing page.
+    if not pdf_url:
+        for href in re.findall(r'href=["\']([^"\']+\.pdf[^"\']*)["\']', landing.text, re.IGNORECASE):
+            cand = urljoin(landing_url, href)
+            if _same_publisher_host(landing_host, urlparse(cand).hostname or ""):
+                pdf_url = cand
+                break
+
+    if not pdf_url:
+        return None
+    if not _same_publisher_host(landing_host, urlparse(pdf_url).hostname or ""):
+        print("  [tier-5b] candidate PDF off official host — rejected", file=sys.stderr)
+        return None
+
+    # Validated download: status 200 + same host + application/pdf + %PDF- bytes.
+    dst = out_dir / "paper.pdf"
+    prov = {
+        "doi": doi,
+        "landing_url": landing_url,
+        "pdf_url": pdf_url,
+        "final_url": None,
+        "http_status": None,
+        "content_type": None,
+        "bytes": None,
+        "host_check": None,
+    }
+    try:
+        with requests.get(pdf_url, headers=headers, stream=True,
+                          timeout=60, allow_redirects=True) as r:
+            prov["http_status"] = r.status_code
+            prov["final_url"] = r.url
+            prov["content_type"] = r.headers.get("content-type", "")
+            if r.status_code != 200:
+                print(f"  [tier-5b] PDF HTTP {r.status_code}", file=sys.stderr)
+                return None
+            final_host = urlparse(r.url).hostname or ""
+            if not _same_publisher_host(landing_host, final_host):
+                print("  [tier-5b] PDF redirected off official host — rejected", file=sys.stderr)
+                return None
+            prov["host_check"] = "same-host" if final_host.lstrip("www.") == landing_host.lstrip("www.") else "subdomain"
+            if not prov["content_type"].lower().startswith("application/pdf"):
+                print("  [tier-5b] not application/pdf — rejected", file=sys.stderr)
+                return None
+            chunks = r.iter_content(chunk_size=65536)
+            first = next(chunks, b"")
+            if not first.startswith(b"%PDF-"):
+                print("  [tier-5b] missing %PDF- magic bytes — rejected", file=sys.stderr)
+                return None
+            total = len(first)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dst.with_suffix(".pdf.part")
+            with open(tmp, "wb") as f:
+                f.write(first)
+                for chunk in chunks:
+                    if chunk:
+                        total += len(chunk)
+                        if total > 200_000_000:
+                            tmp.unlink(missing_ok=True)
+                            return None
+                        f.write(chunk)
+            if total < 1024:
+                tmp.unlink(missing_ok=True)
+                print("  [tier-5b] body too small — rejected", file=sys.stderr)
+                return None
+            tmp.replace(dst)  # atomic promote
+            prov["bytes"] = total
+    except requests.RequestException as e:
+        print(f"  [tier-5b] PDF download failed: {e}", file=sys.stderr)
+        return None
+
+    # Stash provenance for the manifest. No cookies/auth headers are ever stored.
+    meta["_authorized_provenance"] = prov
+    return dst
+
+
 def tier_libgen(meta: dict, out_dir: Path) -> Optional[Path]:
     """Last-resort LibGen lookup. See reference/libgen-fallback.md for design notes."""
     doi = meta.get("doi")
@@ -431,11 +574,13 @@ TIERS = [
     ("europe_pmc", tier_europe_pmc),
     ("core", tier_core),
     ("publisher_extract", tier_publisher_extract),
+    ("authorized_publisher", tier_authorized_publisher),
     ("libgen", tier_libgen),
 ]
 
 
-def fetch_one(identifier: str, out_root: Path, email: str, allow_libgen: bool = True) -> dict:
+def fetch_one(identifier: str, out_root: Path, email: str,
+              allow_libgen: bool = True, allow_institutional: bool = True) -> dict:
     kind, ident = classify(identifier)
     meta = resolve_metadata(kind, ident, email)
     slug = slugify(meta, ident)
@@ -456,6 +601,8 @@ def fetch_one(identifier: str, out_root: Path, email: str, allow_libgen: bool = 
 
     for name, fn in TIERS:
         if name == "libgen" and not allow_libgen:
+            continue
+        if name == "authorized_publisher" and not allow_institutional:
             continue
         sig = fn.__code__.co_varnames[: fn.__code__.co_argcount]
         print(f"  [tier] {name}...", end=" ", flush=True)
@@ -479,6 +626,10 @@ def fetch_one(identifier: str, out_root: Path, email: str, allow_libgen: bool = 
                 "title": meta.get("title"),
                 "ts": int(time.time()),
             }
+            if name == "authorized_publisher":
+                manifest["route"] = "authorized_publisher"
+                if prov := meta.get("_authorized_provenance"):
+                    manifest["provenance"] = prov
             manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
             return manifest
         print("miss")
@@ -504,6 +655,9 @@ def main() -> int:
     p.add_argument("--email", default=DEFAULT_EMAIL,
                    help="email for Unpaywall (use a real address; default from $LINGTAI_RESEARCH_EMAIL)")
     p.add_argument("--no-libgen", action="store_true", help="skip LibGen tier")
+    p.add_argument("--no-institutional", action="store_true",
+                   help="skip the authorized-publisher tier (Tier 5b); use in "
+                        "legal-sensitive or off-network environments")
     p.add_argument("--dry-run", action="store_true", help="resolve metadata only, no PDF fetch")
     args = p.parse_args()
 
@@ -535,7 +689,11 @@ def main() -> int:
     for i, ident in enumerate(identifiers, 1):
         print(f"[{i}/{len(identifiers)}] {ident}")
         try:
-            results.append(fetch_one(ident, out_root, args.email, allow_libgen=not args.no_libgen))
+            results.append(fetch_one(
+                ident, out_root, args.email,
+                allow_libgen=not args.no_libgen,
+                allow_institutional=not args.no_institutional,
+            ))
         except Exception as e:
             print(f"  ERROR: {e}", file=sys.stderr)
             results.append({"status": "error", "reason": str(e), "identifier": ident})

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/scripts/test_authorized_publisher.py
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/scripts/test_authorized_publisher.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Focused tests for the authorized-publisher tier (Tier 5b) in fetch_paper.py.
+
+Self-contained: stubs out the `requests` dependency before import so it runs
+with stdlib only (no network, no pip installs). Run with:
+
+    python3 scripts/test_authorized_publisher.py        # stdlib unittest
+    python3 -m pytest scripts/test_authorized_publisher.py -q   # if pytest present
+
+Covers the cases issue #140 asked for:
+  - citation_pdf_url extraction
+  - same-host / www. alias / subdomain acceptance
+  - sibling/parent-domain rejection
+  - %PDF- magic-byte rejection
+  - Content-Type rejection
+  - successful download promotes only after the file is written
+  - --no-institutional skips the tier
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+# ── Stub `requests` so fetch_paper imports without the real dependency ────────
+class _RequestException(Exception):
+    pass
+
+
+class _Timeout(_RequestException):
+    pass
+
+
+class _ConnectionError(_RequestException):
+    pass
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response, usable as a context manager."""
+
+    def __init__(self, *, status_code=200, url="", headers=None, text="", body=b""):
+        self.status_code = status_code
+        self.url = url
+        self.headers = headers or {}
+        self.text = text
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise _RequestException(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=65536):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i:i + chunk_size]
+
+    def json(self):
+        return {}
+
+
+# Routing table the tests populate per-case: url -> _FakeResponse
+_ROUTES: dict = {}
+
+
+def _fake_get(url, *a, **k):
+    if url in _ROUTES:
+        return _ROUTES[url]
+    # default 404
+    return _FakeResponse(status_code=404, url=url, text="")
+
+
+def _fake_head(url, *a, **k):
+    return _FakeResponse(status_code=404, url=url)
+
+
+_fake_requests = types.ModuleType("requests")
+_fake_requests.get = _fake_get
+_fake_requests.head = _fake_head
+_fake_requests.RequestException = _RequestException
+_fake_requests.Timeout = _Timeout
+_fake_requests.ConnectionError = _ConnectionError
+sys.modules.setdefault("requests", _fake_requests)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import fetch_paper as fp  # noqa: E402
+
+
+PDF_BYTES = b"%PDF-1.7\n" + b"x" * 4096
+HTML_LOGIN = b"<html><body>Please log in</body></html>"
+
+
+def _landing_html(pdf_url: str) -> str:
+    return (
+        '<html><head>'
+        f'<meta name="citation_pdf_url" content="{pdf_url}">'
+        '</head><body>article</body></html>'
+    )
+
+
+class HostCheck(unittest.TestCase):
+    def test_exact_same_host(self):
+        self.assertTrue(fp._same_publisher_host("link.springer.com", "link.springer.com"))
+
+    def test_www_alias_both_directions(self):
+        self.assertTrue(fp._same_publisher_host("link.springer.com", "www.link.springer.com"))
+        self.assertTrue(fp._same_publisher_host("www.link.springer.com", "link.springer.com"))
+
+    def test_subdomain_accepted(self):
+        self.assertTrue(fp._same_publisher_host("link.springer.com", "cdn-pdf.link.springer.com"))
+
+    def test_registrable_parent_rejected(self):
+        self.assertFalse(fp._same_publisher_host("link.springer.com", "springer.com"))
+
+    def test_sibling_domain_rejected(self):
+        self.assertFalse(fp._same_publisher_host("link.springer.com", "springeropen.com"))
+
+    def test_unrelated_host_rejected(self):
+        self.assertFalse(fp._same_publisher_host("link.springer.com", "dl.example-cdn.net"))
+
+    def test_empty_rejected(self):
+        self.assertFalse(fp._same_publisher_host("", "link.springer.com"))
+        self.assertFalse(fp._same_publisher_host("link.springer.com", ""))
+
+
+class TierAuthorizedPublisher(unittest.TestCase):
+    def setUp(self):
+        _ROUTES.clear()
+        self.doi = "10.1007/s11214-020-00743-1"
+        self.landing = "https://link.springer.com/article/" + self.doi
+        self.pdf = "https://link.springer.com/content/pdf/" + self.doi + ".pdf"
+
+    def _route_landing(self, pdf_url):
+        _ROUTES["https://doi.org/" + self.doi] = _FakeResponse(
+            status_code=200, url=self.landing, text=_landing_html(pdf_url))
+
+    def _route_pdf(self, *, url=None, status=200, ctype="application/pdf", body=PDF_BYTES, final_url=None):
+        u = url or self.pdf
+        _ROUTES[u] = _FakeResponse(
+            status_code=status, url=final_url or u,
+            headers={"content-type": ctype}, body=body)
+
+    def test_happy_path_downloads_and_provenance(self):
+        self._route_landing(self.pdf)
+        self._route_pdf()
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            meta = {"doi": self.doi}
+            path = fp.tier_authorized_publisher(meta, "me@example.com", out)
+            self.assertIsNotNone(path)
+            self.assertTrue(path.exists())
+            self.assertEqual(path.read_bytes()[:5], b"%PDF-")
+            prov = meta["_authorized_provenance"]
+            self.assertEqual(prov["http_status"], 200)
+            self.assertEqual(prov["content_type"], "application/pdf")
+            self.assertEqual(prov["bytes"], len(PDF_BYTES))
+            self.assertEqual(prov["landing_url"], self.landing)
+            # no leftover temp file
+            self.assertFalse((out / "paper.pdf.part").exists())
+
+    def test_citation_pdf_url_extraction(self):
+        self._route_landing(self.pdf)
+        self._route_pdf()
+        with TemporaryDirectory() as d:
+            meta = {"doi": self.doi}
+            fp.tier_authorized_publisher(meta, "me@example.com", Path(d))
+            self.assertEqual(meta["_authorized_provenance"]["pdf_url"], self.pdf)
+
+    def test_sibling_domain_pdf_rejected(self):
+        sibling = "https://springeropen.com/content/pdf/x.pdf"
+        self._route_landing(sibling)
+        self._route_pdf(url=sibling)
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", out)
+            self.assertIsNone(path)
+            self.assertFalse((out / "paper.pdf").exists())
+
+    def test_redirect_offsite_rejected(self):
+        # landing offers a same-host pdf URL, but it redirects to a sibling host
+        self._route_landing(self.pdf)
+        self._route_pdf(final_url="https://evil-cdn.net/x.pdf")
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", out)
+            self.assertIsNone(path)
+            self.assertFalse((out / "paper.pdf").exists())
+
+    def test_wrong_content_type_rejected(self):
+        self._route_landing(self.pdf)
+        self._route_pdf(ctype="text/html", body=HTML_LOGIN)
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", out)
+            self.assertIsNone(path)
+            self.assertFalse((out / "paper.pdf").exists())
+
+    def test_missing_magic_bytes_rejected(self):
+        # advertises application/pdf but body is not a PDF
+        self._route_landing(self.pdf)
+        self._route_pdf(body=HTML_LOGIN)
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", out)
+            self.assertIsNone(path)
+            self.assertFalse((out / "paper.pdf").exists())
+
+    def test_subdomain_pdf_accepted(self):
+        sub = "https://cdn-pdf.link.springer.com/x.pdf"
+        self._route_landing(sub)
+        self._route_pdf(url=sub)
+        with TemporaryDirectory() as d:
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", Path(d))
+            self.assertIsNotNone(path)
+
+    def test_no_pdf_link_misses(self):
+        _ROUTES["https://doi.org/" + self.doi] = _FakeResponse(
+            status_code=200, url=self.landing,
+            text="<html><head></head><body>no pdf here</body></html>")
+        with TemporaryDirectory() as d:
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", Path(d))
+            self.assertIsNone(path)
+
+    def test_pdf_403_misses(self):
+        self._route_landing(self.pdf)
+        self._route_pdf(status=403, body=b"")
+        with TemporaryDirectory() as d:
+            out = Path(d)
+            path = fp.tier_authorized_publisher({"doi": self.doi}, "me@example.com", out)
+            self.assertIsNone(path)
+            self.assertFalse((out / "paper.pdf").exists())
+
+    def test_no_doi_misses(self):
+        self.assertIsNone(
+            fp.tier_authorized_publisher({}, "me@example.com", Path(".")))
+
+
+class TierRegistration(unittest.TestCase):
+    def test_tier_registered_before_libgen(self):
+        names = [n for n, _ in fp.TIERS]
+        self.assertIn("authorized_publisher", names)
+        self.assertLess(names.index("authorized_publisher"), names.index("libgen"))
+
+    def test_no_institutional_skips_tier(self):
+        # When allow_institutional=False, fetch_one must not invoke the tier.
+        called = {"hit": False}
+
+        def _spy(meta, email, out_dir):
+            called["hit"] = True
+            return None
+
+        orig = fp.tier_authorized_publisher
+        orig_tiers = fp.TIERS
+        try:
+            fp.tier_authorized_publisher = _spy  # type: ignore
+            fp.TIERS = [("authorized_publisher", _spy)]
+            with TemporaryDirectory() as d:
+                # Stub metadata resolution so no network is hit.
+                _ROUTES.clear()
+                meta = {"doi": "10.1234/x", "title": "t", "authors": ["A B"], "year": 2020}
+                fp.resolve_metadata = lambda *a, **k: meta  # type: ignore
+                fp.fetch_one("10.1234/x", Path(d), "me@example.com",
+                             allow_libgen=False, allow_institutional=False)
+            self.assertFalse(called["hit"], "tier ran despite --no-institutional")
+        finally:
+            fp.tier_authorized_publisher = orig  # type: ignore
+            fp.TIERS = orig_tiers
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Closes #140.

Adds a conservative **authorized institutional publisher PDF** tier (Tier 5b) to the `academic-research` skill, positioned after OA / publisher extraction and before LibGen. The tier is designed for users who already have legitimate institutional/library access in their environment.

## Changes

- Add `tier_authorized_publisher()` in `fetch_paper.py`:
  - resolves DOI to the official publisher landing page;
  - extracts `citation_pdf_url` or same-host `.pdf` anchors;
  - accepts only exact host / `www.` alias / subdomain PDF URLs;
  - validates status, final host, `application/pdf`, `%PDF-` magic bytes, and size before atomic save;
  - records provenance in `manifest.json` with `route: authorized_publisher`.
- Add `--no-institutional` to opt out of the licensed-access probe.
- Add `reference/authorized-publisher-access.md` documenting the workflow, hard boundaries, host rules, manual use, and failure modes.
- Add stdlib-only tests for host validation, download gates, route registration, and the opt-out flag.
- Thread the new tier through `SKILL.md`, `pipeline-obtain-pdf.md`, `decision-tree.md`, and `libgen-fallback.md`; replace the stale 403/Sci-Hub fallback guidance with the licensed tier.

## Safety / policy boundaries

This does **not** bypass paywalls/CAPTCHAs, capture or replay cookies/session tokens, guess EZproxy URLs, or use shadow libraries. It only follows official publisher links that are already accessible from the user's environment and falls through cleanly otherwise.

## Validation

- `python3 -m py_compile scripts/fetch_paper.py scripts/test_authorized_publisher.py`
- `python3 scripts/test_authorized_publisher.py` → 19 tests passed
- Relative Markdown link check → OK
- `git diff --check` → OK
- `go test ./internal/preset/ ./internal/tui/ -run 'SwissKnife|Populate|SkillFiles|Skill'` → OK

## Notes

No live licensed-network smoke test was run in this environment; the logic is fixture-tested. A maintainer with institutional access can optionally smoke-test one DOI before merge.
