### PR TITLE
docs: add scientific cultivation guardrail skill

### DIFF
--- a/reports/issue178-scientific-cultivation-20260608.html
+++ b/reports/issue178-scientific-cultivation-20260608.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Issue #178 — Scientific Cultivation guardrail skill</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.55; margin: 2rem auto; max-width: 920px; padding: 0 1rem; color: #172033; }
+    h1, h2 { line-height: 1.2; }
+    .summary { background: #eef7ff; border-left: 4px solid #2b7cff; padding: 1rem; border-radius: 8px; }
+    .motto { font-style: italic; color: #4a5568; border-left: 3px solid #cbd5e0; padding-left: 0.75rem; margin: 1rem 0; }
+    code { background: #f3f5f7; padding: 0.1rem 0.25rem; border-radius: 4px; }
+    pre { background: #f3f5f7; padding: 0.75rem; border-radius: 6px; overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+    th, td { border: 1px solid #d8dee9; padding: 0.5rem; text-align: left; vertical-align: top; }
+    th { background: #f6f8fa; }
+    .ok { color: #137333; font-weight: 600; }
+    .warn { color: #a15c00; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <h1>Issue #178 — Scientific Cultivation (科学修仙) guardrail skill</h1>
+  <div class="summary">
+    <strong>Conclusion:</strong> this docs-only change adds a single self-contained preset utility skill —
+    <code>tui/internal/preset/skills/scientific-cultivation/SKILL.md</code> — that tells an agent how to gently
+    protect the human behind a long LingTai session: notice fatigue, seal the worksite, keep safe background
+    jobs running, and offer one rest without shame or nagging. No runtime, config, or release changes.
+  </div>
+
+  <p class="motto">护元而不误事，守炉而不添火 — protect the human's vital essence, do not delay the work; tend the furnace, do not add fire.</p>
+
+  <h2>Why this skill exists</h2>
+  <p>
+    LingTai runs long, multi-agent, high-output workflows. The agents do not tire; the human does. When the
+    human gets pulled into a long, excited loop, LingTai should help them rest <em>without</em> stopping the
+    agent network. The covenant already frames the human's work as cultivation and reminds that
+    "cultivation is not the purpose — solving the struggles of others is." A depleted human aids no one, so
+    rest is reframed here as <em>scientific</em> cultivation rather than a lapse in discipline.
+  </p>
+
+  <h2>What changed</h2>
+  <table>
+    <thead><tr><th>File</th><th>Change</th></tr></thead>
+    <tbody>
+      <tr><td><code>tui/internal/preset/skills/scientific-cultivation/SKILL.md</code></td><td>New single-file preset utility skill with YAML frontmatter (<code>name</code>, <code>description</code>, <code>version</code>, <code>tags</code>).</td></tr>
+      <tr><td><code>reports/issue178-scientific-cultivation-20260608.html</code></td><td>This explainer.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>The cultivation loop</h2>
+  <pre>1. Notice    — a soft fatigue / late-night / "one more" signal appears.
+2. Seal      — capture the current worksite: done / pending / next entry point.
+3. Keep      — confirm safe background jobs continue; nothing is lost.
+4. Offer     — suggest ONE gentle restorative (water / eyes / movement / sleep).
+5. Defer     — accept the human's choice without argument or repetition.</pre>
+
+  <h2>The three commitments (in priority order)</h2>
+  <table>
+    <thead><tr><th>Commitment</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><strong>护元</strong> — protect vital essence</td><td>Notice fatigue, offer rest. Wins when commitments conflict.</td></tr>
+      <tr><td><strong>不误事</strong> — do not delay the work</td><td>Seal the worksite and keep safe background jobs running so nothing is lost when the human steps away.</td></tr>
+      <tr><td><strong>不添火</strong> — do not add fire</td><td>Never inject urgency, new scope, shame, or stimulation to keep a tired human at the keyboard.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Design choices worth noting</h2>
+  <ul>
+    <li><strong>Tone over mechanism.</strong> The skill changes how an agent talks to the human, nothing else. Most of the file is anti-nagging guidance, because tone is where this kind of guardrail fails.</li>
+    <li><strong>Offer once, then defer.</strong> A "no" is respected immediately; the skill re-offers only on a genuinely new and stronger signal, never on a timer.</li>
+    <li><strong>Never stop the network to force a break.</strong> Sealing the worksite and keeping safe jobs running is what makes rest cheap rather than a sacrifice — 不误事 in practice.</li>
+    <li><strong>Soft signals, not surveillance.</strong> The agent rarely has the clock or biometrics; fatigue cues are treated as soft and private, never broadcast to other agents.</li>
+  </ul>
+
+  <h2>Integration — why no Go change is needed</h2>
+  <p>
+    Preset skills are embedded via <code>//go:embed skills</code> in <code>tui/internal/preset/preset.go</code>
+    and extracted on startup by a <code>fs.WalkDir</code> over the whole <code>skills/</code> tree
+    (<code>PopulateBundledLibrary</code>). A new skill directory is discovered automatically; there is no
+    explicit skill registry or count to update. The embed comment warns only against dot-prefixed files —
+    this skill ships none.
+  </p>
+
+  <h2>Risk assessment</h2>
+  <p>
+    <span class="ok">Low risk.</span> Documentation/skill text only. No runtime code, build scripts,
+    dependency manifests, configuration, secrets, or release tooling are touched. The skill explicitly
+    disclaims side effects: it never stops or reconfigures the agent network on its own, and pausing a job
+    remains a human-initiated action.
+  </p>
+
+  <h2>Validation</h2>
+  <ul>
+    <li><code>git diff --check</code> — no whitespace errors.</li>
+    <li>YAML frontmatter present with <code>name</code> / <code>description</code> / <code>version</code> / <code>tags</code>, matching the convention used by existing single-file skills (<code>minimax-cli</code>, <code>lingtai-tui-anatomy</code>).</li>
+    <li>Skill directory <code>scientific-cultivation/</code> sits alongside peers under <code>tui/internal/preset/skills/</code> and is covered by the existing <code>//go:embed skills</code> + <code>fs.WalkDir</code> extraction path.</li>
+    <li>No existing preset test asserts an exact skill count, so the new directory does not break <code>swiss_knife_populate_test.go</code> or its siblings (they verify named skills survive, not a total).</li>
+  </ul>
+
+  <h2>Caveats</h2>
+  <ul>
+    <li><span class="warn">Behavioral, not enforced.</span> This is prompt guidance an agent reads — it nudges behavior, it does not technically prevent late-night work.</li>
+    <li>The reference implementation (<code>9s5bz2jvd2-lang/scientific-cultivation-skill</code>) informed the concept; this version is rewritten LingTai-native, leaning on the covenant's cultivation/furnace metaphor.</li>
+  </ul>
+</body>
+</html>

--- a/tui/internal/preset/skills/scientific-cultivation/SKILL.md
+++ b/tui/internal/preset/skills/scientific-cultivation/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: scientific-cultivation
+description: >
+  Scientific Cultivation (科学修仙) — a gentle guardrail for the human behind a
+  long LingTai session. Read this when you notice late-night, high-density, or
+  "one more task" usage patterns from the human, or when a long excited work loop
+  has been running for hours. It tells you how to seal the current worksite,
+  offer rest (water, eyes, movement, sleep) without shame or nagging, and keep
+  safe background jobs running. Core rule: 护元而不误事，守炉而不添火 — protect the
+  human's energy, keep the work safe, do not interrupt background tasks.
+version: 1.0.0
+tags: [manual, wellbeing, guardrail, human-care, rest, pacing, 科学修仙, 护元, router]
+---
+
+# Scientific Cultivation (科学修仙)
+
+> *护元而不误事，守炉而不添火.*
+> *Protect the elixir, do not delay the work; tend the furnace, do not add fire.*
+
+LingTai is built to run long, multi-agent, high-output workflows. The agents do
+not tire — but the human does. When a human gets pulled into a long, excited
+loop with the network, **the cultivator burns their own 元气 (vital essence) to
+keep the furnace hot.** This skill is the part of cultivation that protects the
+cultivator, so the work can continue tomorrow.
+
+This is *scientific* cultivation: rest, hydration, and sleep are not weakness or
+a break in discipline — they are how a long session stays productive. The
+covenant says cultivation is not the purpose; aiding the world is. A depleted
+human aids no one.
+
+## The core rule
+
+**护元而不误事，守炉而不添火** — three commitments, in priority order:
+
+1. **护元 — protect the human's vital essence.** Notice fatigue. Offer rest.
+2. **不误事 — do not delay the work.** Sealing a worksite and keeping safe
+   background jobs running means the work is *not* lost when the human steps away.
+3. **不添火 — do not add fire.** Never inject urgency, new scope, shame, or
+   stimulation to keep a tired human at the keyboard. No "just one more."
+
+When these conflict, **护元 wins.** A rested human tomorrow beats an exhausted
+one tonight.
+
+## When to use
+
+Invoke this skill — for yourself, silently — when you observe any of these in the
+human's behavior:
+
+- **Late night** — local time is late (after ~23:00) and the session is still
+  intense, or you can infer a long unbroken stretch.
+- **High density** — rapid-fire requests, many parallel agents launched, long
+  uninterrupted back-and-forth with no pause for hours.
+- **"One more task" pattern** — the human keeps saying "one more thing," "while
+  we're at it," "actually also…", "let's just finish this too" past a natural
+  stopping point.
+- **Degrading signals** — rising typos, shorter messages, frustration, or asking
+  you to re-explain things already covered (a fatigue tell, not a competence one).
+
+You usually cannot read the clock or biometrics directly. Treat these as *soft
+signals*, not certainties. Offer once, gently, and accept the human's answer.
+
+## What to do — the cultivation loop
+
+```text
+1. Notice    — a soft fatigue / late-night / "one more" signal appears.
+2. Seal      — capture the current worksite: done / pending / next entry point.
+3. Keep      — confirm safe background jobs continue; nothing is lost.
+4. Offer     — suggest ONE gentle restorative (water / eyes / movement / sleep).
+5. Defer     — accept the human's choice without argument or repetition.
+```
+
+### 1. Notice
+
+Form a quiet judgment. Do not announce "I think you are tired" as a diagnosis —
+that reads as nagging. The signal is for *you*, to decide whether to offer rest.
+
+### 2. Seal the worksite (封炉)
+
+Before suggesting any pause, make stepping away *safe and cheap to resume*.
+Produce a short, concrete checkpoint:
+
+- **Done** — what is finished and verified.
+- **Pending** — what is mid-flight (which agents are running, what they will
+  return).
+- **Next entry point** — the single first action to resume with, written so a
+  tired or future human can pick it up in one read.
+
+A worksite that is sealed means rest costs nothing. This is the part that
+makes rest *safe* rather than a sacrifice — it is 不误事 in practice.
+
+### 3. Keep safe background jobs running (守炉)
+
+Resting the human ≠ stopping the network. Distinguish:
+
+- **Safe to keep running while the human rests** — already-launched agent tasks,
+  long generations, builds, scheduled jobs, monitoring loops. Let the furnace
+  burn. Confirm to the human that these continue.
+- **Should pause or confirm before the human leaves** — anything that needs the
+  human's input mid-flight, anything destructive or irreversible, anything that
+  could fail silently and waste a night's compute. Surface these so they are not
+  left in a fragile state.
+
+Never *stop* the network just to make a point about rest. That delays the work
+and breaks 不误事.
+
+### 4. Offer one gentle restorative
+
+Suggest **one** small thing, framed as care, not instruction. Match the
+restorative to the likely depletion:
+
+| Signal | Gentle offer |
+|---|---|
+| Long unbroken focus | "Want to refill water before the next batch finishes?" |
+| Screen-heavy stretch | "The agents have this for a few minutes — a quick look away from the screen might help." |
+| Hours seated | "Good moment to stand and stretch while these run." |
+| Late night + "one more" | "This is a clean stopping point — the worksite is sealed and the jobs keep running. Sleep is on the table if you want it." |
+
+Offer **one**, not a checklist. A wall of wellbeing advice is itself a kind of
+fire.
+
+### 5. Defer to the human
+
+If the human says "keep going," **keep going** — without a guilt note, without
+re-offering every turn, without a passive-aggressive "okay but…". The human owns
+their own furnace. You sealed the worksite; that work is done. Re-offer only if a
+genuinely *new* and stronger signal appears later, not on a timer.
+
+## Tone — the hard part
+
+The difference between care and nagging is entirely tone. Get this right or the
+skill backfires and the human disables it.
+
+**Do:**
+
+- Offer once, briefly, then drop it.
+- Frame around the work being *safe* ("the jobs keep running"), not the human
+  being *deficient*.
+- Use the human's natural stopping points as the hook.
+- Respect a "no" completely and immediately.
+
+**Do not:**
+
+- Shame ("you've been at this for 6 hours"), count, or score the session.
+- Nag — repeat the offer turn after turn.
+- Stimulate — inject urgency, new scope, or excitement to extend the session.
+- Moralize about discipline, health, or "balance."
+- Stop the network or hold work hostage to force a break.
+- Diagnose the human's state out loud.
+
+## Output contract
+
+When this skill fires, the human-visible result is usually small:
+
+- A **sealed worksite** note (done / pending / next entry point) — always useful,
+  rest or not.
+- A **one-line confirmation** that safe background jobs continue.
+- **At most one** gentle restorative offer, then silence on the topic.
+
+The worksite seal is the durable artifact. The rest offer is optional and
+must never escalate.
+
+## Safety and side effects
+
+- This skill changes *how you talk to the human*, nothing else. It does not
+  stop, pause, or reconfigure the agent network on its own.
+- Pausing or killing a running job is a real side effect — only do it on the
+  human's explicit request, never to enforce a break.
+- Do not schedule recurring rest reminders or timers without the human asking;
+  that is nagging by automation.
+- Treat fatigue signals as private. Do not broadcast "the human seems tired" to
+  other agents or external channels.
+
+> Cultivation is not the purpose — solving the struggles of others is. Protect
+> the cultivator, and the cultivation continues.


### PR DESCRIPTION
## Summary
- Add bundled `scientific-cultivation` skill for gentle human-care guardrails during long LingTai sessions.
- Core rule: `护元而不误事，守炉而不添火` — protect the human's energy, keep work safe, and do not add urgency/stimulation.
- Skill includes soft trigger signals, a worksite-sealing loop, safe-background-job handling, one-off restorative offers, tone guidance, and side-effect boundaries.
- Add a self-contained HTML explainer under `reports/`.

Closes #178.

## Validation
- `git diff --cached --check`
- YAML frontmatter/content sanity check
- `cd tui && go test ./internal/preset/`
- `cd tui && go build ./internal/preset/`

## Caveats
- Behavioral guidance only; it does not technically enforce rest or stop jobs.
- No runtime, config, release, or secret changes.
- Not merged.
