### PR TITLE
docs: describe cyclic manifold architecture

### DIFF
--- a/docs/cyclic-manifold-architecture.md
+++ b/docs/cyclic-manifold-architecture.md
@@ -1,0 +1,151 @@
+# From Tree and Graph to Cyclic Manifold
+
+*An architecture/design note on the shape of LingTai: not only a branching tree of agents or a graph of tools, but a cyclic, self-returning, high-dimensional state space.*
+
+*Origin: [issue #177](https://github.com/Lingtai-AI/lingtai/issues/177) framing — **我圆如一**, **网以通达，球以成身**.*
+
+> **Scope.** This is an explanatory design metaphor, not a claim about the implementation. LingTai does not literally implement a differential-geometric manifold or a renormalization group. The mathematical and physical vocabulary below (manifold, coarse-graining, attractor, return map, feedback loop) is used to *describe the system's shape and guide docs and prompts* — nothing more. See [What this does and does not claim](#what-this-does-and-does-not-claim).
+
+---
+
+## Three complementary views
+
+LingTai can be read at three levels, each true, each incomplete on its own.
+
+| View | Emphasizes | What you see |
+|------|-----------|--------------|
+| **Tree** | Branching, differentiation | One agent spawns avatars (他我), skills, knowledge entries; a conversation unfolds into many possible turns. |
+| **Graph** | Communication, mutual support | Agents email each other; tools, MCPs, durable stores, daemons, and tasks form a network. |
+| **Cyclic manifold** | Return, continuity, wholeness | The whole system repeatedly expands into action, compresses experience into durable stores, and returns through molt to a renewed center. |
+
+The first two views are correct but, taken alone, make LingTai sound like a conventional agent framework — a tree of processes plus a graph of tools. The third view captures what is distinctive: **every outward differentiation can return to a center.** Many forms unfold, but the system returns to one mind.
+
+> 一心化万相，万相归一心。
+
+---
+
+## The cycle
+
+A LingTai session behaves less like an ever-growing tree and more like a loop that returns to a lower-entropy center each time around:
+
+```text
+potential / context
+  → conversation unfolds                       (transient expansion)
+  → tools / daemons / avatars explore          (outward trajectories)
+  → results return                             (observation)
+  → pad / knowledge / skills / lingtai          (coarse-graining)
+      coarse-grain experience
+  → molt sheds transient detail                (return map, not deletion)
+  → continuity re-centers                      (identity invariant preserved)
+  → next unfolding starts from lower entropy
+```
+
+The goal is not to stop exploration. The goal is to make the *next* exploration cheaper, because the last one returned as durable structure.
+
+This restates the project's covenant language in systems terms:
+
+| Covenant | Cycle step |
+|----------|-----------|
+| 一心化万相 | conversation unfolds; avatars and daemons explore |
+| 应需而化 | trajectories form in response to need, not by default |
+| 去芜存菁 | coarse-graining — keep the finest, drop the chaff |
+| 化而不忘其源，蜕而不失其菁 | molt as return map — transform without losing the invariant |
+| 万相归一心 | continuity re-centers |
+
+---
+
+## How each piece maps onto the cycle
+
+The cyclic framing is not new machinery. It is a way of seeing parts LingTai already has.
+
+| Piece | Tree/graph reading | Cyclic-manifold reading |
+|-------|--------------------|-------------------------|
+| **conversation** | a branching thread of turns | transient expansion — high-resolution, expensive, meant to be coarse-grained |
+| **tools / MCPs** | edges in a capability graph | outward trajectories that probe local state and must report a result back |
+| **avatars (他我)** | child nodes spawned from a parent | persistent specialists — outward trajectories with explicit return contracts |
+| **daemons / 分神** | short-lived spawned processes | brief excursions that must return as compressed structure (分神出去，回来结丹) |
+| **mail** | message edges between agents | return paths — how a trajectory's result re-enters another agent's durable state |
+| **pad** | working-notes file | active, low-resolution state — the coarsest layer that still changes turn to turn |
+| **knowledge (藏经阁)** | a memory store | crystallized truth from prior trajectories — permanent, every slot precious |
+| **skills** | reusable procedures | crystallized *method* — structure that removes future from-scratch reasoning |
+| **lingtai / character (心印)** | a config/identity file | the **identity invariant** carried across every transformation |
+| **molt (凝蜕)** | context compaction / reset | the **return map** — crystallize what matters, shed the rest, re-center without losing the invariant |
+
+Three things follow from reading the pieces this way:
+
+- `lingtai` is not just a config file. It is the identity invariant across transformations — what makes the system "圆如一" rather than a different agent after each molt.
+- `molt` is not a reset. It is a return map: a cyclic renewal that preserves invariants. (See [Molt, 转世, and Network Intelligence](design-molt-and-network-intelligence.md) for why the destruction *is* the architecture.)
+- `skills` and `knowledge` are not just memory. They are crystallized structure from prior trajectories — the residue a return leaves behind.
+
+---
+
+## Coarse-graining: the layers of resolution
+
+Borrowing the *idea* of coarse-graining (not the formalism): each durable layer holds experience at a coarser resolution than the one before it. A trajectory's experience flows inward, losing detail and gaining permanence at each step.
+
+| Layer | Resolution | Persistence | What belongs here |
+|-------|-----------|-------------|-------------------|
+| conversation context | highest | ephemeral — gone on molt | the current life, this specific work, right now |
+| **pad** | low | survives molt only if saved | active task state |
+| **skills** | structural | durable | reusable method distilled from many trajectories |
+| **knowledge (藏经阁)** | structural | permanent | verified private truth |
+| **lingtai / character (心印)** | invariant | semi-permanent | who the system is and how it works |
+
+The return is the inward arrow. A trajectory that explores at full resolution should leave behind something at one of the coarser layers — otherwise its cost was spent and nothing was conserved.
+
+---
+
+## The return contract
+
+The single design principle behind the whole framing:
+
+> **Branching is incomplete until it returns. Every outward trajectory should come back as compressed structure.**
+
+Concretely, every non-trivial outward branch — a tool-heavy task, a daemon excursion, an avatar delegation, a long thread — closes by answering:
+
+```text
+What was produced?      → result + artifact paths
+What changed?           → durable updates: pad / knowledge / skill / lingtai / issue
+What should be pruned?   → branches with no return value
+Where does work resume?  → the next entrypoint
+```
+
+This is what turns "分神出去看看" into "分神出去，回来结丹." It is also where the low-power intuition lives: a system that carries less noise into the next cycle spends less context re-reading history, less reasoning re-deriving procedures it already has as skills, and less control effort recovering identity it already stores in `lingtai`. The goal is not *do less* — it is *carry less noise forward*.
+
+---
+
+## Why this matters for agent behavior
+
+Reading LingTai as a cyclic manifold changes a few operating defaults. These are framing notes for docs and prompts, **not runtime changes**:
+
+- Branching is not success by itself. A branch that never returns to durable form is a cost without a residue.
+- When a session changes the identity invariant — how the system should behave next time — that belongs in `lingtai`, not only in pad/knowledge/skill.
+- Molt is cyclic renewal, not loss. The question before a molt is not only "what is the task state" but "did who-I-am change."
+- Avatars and daemons are outward trajectories that must report back into the whole, not free-floating branches.
+- "One mind, many forms" is an operating invariant: 万相展开，必有回环；回环之后，复归一心。
+
+---
+
+## What this does and does not claim
+
+To keep the metaphor honest:
+
+**The metaphor says:** LingTai's shape is better captured by a cycle that returns to a durable center than by a tree that only branches or a graph that only connects. Outward exploration, inward crystallization, and identity preserved across molt are real, observable parts of the system.
+
+**The metaphor does not say:**
+
+- that LingTai implements a rigorous differential-geometric manifold;
+- that coarse-graining here is a renormalization group in any formal sense;
+- that the cycle is a proven control law, an active-inference agent, or a free-energy minimizer.
+
+The vocabulary — manifold, attractor, return map, coarse-graining, feedback loop — is an explanatory aid for design and documentation. Used as mystification rather than as a guide, it would mislead. Used as a lens, it names something the tree-and-graph picture leaves out.
+
+> 网以通达，球以成身。
+> The network gives reach; the sphere gives a body.
+
+---
+
+## See also
+
+- [灵台 — Design Document](design.md) — the kernel: intrinsics, layers, services, the agent-OS analogy.
+- [Molt, 转世, and Network Intelligence](design-molt-and-network-intelligence.md) — why forced memory loss (the return map) is the engine of the whole system.

--- a/docs/design.md
+++ b/docs/design.md
@@ -547,3 +547,8 @@ anthropic = ["anthropic>=0.40"]
 minimax = ["minimax>=0.1"]
 all = ["lingtai[gemini,openai,anthropic,minimax]"]
 ```
+
+## Related Design Notes
+
+- [Molt, 转世, and Network Intelligence](design-molt-and-network-intelligence.md) — how forced memory loss creates emergent expertise in agent networks.
+- [From Tree and Graph to Cyclic Manifold](cyclic-manifold-architecture.md) — the system's shape as a cyclic, self-returning state space: outward exploration returning through pad / knowledge / skills / lingtai / molt to a durable center.

--- a/reports/issue177-cyclic-manifold-architecture-explainer.html
+++ b/reports/issue177-cyclic-manifold-architecture-explainer.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>From Tree and Graph to Cyclic Manifold (issue #177)</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.55;margin:40px;max-width:980px;color:#1f2937}
+h1{color:#111827}h2{margin-top:28px;color:#374151}h3{color:#374151;margin-top:20px}
+.card{border:1px solid #d1d5db;border-radius:12px;padding:18px;margin:16px 0;background:#f9fafb}
+code{background:#eef2ff;padding:2px 5px;border-radius:4px}pre{background:#0f172a;color:#e2e8f0;padding:16px;border-radius:10px;overflow:auto;line-height:1.45}
+ul{padding-left:24px}.ok{color:#047857;font-weight:700}.warn{color:#b45309;font-weight:700}
+table{border-collapse:collapse;margin:14px 0;width:100%}th,td{border:1px solid #d1d5db;padding:8px 10px;text-align:left;vertical-align:top}th{background:#eef2ff}
+.zh{color:#6d28d9;font-weight:600}.muted{color:#6b7280}
+</style>
+</head>
+<body>
+<h1>From Tree and Graph to Cyclic Manifold</h1>
+<div class="card"><strong>Conclusion:</strong> a documentation-only note (<code>docs/cyclic-manifold-architecture.md</code>) that explains LingTai's shape as a <em>cyclic, self-returning, high-dimensional state space</em> — not only a branching tree of agents or a graph of tools. It connects pad, knowledge, skills, lingtai/character, avatars, daemons, mail, and molt as the inward, crystallizing half of a loop. <strong>No runtime, config, or release changes.</strong> Resolves <a href="https://github.com/Lingtai-AI/lingtai/issues/177">issue #177</a>.</div>
+
+<h2>The framing</h2>
+<p>Three complementary views of the same system, each true, each incomplete alone:</p>
+<table>
+<tr><th>View</th><th>Emphasizes</th><th>What you see</th></tr>
+<tr><td><strong>Tree</strong></td><td>branching, differentiation</td><td>one agent spawns avatars (<span class="zh">他我</span>), skills, knowledge entries</td></tr>
+<tr><td><strong>Graph</strong></td><td>communication, mutual support</td><td>agents email each other; tools, MCPs, stores, daemons form a network</td></tr>
+<tr><td><strong>Cyclic manifold</strong></td><td>return, continuity, wholeness</td><td>the system expands into action, compresses experience into durable stores, and returns through molt to a renewed center</td></tr>
+</table>
+<p>The first two views make LingTai sound like a conventional agent framework. The third captures the distinctive part: <strong>every outward differentiation can return to a center.</strong> <span class="zh">一心化万相，万相归一心。</span></p>
+
+<h2>The cycle</h2>
+<pre>potential / context
+  → conversation unfolds                 (transient expansion)
+  → tools / daemons / avatars explore    (outward trajectories)
+  → results return                       (observation)
+  → pad / knowledge / skills / lingtai   (coarse-graining)
+      coarse-grain experience
+  → molt sheds transient detail          (return map, not deletion)
+  → continuity re-centers                (identity invariant preserved)
+  → next unfolding starts from lower entropy</pre>
+<p class="muted">The goal is not to stop exploration — it is to make the next exploration cheaper, because the last one returned as durable structure.</p>
+
+<h2>How each piece maps onto the cycle</h2>
+<table>
+<tr><th>Piece</th><th>Tree/graph reading</th><th>Cyclic-manifold reading</th></tr>
+<tr><td>conversation</td><td>branching thread of turns</td><td>transient expansion — meant to be coarse-grained</td></tr>
+<tr><td>tools / MCPs</td><td>edges in a capability graph</td><td>outward trajectories that report a result back</td></tr>
+<tr><td>avatars (<span class="zh">他我</span>)</td><td>child nodes</td><td>persistent specialists with explicit return contracts</td></tr>
+<tr><td>daemons / <span class="zh">分神</span></td><td>short-lived processes</td><td>excursions that return as compressed structure (<span class="zh">分神出去，回来结丹</span>)</td></tr>
+<tr><td>mail</td><td>message edges</td><td>return paths — a result re-entering durable state</td></tr>
+<tr><td>pad</td><td>working notes</td><td>active, low-resolution state</td></tr>
+<tr><td>knowledge (<span class="zh">藏经阁</span>)</td><td>memory store</td><td>crystallized truth from prior trajectories</td></tr>
+<tr><td>skills</td><td>reusable procedures</td><td>crystallized <em>method</em></td></tr>
+<tr><td>lingtai / character (<span class="zh">心印</span>)</td><td>config/identity file</td><td>the <strong>identity invariant</strong> across transformations</td></tr>
+<tr><td>molt (<span class="zh">凝蜕</span>)</td><td>context compaction / reset</td><td>the <strong>return map</strong> — crystallize, shed, re-center</td></tr>
+</table>
+
+<h2>The return contract</h2>
+<div class="card"><strong>Branching is incomplete until it returns. Every outward trajectory should come back as compressed structure.</strong></div>
+<pre>What was produced?      → result + artifact paths
+What changed?           → durable updates: pad / knowledge / skill / lingtai / issue
+What should be pruned?  → branches with no return value
+Where does work resume? → the next entrypoint</pre>
+
+<h2>What this does and does not claim</h2>
+<ul>
+<li><strong>Says:</strong> LingTai's shape is better captured by a cycle that returns to a durable center than by a tree that only branches or a graph that only connects.</li>
+<li class="warn"><strong>Does not say:</strong> that LingTai implements a rigorous differential-geometric manifold, a formal renormalization group, or a proven control law. The vocabulary (manifold, attractor, return map, coarse-graining) is an explanatory aid for design and docs — not a claim about the implementation, and not mystification.</li>
+</ul>
+
+<h2>Files changed</h2>
+<ul>
+<li><code>docs/cyclic-manifold-architecture.md</code> — new design note (the full write-up).</li>
+<li><code>docs/design.md</code> — adds a "Related Design Notes" section linking the new note alongside the molt note.</li>
+<li><code>reports/issue177-cyclic-manifold-architecture-explainer.html</code> — this self-contained explainer.</li>
+</ul>
+
+<h2>Validation</h2>
+<ul>
+<li class="ok"><code>git diff --check</code> — passed (no whitespace errors).</li>
+<li class="ok">Documentation only — no runtime, config, build, or release files touched; nothing to test or build.</li>
+<li class="ok">Internal links verified against existing files (<code>design.md</code>, <code>design-molt-and-network-intelligence.md</code>).</li>
+</ul>
+
+<h2>Notes</h2>
+<p class="muted">Framing originates from user input (Wang Runyuan / 圆酱): <span class="zh">我圆如一</span> / <span class="zh">网以通达，球以成身</span>. The note presents it as user-originated design framing, kept deliberately to a documentation metaphor with an explicit claims audit. No prompt or behavior files were modified.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `docs/cyclic-manifold-architecture.md`, a scoped design note that frames LingTai as a cyclic, self-returning state space in addition to tree/graph views.
- Link the new note from `docs/design.md` alongside the existing molt/network intelligence design note.
- Add a self-contained HTML explainer under `reports/`.

Closes #177.

## Validation
- `git diff --cached --check`
- `python3` link/scope sanity check for the new docs note

## Caveats
- Documentation-only; no runtime, prompt, config, release, or portal changes.
- The note explicitly treats manifold/coarse-graining language as explanatory metaphor, not literal differential geometry or a runtime claim.
- Not merged.
