### PR TITLE
Add swiss-knife preset-health subskill (read-only)

### DIFF
--- a/reports/issue194-preset-health-skill-explainer.html
+++ b/reports/issue194-preset-health-skill-explainer.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Issue #194 — Swiss-knife preset health-check subskill</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.55; margin: 2rem auto; max-width: 920px; padding: 0 1rem; color: #172033; }
+    h1, h2 { line-height: 1.2; }
+    .summary { background: #eef7ff; border-left: 4px solid #2b7cff; padding: 1rem; border-radius: 8px; }
+    .warn { background: #fff7e6; border-left: 4px solid #e08600; padding: 1rem; border-radius: 8px; }
+    code { background: #f3f5f7; padding: 0.1rem 0.25rem; border-radius: 4px; }
+    table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+    th, td { border: 1px solid #d8dee9; padding: 0.5rem; text-align: left; vertical-align: top; }
+    th { background: #f6f8fa; }
+    .ok { color: #137333; font-weight: 600; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.95em; }
+  </style>
+</head>
+<body>
+  <h1>Issue #194 — Swiss-knife preset health-check subskill</h1>
+  <div class="summary">
+    <strong>Conclusion:</strong> this change adds a documentation-only, <strong>read-only</strong> swiss-knife
+    nested reference, <code>preset-health</code>, that gives agents a repeatable procedure to enumerate
+    saved presets, classify each failure, and report actionable fixes <strong>without printing or mutating
+    any secret</strong>. The swiss-knife router catalog and routing table are updated so the new reference is
+    discoverable, and the embedded-skill extraction test is extended to cover the new file.
+  </div>
+
+  <h2>Why this was needed</h2>
+  <p>
+    Agents could call <code>system(action="presets")</code> and eyeball connectivity statuses, but there was
+    no documented, repeatable workflow for checking <em>all</em> saved presets, classifying failures
+    (expired key, missing credentials, unreachable endpoint, invalid model/config, connectivity failure),
+    and reporting them safely. The triggering case: <code>gemini-test.json</code> reported
+    <code>connectivity.status = no_credentials</code> with <code>GEMINI_API_KEY not set</code>, and a separate
+    preset was expired — both required ad-hoc manual interpretation.
+  </p>
+
+  <h2>What changed</h2>
+  <table>
+    <thead><tr><th>File</th><th>Change</th></tr></thead>
+    <tbody>
+      <tr><td class="mono">tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md</td><td>New nested reference: read-only enumerate → check credential presence → probe via <code>/doctor</code> → classify → redacted report → human-confirmed remediation.</td></tr>
+      <tr><td class="mono">tui/internal/preset/skills/swiss-knife/SKILL.md</td><td>Router updated: added <code>preset-health</code> to the description, the <code>nested_references</code> YAML block, and the routing table. Bumped version 2.2.0 → 2.3.0.</td></tr>
+      <tr><td class="mono">tui/internal/preset/swiss_knife_populate_test.go</td><td>Added <code>reference/preset-health/SKILL.md</code> to the embedded-extraction assertion so the new file is verified to ship.</td></tr>
+      <tr><td class="mono">reports/issue194-preset-health-skill-explainer.html</td><td>This self-contained explainer.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>The classification taxonomy</h2>
+  <p>The skill maps each preset to a fixed set of classes, grounded in the connectivity outcomes the TUI's
+  <code>/doctor</code> probe already distinguishes (<code>probeOK</code>, <code>probeAuthError</code>,
+  <code>probeNoKey</code>, <code>probeNetworkError</code>, <code>probeRateLimit</code>,
+  <code>probeOverloaded</code>, <code>probeEmptyResponse</code>, <code>probeOAuth</code>):</p>
+  <table>
+    <thead><tr><th>Class</th><th>Trigger</th></tr></thead>
+    <tbody>
+      <tr><td><code>ok</code></td><td>reachable, authed, valid model</td></tr>
+      <tr><td><code>no_credentials</code></td><td><code>api_key_env</code> declared but the variable is empty/unset</td></tr>
+      <tr><td><code>auth_failed</code> / <code>expired_key</code></td><td>credential present but rejected (401/403)</td></tr>
+      <tr><td><code>endpoint_unreachable</code></td><td>DNS/connect/TLS/timeout to <code>base_url</code></td></tr>
+      <tr><td><code>model_not_found</code></td><td>auth ok but model rejected/unknown</td></tr>
+      <tr><td><code>config_error</code></td><td>malformed JSON, missing <code>provider</code>/<code>model</code>, invalid <code>base_url</code></td></tr>
+      <tr><td><code>rate_limited</code></td><td>reachable + authed but throttled (transient — retry)</td></tr>
+      <tr><td><code>connectivity_failure</code></td><td>reachable but empty/invalid response envelope</td></tr>
+      <tr><td><code>unknown</code></td><td>none of the above</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Secret safety</h2>
+  <div class="warn">
+    <strong>No secrets, ever.</strong> The skill checks credential <em>presence</em> only (set vs not-set), never
+    value; refers to credentials by env-var <em>name</em> (e.g. <code>GEMINI_API_KEY</code>); and ships a redactor
+    that strips bearer tokens, key-like strings, and URL query parameters from any raw error text before it lands
+    in a report.
+  </div>
+
+  <h2>Read-only contract</h2>
+  <p>
+    The reference never edits <code>~/.lingtai-tui/presets/saved/*.json</code>, agent <code>init.json</code>, or any
+    <code>manifest.preset.allowed</code> list, and it does not switch the active preset to probe an inactive one.
+    Remediation (set an env var, rotate an expired key, remove a preset from an agent's allowed list, update a
+    retired model) is presented as a human-confirmed recommendation — the workflow stops at the report.
+  </p>
+
+  <h2>Risk assessment</h2>
+  <p><span class="ok">Low risk.</span> The change is documentation/skill-workflow plus one test-assertion line and a
+  router catalog edit. No runtime Go logic, build scripts, or dependency manifests are touched. No script is added,
+  so there is no executable surface to audit beyond the read-only shell snippets embedded in the SKILL.md.</p>
+
+  <h2>Validation</h2>
+  <ul>
+    <li><code>go test ./internal/preset/ -run SwissKnife</code> — the extended extraction test passes, confirming the new reference ships in the embedded bundle.</li>
+    <li>Router cross-reference: <code>swiss-knife/SKILL.md</code> mentions <code>preset-health</code> in its description, <code>nested_references</code> block, and routing table.</li>
+    <li><code>git diff --check</code> — no whitespace errors.</li>
+  </ul>
+</body>
+</html>

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -12,10 +12,12 @@ description: >
   browser deliverables; xiaomi-mimo for Xiaomi MiMo provider discovery;
   zhipu-coding-plan for Z.AI / BigModel coding-plan capabilities; headless-bot
   for provisioning fresh LingTai bot projects such as Telegram bots from
-  `lingtai-tui spawn`; find-something-to-do for idle curiosity practice. This
+  `lingtai-tui spawn`; find-something-to-do for idle curiosity practice;
+  preset-health for read-only health checks of saved presets (classify expired
+  keys, missing credentials, unreachable endpoints, invalid model/config). This
   parent is the route map; each nested reference is self-contained under
   `reference/<name>/SKILL.md`.
-version: 2.2.0
+version: 2.3.0
 tags: [utilities, umbrella, toolkit, nested-skill]
 ---
 
@@ -119,6 +121,16 @@ nested_references:
       Nested swiss-knife reference for idle curiosity practice. Read this when
       you have no pending task, no human waiting, and want a reflective way to
       notice quiet impulses or choose a small autonomous exploration.
+  - name: preset-health
+    location: reference/preset-health/SKILL.md
+    description: >
+      Nested swiss-knife reference for read-only saved-preset health checks.
+      Read this when the human asks whether saved presets still work, which one
+      is expired or misconfigured, or why `system(action="presets")` shows a bad
+      connectivity status. It enumerates saved presets, classifies failures
+      (expired key, missing credentials, unreachable endpoint, invalid
+      model/config, connectivity failure), and reports actionable fixes without
+      printing or mutating any secret.
 ```
 
 ## Routing table
@@ -139,6 +151,7 @@ nested_references:
 | Discover/configure Zhipu / Z.AI coding-plan capabilities | `reference/zhipu-coding-plan/SKILL.md` |
 | Create or automate a headless LingTai bot project, including Telegram bots | `reference/headless-bot/SKILL.md` |
 | Practice idle curiosity when there is no pending task or human waiting | `reference/find-something-to-do/SKILL.md` |
+| Health-check saved presets (read-only): classify expired keys, missing credentials, unreachable endpoints, invalid model/config | `reference/preset-health/SKILL.md` |
 
 ## How to use this router
 

--- a/tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: preset-health
+description: >
+  Nested swiss-knife reference for saved-preset health checks. Read this when
+  the human asks whether saved presets still work, which preset is expired or
+  misconfigured, why `system(action="presets")` shows a bad connectivity
+  status, or for a safe procedure to enumerate saved presets, classify each
+  failure (expired key, missing credentials, unreachable endpoint, invalid
+  model/config, connectivity failure), and report results without leaking
+  secrets. This is a READ-ONLY diagnostic workflow: it never edits a preset or
+  an agent `init.json` on its own — it produces an actionable report and tells
+  the human exactly which one-line change to confirm.
+version: 1.0.0
+tags: [presets, health-check, diagnostics, read-only, connectivity]
+---
+
+# Preset Health Check (read-only)
+
+A repeatable, read-only procedure for testing whether saved presets are healthy,
+classifying any failures, and producing an actionable report — without printing
+or mutating credentials.
+
+> **Read-only contract.** This reference enumerates, probes, and reports. It does
+> **not** edit `~/.lingtai-tui/presets/saved/*.json`, agent `init.json`, or any
+> `manifest.preset.allowed` list. Remediation is described as a recommendation
+> for the human to confirm and apply (or to explicitly authorize you to apply
+> through the normal preset tooling). Never run a "fix" step automatically.
+
+## When to use
+
+- The human asks "are my presets still working?" or "which preset is broken?"
+- `system(action="presets")` surfaced a non-`ok` connectivity status (for
+  example `no_credentials`, an auth failure, or an unreachable endpoint).
+- A provider rotated keys, retired a model, or moved an endpoint and you need to
+  find every saved preset affected.
+- A new agent needs a clear procedure to triage presets before relying on them.
+
+## Where saved presets live
+
+Saved (user-owned) presets are JSON files here:
+
+```
+~/.lingtai-tui/presets/saved/*.json
+```
+
+Built-in templates live under `~/.lingtai-tui/presets/templates/` and are
+rewritten on every `lingtai-tui bootstrap` — the directory itself is the marker
+distinguishing built-in from user-owned, so a health check focuses on
+`saved/`. The skill tree this reference ships in is extracted to
+`~/.lingtai-tui/utilities/swiss-knife/reference/preset-health/SKILL.md`.
+
+Each preset's relevant shape (other fields omitted):
+
+```json
+{
+  "manifest": {
+    "llm": {
+      "provider": "gemini",
+      "model": "gemini-2.0-flash",
+      "base_url": "https://...",
+      "api_key_env": "GEMINI_API_KEY"
+    }
+  }
+}
+```
+
+The credential is referenced indirectly through `api_key_env` (an environment
+variable **name**), not stored inline. That indirection is what lets a health
+check report "credential missing" without ever reading the secret value.
+
+## Step 1 — Enumerate saved presets
+
+Prefer the structured listing the runtime already exposes:
+
+```bash
+lingtai-tui presets --saved --json
+```
+
+This emits one entry per preset (`name`, `description`, `source`, `path`). If the
+CLI is unavailable, list the directory directly (read-only):
+
+```bash
+ls -1 ~/.lingtai-tui/presets/saved/*.json 2>/dev/null
+```
+
+For each preset, read only the non-secret config fields you need to classify it:
+`manifest.llm.provider`, `manifest.llm.model`, `manifest.llm.base_url`, and the
+**name** `manifest.llm.api_key_env`. Do not read or echo the value of the env
+var named by `api_key_env`.
+
+## Step 2 — Check credential presence (no secret values)
+
+A preset that declares `api_key_env` needs that variable set in the agent's
+resolved environment. Check **presence only**:
+
+```bash
+# Reports set / not-set WITHOUT revealing the value.
+env_name="GEMINI_API_KEY"
+if [ -n "${!env_name+x}" ] && [ -n "${!env_name}" ]; then
+  echo "$env_name: set"
+else
+  echo "$env_name: NOT set"
+fi
+```
+
+The runtime resolves credentials the same way internally: a preset with a
+non-empty `api_key_env` is considered to have a usable credential only when that
+variable is non-empty (Codex is the documented exception — it authenticates via
+ChatGPT OAuth and declares no `api_key_env`). A "not set" result maps to the
+`no_credentials` class below — this is exactly the case the issue saw with
+`gemini-test.json` reporting `GEMINI_API_KEY not set in environment`.
+
+## Step 3 — Probe connectivity (read-only)
+
+Reuse the live check the TUI already performs rather than inventing a new probe.
+`/doctor` runs the canonical LLM connectivity probe against the **active** agent's
+configuration; run it (or read the most recent doctor output) to see the real
+state. The doctor probe distinguishes these outcomes, which are the source of
+truth for classification:
+
+| Doctor probe outcome | Meaning |
+|---|---|
+| ok | endpoint reachable, auth accepted, response envelope non-empty |
+| auth error | endpoint reachable but credential rejected (401/403, expired/invalid key) |
+| no key | no credential configured for a preset that needs one |
+| oauth | OAuth-style auth pending/needed (e.g. Codex) |
+| network error | endpoint unreachable (DNS/connect/TLS/timeout) |
+| rate limit / overloaded | reachable and authed, transiently throttled |
+| empty response | endpoint replied but with an empty/invalid envelope (often a proxy) |
+
+To probe a **saved preset that is not the active one** without mutating
+anything, do not edit the agent to switch presets. Instead report what static
+inspection (Steps 1–2) shows, and recommend the human refresh onto that preset
+in a throwaway/dev agent if a live probe is required. Switching the active
+preset is a configuration change and is out of scope for this read-only skill.
+
+## Step 4 — Classify each preset
+
+Map findings to a fixed taxonomy so reports are consistent:
+
+| Class | Trigger | Typical doctor outcome |
+|---|---|---|
+| `ok` | reachable, authed, valid model | ok |
+| `no_credentials` | `api_key_env` set but variable empty/unset | no key |
+| `auth_failed` / `expired_key` | credential present but rejected (401/403) | auth error |
+| `endpoint_unreachable` | DNS/connect/TLS/timeout to `base_url` | network error |
+| `model_not_found` | auth ok but model rejected/unknown (404 model, "model not found") | auth error/unknown w/ model detail |
+| `config_error` | malformed preset JSON, missing `provider`/`model`, invalid `base_url` | varies (often unknown/empty) |
+| `rate_limited` | reachable + authed but throttled (transient) | rate limit / overloaded |
+| `connectivity_failure` | reachable but empty/invalid response envelope | empty response |
+| `unknown` | none of the above | default/unknown |
+
+Notes:
+- `model_not_found` vs `auth_failed`: read the error **detail** — an
+  authentication message points to credentials; a "model" message points to the
+  `model` field. When the provider conflates them, report both as candidates.
+- `config_error` is a static finding (bad JSON, empty `provider`/`model`, a
+  `base_url` that is not a valid URL) and needs no network call. The runtime's
+  own validation requires a non-empty `summary`, a `tier` in 1..5, and non-empty
+  `llm.provider`/`llm.model`; a preset failing those is `config_error`.
+- A transient class (`rate_limited`) should be retried before being reported as a
+  hard failure.
+
+## Step 5 — Report safely (no secrets)
+
+Produce a concise table. Columns: preset name, provider/model, status class,
+short error summary, recommended fix.
+
+**Redaction rules (mandatory):**
+- Never print API key values, tokens, or full `Authorization` headers.
+- Refer to credentials by env-var **name** only (`GEMINI_API_KEY`), never value.
+- If a raw error body might embed a key or signed URL, redact it: keep the
+  status code and the human-readable message, drop query strings and bearer
+  tokens. A safe redactor for ad-hoc error text:
+
+  ```bash
+  # Redact bearer tokens, sk-/key-like strings, and URL query strings.
+  redact() {
+    sed -E \
+      -e 's/(Bearer )[A-Za-z0-9._-]+/\1[REDACTED]/g' \
+      -e 's/\b(sk|key|tok)[-_][A-Za-z0-9]{6,}/[REDACTED]/g' \
+      -e 's/([?&](api[_-]?key|token|key|sig)=)[^&[:space:]]+/\1[REDACTED]/gi'
+  }
+  ```
+
+Example report shape (illustrative values):
+
+| Preset | Provider / model | Status | Error summary | Recommended fix |
+|---|---|---|---|---|
+| `gemini-test` | gemini / gemini-2.0-flash | `no_credentials` | `GEMINI_API_KEY not set` | Set `GEMINI_API_KEY` in the agent env, then refresh |
+| `minimax_cn` | minimax / abab6.5 | `auth_failed` | `401 invalid api key` | Replace expired `MINIMAX_API_KEY`, or remove preset from this agent's allowed list |
+| `kimi` | moonshot / kimi-k2 | `ok` | — | none |
+
+## Step 6 — Remediation guidance (recommend, do not apply)
+
+State the smallest change and let the human confirm it. Common fixes:
+
+- **`no_credentials`** — set the env var named by `api_key_env` in the agent's
+  environment (or `env_file`), then `system(action="refresh")` so the agent
+  re-resolves config.
+- **`auth_failed` / `expired_key`** — rotate the credential (ask the human for a
+  replacement key) and refresh. If the preset is simply no longer wanted on this
+  agent, recommend removing it from `manifest.preset.allowed` — flag that this is
+  a config edit requiring explicit human confirmation before anyone applies it.
+- **`endpoint_unreachable`** — verify `base_url`, network/DNS, and provider
+  status; do not change the URL speculatively.
+- **`model_not_found`** — update `manifest.llm.model` to a currently-served model
+  for that provider (human-confirmed).
+- **`config_error`** — fix the malformed field; re-validate.
+
+Every one of these is a recommendation. This skill stops at the report — it does
+not write to any preset or `init.json`.
+
+## Read-only checklist
+
+- [ ] Listed presets via `presets --json` or a directory read — no writes.
+- [ ] Checked credential **presence**, never value.
+- [ ] Used `/doctor`'s existing probe for live state; did not switch the active
+      preset to probe another one.
+- [ ] Classified each preset against the fixed taxonomy.
+- [ ] Redacted all secrets and key-bearing URLs in the report.
+- [ ] Presented remediation as human-confirmed recommendations only.
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load
+> the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -45,6 +45,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/xiaomi-mimo/SKILL.md",
 		"reference/zhipu-coding-plan/SKILL.md",
 		"reference/find-something-to-do/SKILL.md",
+		"reference/preset-health/SKILL.md",
 	} {
 		if _, err := os.Stat(filepath.Join(utilitiesDir, rel)); err != nil {
 			t.Fatalf("expected bundled swiss-knife file %s to be extracted: %v", rel, err)


### PR DESCRIPTION
## Summary

Adds a **read-only** swiss-knife nested reference, `preset-health`, that gives agents a repeatable workflow to test whether saved presets are healthy — addressing #194, where an agent had to inspect `system(action="presets")` connectivity statuses by hand (e.g. `gemini-test.json` → `no_credentials`, and a separately-expired preset) with no portable procedure.

The reference documents how to:
- **Enumerate** saved presets under `~/.lingtai-tui/presets/saved/` (via `lingtai-tui presets --saved --json` or a directory read).
- **Check credential presence** by env-var *name* only — never the value.
- **Probe connectivity** by reusing the TUI's existing `/doctor` LLM probe rather than inventing a new one.
- **Classify** each preset: `ok`, `no_credentials`, `auth_failed`/`expired_key`, `endpoint_unreachable`, `model_not_found`, `config_error`, `rate_limited`, `connectivity_failure`, `unknown`.
- **Report safely**, with a redactor that strips bearer tokens, key-like strings, and URL query params.
- **Recommend remediation** for the human to confirm — the skill never edits a preset or agent `init.json`, never switches the active preset, and never prints a secret.

No script is added (doc-only); the only executable surface is read-only shell snippets inside the SKILL.md.

### Files changed
- `tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md` — new nested reference.
- `tui/internal/preset/skills/swiss-knife/SKILL.md` — router updated (description, `nested_references` block, routing table; version 2.2.0 → 2.3.0) so the reference is discoverable.
- `tui/internal/preset/swiss_knife_populate_test.go` — assert the new file ships in the embedded bundle.
- `reports/issue194-preset-health-skill-explainer.html` — self-contained explainer.

## Validation
- `go test ./internal/preset/` — passes (includes the extended `TestPopulateBundledLibrary_SwissKnifeNestedReferences`, verifying the new reference extracts to disk).
- `go vet ./internal/preset/` — clean.
- Router cross-reference: `preset-health` appears in the description, `nested_references` YAML, and routing table.
- `git diff --check` — no whitespace errors.

## Caveats
- Doc-only: no live preset probe is executed by this PR; the skill points agents at the existing `/doctor` probe for live state.
- The skill intentionally does not probe an *inactive* saved preset live (that would require switching the active preset, a config mutation out of scope for a read-only workflow); it reports static inspection and recommends a throwaway/dev-agent refresh if a live probe is required.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)