### PR TITLE
docs: Graphify repo map doc and HTML explainer (#259)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ lingtai-projects
 .chat_history.json
 _telegram_agent/
 
+# Graphify knowledge-graph output (regenerated locally; see docs/graphify.md)
+graphify-out/
+
 .worktrees
 
 # Local-only files: codex CLI agent guidance, ccusage screenshots

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ This repo carries two Go binaries:
 - **Set up a channel** — `/mcp` inside the TUI, then the addon's own onboarding resource.
 - **Write a skill** — see `tui/internal/preset/skills/lingtai-dev-guide/` after first launch.
 - **Source layout** — start at [`ANATOMY.md`](ANATOMY.md), then descend into `tui/ANATOMY.md` or `portal/ANATOMY.md`.
+- **Navigate by knowledge graph** — generate and query a repo map with Graphify; see [`docs/graphify.md`](docs/graphify.md).
 - **Release process** — [`RELEASING.md`](RELEASING.md).
 - **Contributing** — anatomy-first, worktree-first, with validation in the PR body. See [Contributing](#contributing).
 

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -1,0 +1,153 @@
+# Graphify repo map
+
+This document explains how contributors use [Graphify](https://github.com/) to build a
+knowledge graph of this repository, what the generated artifacts contain, how to
+regenerate them, and which navigation/documentation improvements the latest run
+surfaced.
+
+The graph itself is **not committed**. Output lands in `graphify-out/`, which is
+git-ignored and regenerated locally on demand. This doc plus
+[`reports/graphify-repo-map-20260609.html`](../reports/graphify-repo-map-20260609.html)
+is the curated, checked-in record derived from the run.
+
+## What Graphify is used for here
+
+LingTai is a multi-language, multi-surface codebase (Go TUI + portal, a Python
+runtime, prompt assets, and three README language variants). Graphify gives us a
+single semantic map across all of it so we can:
+
+- See the high-level **community structure** of the codebase as a map instead of a
+  file tree.
+- Find **god nodes** (over-connected symbols) that signal noisy or generic naming.
+- Surface **semantic connections** between docs and concepts that file paths hide
+  (e.g. the three README variants all mapping to the same concept).
+- Identify **weakly connected** docs/code that need stronger cross-links back to
+  core concepts before a larger refactor.
+
+Treat the graph as a navigation aid and a source of *leads*, not facts — inferred
+and ambiguous edges must be verified against source files before being used as
+design evidence.
+
+## Latest run summary
+
+From the local run captured in issue
+[#259](https://github.com/Lingtai-AI/lingtai/issues/259):
+
+| Metric | Value |
+| --- | --- |
+| Supported files in corpus | 490 |
+| Approx. words | 563,347 |
+| Graph nodes | 6,588 |
+| Graph edges | 9,908 |
+| Communities | 365 |
+| Edge extraction mix | 87% extracted / 13% inferred |
+| HTML view | aggregated community view (graph is above the 5,000-node threshold) |
+
+Outputs from that run:
+
+- `graphify-out/graph.html` — interactive community map.
+- `graphify-out/GRAPH_REPORT.md` — god nodes, surprising connections, suggested
+  questions.
+- `graphify-out/graph.json` — raw graph for tooling.
+
+## How to regenerate
+
+For agent-assisted use inside Codex/Claude-style environments:
+
+```bash
+/graphify .
+```
+
+For headless CLI use, semantic extraction needs an LLM backend when docs, papers,
+or images are included:
+
+```bash
+export GEMINI_API_KEY=...
+graphify extract . --backend gemini
+```
+
+Useful follow-up commands once the graph exists:
+
+```bash
+graphify query "Why does contains() connect so many code and test nodes?"
+graphify explain "Preset"
+graphify path "Agent Operating System" "Filesystem-only IPC"
+graphify export html
+```
+
+### Recommended workflow
+
+1. Generate the graph locally with `/graphify .` or
+   `graphify extract . --backend gemini`.
+2. Open `graphify-out/graph.html` for the high-level community map.
+3. Read `graphify-out/GRAPH_REPORT.md` for god nodes, surprising connections, and
+   suggested questions.
+4. Use `graphify query`, `graphify explain`, and `graphify path` to investigate
+   architecture questions *before* making broad changes.
+5. Treat inferred and ambiguous edges as leads, not facts, and verify them against
+   source files before using them as design evidence.
+
+## Findings from the latest graph
+
+### Top hub nodes
+
+| Node | Edges |
+| --- | --- |
+| `contains()` | 92 |
+| `Preset` | 71 |
+| `FirstRunModel` | 57 |
+| `PresetEditorModel` | 55 |
+| `App` | 48 |
+
+`Preset`, `FirstRunModel`, `PresetEditorModel`, and `App` are genuine architectural
+hubs. `contains()` is a **generic / noisy hub** — see below.
+
+### Interesting semantic connections
+
+- `Network Intelligence` is semantically similar to `AI Organization Substrate`.
+- `Agent Operating System` is semantically similar to `AI Organization Substrate`.
+- `Email Not Talk Decision` is semantically similar to `Filesystem-only IPC`.
+- The English, Chinese, and classical-Chinese README variants all map back to the
+  same AI-organization concept.
+
+### Noisy / generic hubs to review
+
+The graph flags several generic high-degree nodes whose labels are not
+package-qualified enough to be useful for navigation:
+
+`contains()`, `Delete()`, `Path`, `T`, `main()`.
+
+These are candidates for better package-qualified labels, exclude rules, or
+naming conventions in future Graphify runs.
+
+## Actionable navigation & documentation improvements
+
+These are the concrete, low-risk follow-ups the graph suggests. They are tracked
+against issue #259's acceptance criteria; this PR completes the documentation
+items and records the analysis for the rest.
+
+1. **Cross-link the architecture docs.** The strongest semantic clusters all orbit
+   the AI-organization concept. The major architecture docs are:
+   - [`ANATOMY.md`](../ANATOMY.md) — source-grounded repo map.
+   - [`docs/design.md`](./design.md) — core design.
+   - [`docs/design-molt-and-network-intelligence.md`](./design-molt-and-network-intelligence.md)
+     — molt + network intelligence.
+   - Surface anatomy: [`tui/ANATOMY.md`](../tui/ANATOMY.md),
+     [`portal/ANATOMY.md`](../portal/ANATOMY.md).
+
+2. **Strengthen weakly connected docs.** Use the graph's weakly-connected-node list
+   to find docs or code areas that need stronger cross-links back to the core
+   concepts: `Preset`, `Filesystem-only IPC`, `Agent Operating System`, and
+   `AI Organization Substrate`.
+
+3. **Clean up noisy hubs (future Graphify run).** Review `contains()`, `Delete()`,
+   `Path`, `T`, and `main()` for package-qualified labels, exclude rules, or
+   naming conventions so the graph navigates better.
+
+4. **Maintainer refresh workflow.** Regenerate the graph before larger architecture
+   changes or releases (see *How to regenerate*). This stays manual for now; CI can
+   come later if the generated artifacts prove useful enough.
+
+5. **Artifact policy.** Keep `graphify-out/` generated locally and git-ignored
+   (already configured in `.gitignore`). Commit only curated docs derived from the
+   report — this file and the HTML explainer under `reports/`.

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -1,7 +1,7 @@
 # Graphify repo map
 
-This document explains how contributors use [Graphify](https://github.com/) to build a
-knowledge graph of this repository, what the generated artifacts contain, how to
+This document explains how contributors use Graphify to build a knowledge graph
+of this repository, what the generated artifacts contain, how to
 regenerate them, and which navigation/documentation improvements the latest run
 surfaced.
 

--- a/reports/graphify-repo-map-20260609.html
+++ b/reports/graphify-repo-map-20260609.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LingTai Graphify repo map — explainer</title>
+<style>
+body{font:15px/1.55 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:#0b1020;color:#eef3ff}
+main{max-width:1180px;margin:0 auto;padding:32px 24px 80px}
+section{background:#121a33;border:1px solid #28345f;border-radius:14px;padding:18px;margin:18px 0}
+h1{margin-top:0;font-size:32px} h2{color:#dbeafe} h3{color:#bcd4ff;margin-bottom:6px}
+code{color:#b3ecff} pre{white-space:pre-wrap;word-break:break-word;background:#071021;border:1px solid #28345f;border-radius:10px;padding:14px;overflow:auto}
+.badge{display:inline-block;border:1px solid #28345f;border-radius:999px;padding:4px 9px;background:#16213f;color:#cce9ff;margin-right:8px;margin-bottom:6px}
+.callout{border-left:4px solid #80d8ff;padding-left:14px;color:#dff7ff}
+table{border-collapse:collapse;width:100%;margin-top:8px}
+th,td{border:1px solid #28345f;padding:7px 10px;text-align:left}
+th{background:#16213f;color:#cce9ff}
+a{color:#9fd0ff}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px}
+.stat{background:#071021;border:1px solid #28345f;border-radius:10px;padding:14px;text-align:center}
+.stat .n{font-size:26px;color:#9fe3ff;font-weight:700} .stat .l{color:#a9bbe6;font-size:12px}
+.tag-ok{color:#7dab8f} .tag-noise{color:#e6a96b}
+footer{color:#6f7fb0;font-size:12px;margin-top:24px}
+</style></head><body><main>
+
+<h1>LingTai Graphify repo map</h1>
+<p>
+  <span class="badge">docs-only</span>
+  <span class="badge">issue #259</span>
+  <span class="badge">self-contained explainer</span>
+  <span class="badge">artifacts regenerated locally</span>
+</p>
+<p class="callout">
+  A knowledge graph of this repository was generated with <strong>Graphify</strong>
+  to make the codebase easier to navigate and to spot where the architecture/docs
+  graph is noisy or under-connected. The graph itself is <strong>not committed</strong>;
+  it lives in the git-ignored <code>graphify-out/</code> and is regenerated on demand.
+  This page and <code>docs/graphify.md</code> are the curated, checked-in record.
+</p>
+
+<section>
+  <h2>Run at a glance</h2>
+  <div class="grid">
+    <div class="stat"><div class="n">490</div><div class="l">supported files</div></div>
+    <div class="stat"><div class="n">563,347</div><div class="l">words</div></div>
+    <div class="stat"><div class="n">6,588</div><div class="l">nodes</div></div>
+    <div class="stat"><div class="n">9,908</div><div class="l">edges</div></div>
+    <div class="stat"><div class="n">365</div><div class="l">communities</div></div>
+    <div class="stat"><div class="n">87% / 13%</div><div class="l">extracted / inferred edges</div></div>
+  </div>
+  <p>Because the graph is above the 5,000-node threshold, the HTML view Graphify
+     produces is an <strong>aggregated community view</strong> rather than a full
+     node graph.</p>
+</section>
+
+<section>
+  <h2>Artifacts</h2>
+  <table>
+    <tr><th>File</th><th>What it holds</th></tr>
+    <tr><td><code>graphify-out/graph.html</code></td><td>Interactive community map.</td></tr>
+    <tr><td><code>graphify-out/GRAPH_REPORT.md</code></td><td>God nodes, surprising connections, suggested questions.</td></tr>
+    <tr><td><code>graphify-out/graph.json</code></td><td>Raw graph for tooling.</td></tr>
+  </table>
+  <p class="callout">Policy: keep <code>graphify-out/</code> generated locally and
+     git-ignored. Commit only curated docs derived from the report.</p>
+</section>
+
+<section>
+  <h2>How to regenerate</h2>
+  <h3>Agent-assisted (Codex / Claude-style)</h3>
+  <pre>/graphify .</pre>
+  <h3>Headless CLI (needs an LLM backend for docs/papers/images)</h3>
+  <pre>export GEMINI_API_KEY=...
+graphify extract . --backend gemini</pre>
+  <h3>Useful follow-ups</h3>
+  <pre>graphify query "Why does contains() connect so many code and test nodes?"
+graphify explain "Preset"
+graphify path "Agent Operating System" "Filesystem-only IPC"
+graphify export html</pre>
+  <h3>Recommended workflow</h3>
+  <ol>
+    <li>Generate the graph with <code>/graphify .</code> or
+        <code>graphify extract . --backend gemini</code>.</li>
+    <li>Open <code>graphify-out/graph.html</code> for the high-level community map.</li>
+    <li>Read <code>graphify-out/GRAPH_REPORT.md</code> for god nodes and leads.</li>
+    <li>Use <code>query</code> / <code>explain</code> / <code>path</code> to
+        investigate architecture questions <em>before</em> broad changes.</li>
+    <li>Verify inferred and ambiguous edges against source files before treating
+        them as design evidence.</li>
+  </ol>
+</section>
+
+<section>
+  <h2>Findings</h2>
+  <h3>Top hub nodes</h3>
+  <table>
+    <tr><th>Node</th><th>Edges</th><th>Read as</th></tr>
+    <tr><td><code>contains()</code></td><td>92</td><td class="tag-noise">generic / noisy hub</td></tr>
+    <tr><td><code>Preset</code></td><td>71</td><td class="tag-ok">genuine architecture hub</td></tr>
+    <tr><td><code>FirstRunModel</code></td><td>57</td><td class="tag-ok">genuine architecture hub</td></tr>
+    <tr><td><code>PresetEditorModel</code></td><td>55</td><td class="tag-ok">genuine architecture hub</td></tr>
+    <tr><td><code>App</code></td><td>48</td><td class="tag-ok">genuine architecture hub</td></tr>
+  </table>
+
+  <h3>Interesting semantic connections</h3>
+  <ul>
+    <li><code>Network Intelligence</code> ≈ <code>AI Organization Substrate</code>.</li>
+    <li><code>Agent Operating System</code> ≈ <code>AI Organization Substrate</code>.</li>
+    <li><code>Email Not Talk Decision</code> ≈ <code>Filesystem-only IPC</code>.</li>
+    <li>English, Chinese, and classical-Chinese README variants all map back to the
+        same AI-organization concept.</li>
+  </ul>
+
+  <h3>Noisy / generic hubs to review</h3>
+  <p>Not package-qualified enough to navigate by — candidates for better labels,
+     exclude rules, or naming conventions in future runs:</p>
+  <p><code>contains()</code>, <code>Delete()</code>, <code>Path</code>,
+     <code>T</code>, <code>main()</code></p>
+</section>
+
+<section>
+  <h2>Actionable improvements</h2>
+  <ol>
+    <li><strong>Cross-link architecture docs</strong> — <code>ANATOMY.md</code>,
+        <code>docs/design.md</code>,
+        <code>docs/design-molt-and-network-intelligence.md</code>, plus
+        <code>tui/ANATOMY.md</code> and <code>portal/ANATOMY.md</code>.</li>
+    <li><strong>Strengthen weakly connected docs</strong> back to core concepts:
+        <code>Preset</code>, <code>Filesystem-only IPC</code>,
+        <code>Agent Operating System</code>, <code>AI Organization Substrate</code>.</li>
+    <li><strong>Clean up noisy hubs</strong> in a future Graphify run (labels /
+        exclude rules / naming).</li>
+    <li><strong>Maintainer refresh workflow</strong> — regenerate before larger
+        architecture changes or releases; manual for now, CI later if useful.</li>
+    <li><strong>Artifact policy</strong> — keep <code>graphify-out/</code>
+        local + ignored; commit only curated docs.</li>
+  </ol>
+</section>
+
+<footer>
+  Generated for issue #259 · branch <code>docs/issue-259-graphify-repo-map-20260609</code> ·
+  See <code>docs/graphify.md</code> for the maintainable Markdown version.
+</footer>
+
+</main></body></html>


### PR DESCRIPTION
## Summary

Documents the Graphify knowledge-graph repo map for this repository (issue #259) and captures the latest run's navigation/documentation insights as a maintainable, curated record. **Docs-only, low-risk.**

- **`docs/graphify.md`** — what Graphify is used for here, the latest run summary (490 files, ~563,347 words, 6,588 nodes, 9,908 edges, 365 communities, 87% extracted / 13% inferred edges), how to regenerate (`/graphify .` or `graphify extract . --backend gemini`), follow-up query commands, findings (top hubs, semantic connections, noisy hubs), and actionable cross-link/cleanup follow-ups.
- **`reports/graphify-repo-map-20260609.html`** — self-contained dark-theme explainer matching the existing `reports/` style.
- **`README.md`** — one bullet added under *Docs by goal* linking `docs/graphify.md`.
- **`.gitignore`** — ignore generated `graphify-out/` so large artifacts stay local.

Large Graphify output files (`graph.html`, `graph.json`, `GRAPH_REPORT.md`) are intentionally **not committed**; only curated docs derived from the report are checked in.

## Acceptance criteria status

- [x] Contributor-facing docs for running Graphify on this repo
- [x] Document the key graph artifacts and query commands
- [x] Decide whether `graphify-out/` should remain ignored/generated → ignored; curated docs checked in
- [~] Architecture cross-links — the recommended cross-links are documented in `docs/graphify.md`; inline edits to each architecture doc are left as a tracked follow-up to keep this PR docs-only and low-risk
- [~] Noisy graph hubs — reviewed and documented (`contains()`, `Delete()`, `Path`, `T`, `main()`); the actual label/exclude-rule changes belong to a future Graphify run

Because two criteria are documented/decided rather than fully actioned, this PR does **not** auto-close the issue.

## Validation

- `git diff --check` — passed (no whitespace/conflict errors)
- 4 files changed, 300 insertions(+); both new files ~8 KB
- All relative links in `docs/graphify.md` resolve (ANATOMY.md, docs/design.md, design-molt-and-network-intelligence.md, tui/ANATOMY.md, portal/ANATOMY.md, reports HTML)
- README link target `docs/graphify.md` exists
- HTML tag balance checked (section/table/ol/ul all balanced)

## Caveats

- Refs #259 (does not close — see criteria status above).
- Graphify metrics are reproduced from the issue's local run, not re-generated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)