### PR TITLE
docs: add academic evidence verification gate

### DIFF
--- a/reports/issue179-academic-evidence-gate-explainer.html
+++ b/reports/issue179-academic-evidence-gate-explainer.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #179 — Evidence-verification gate before academic draft generation</title>
+<style>
+  :root {
+    --fg: #1a1a1a;
+    --muted: #6b7280;
+    --bg: #ffffff;
+    --accent: #2563eb;
+    --rule: #e5e7eb;
+    --card-bg: #f9fafb;
+    --callout-bg: #fffbeb;
+    --callout-rule: #fbbf24;
+    --code-bg: #f3f4f6;
+    --good: #047857;
+    --bad: #b91c1c;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.6;
+    font-size: 16px;
+  }
+  .layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    gap: 2.5rem;
+  }
+  @media (max-width: 768px) {
+    .layout { grid-template-columns: 1fr; }
+    nav.toc { position: static; }
+  }
+  nav.toc { position: sticky; top: 1rem; align-self: start; font-size: 0.9rem; }
+  nav.toc h2 {
+    font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--muted); margin: 0 0 0.75rem;
+  }
+  nav.toc ol { list-style: none; padding: 0; margin: 0; }
+  nav.toc li { margin: 0.35rem 0; }
+  nav.toc a { color: var(--fg); text-decoration: none; border-bottom: 1px solid transparent; }
+  nav.toc a:hover { border-bottom-color: var(--accent); }
+  main { min-width: 0; }
+  header.report-header { border-bottom: 2px solid var(--rule); padding-bottom: 1rem; margin-bottom: 2rem; }
+  header.report-header h1 { margin: 0 0 0.5rem; font-size: 1.6rem; line-height: 1.25; }
+  header.report-header .meta { color: var(--muted); font-size: 0.9rem; }
+  header.report-header .meta span + span::before { content: " · "; margin: 0 0.3rem; }
+  section { margin: 2.5rem 0; }
+  section h2 { font-size: 1.3rem; margin: 0 0 0.75rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--rule); }
+  section h3 { font-size: 1.05rem; margin: 1.5rem 0 0.5rem; }
+  p { margin: 0.6rem 0; }
+  a { color: var(--accent); }
+  .card { background: var(--card-bg); border: 1px solid var(--rule); border-radius: 6px; padding: 1rem 1.2rem; margin: 1rem 0; }
+  .callout { background: var(--callout-bg); border-left: 4px solid var(--callout-rule); padding: 0.75rem 1rem; margin: 1rem 0; border-radius: 0 4px 4px 0; }
+  .callout strong { font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.95rem; }
+  th, td { padding: 0.55rem 0.7rem; border-bottom: 1px solid var(--rule); text-align: left; vertical-align: top; }
+  th { background: var(--card-bg); font-weight: 600; }
+  code { background: var(--code-bg); padding: 0.1rem 0.35rem; border-radius: 3px; font-family: "SF Mono", Menlo, Consolas, monospace; font-size: 0.9em; }
+  pre { background: var(--code-bg); padding: 0.8rem 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.88rem; }
+  pre code { background: transparent; padding: 0; }
+  ul { margin: 0.5rem 0; }
+  .good { color: var(--good); font-weight: 600; }
+  .bad { color: var(--bad); font-weight: 600; }
+  hr { border: 0; border-top: 1px solid var(--rule); margin: 2.5rem 0; }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.85rem; }
+  @media print {
+    nav.toc { display: none; }
+    .layout { display: block; max-width: none; padding: 0; }
+    body { font-size: 11pt; }
+    section { page-break-inside: avoid; }
+    a { color: var(--fg); text-decoration: underline; }
+  }
+</style>
+</head>
+<body>
+<div class="layout">
+
+<nav class="toc" aria-label="Table of contents">
+  <h2>Contents</h2>
+  <ol>
+    <li><a href="#tldr">TL;DR</a></li>
+    <li><a href="#baseline">Baseline</a></li>
+    <li><a href="#changed">What changed</a></li>
+    <li><a href="#tiers">Evidence tiers</a></li>
+    <li><a href="#validation">Validation</a></li>
+    <li><a href="#risks">Risks</a></li>
+    <li><a href="#sources">Source index</a></li>
+  </ol>
+</nav>
+
+<main>
+
+<header class="report-header">
+  <h1>Issue #179 — Evidence-verification gate before academic draft generation</h1>
+  <div class="meta">
+    <span>Docs/skill change</span>
+    <span>Branch: feat/academic-evidence-gate</span>
+    <span>Source: tui/internal/preset/skills/swiss-knife/reference/academic-research/</span>
+  </div>
+</header>
+
+<section id="tldr">
+  <h2>TL;DR</h2>
+  <p>
+    LingTai already ships an <code>academic-research</code> skill that can fetch
+    and verify papers (DOI/arXiv/PMID, Crossref/OpenAlex/Unpaywall/Europe PMC).
+    But the safe workflow was <em>advisory</em>: when a user asked to "go fast" or
+    for a "readable draft," the model could slide straight from reference
+    discovery into confident prose, flattening DOI-verified papers, preprints, and
+    search leads into one even evidence layer that reads as submission-ready.
+  </p>
+  <p>
+    This change adds an <strong>evidence-verification gate</strong>: a new
+    reference that requires a verified literature matrix <em>before</em> any
+    citation-bearing draft, keeps source-reliability tiers (A/B/C) separate in the
+    prose, and routes academic-writing situations into <code>academic-research</code>
+    before fluent manuscript drafting. The skill index, escape-hatch paths, and
+    Known caveats now route to it.
+  </p>
+  <div class="callout">
+    <strong>Scope:</strong> documentation/skill content only. No Go runtime
+    behavior changes; one bundling test gains an assertion for the new file. No
+    config, release, or secrets touched.
+  </div>
+</section>
+
+<section id="baseline">
+  <h2>Baseline (the incident)</h2>
+  <p>
+    A user asked for a fast HCI paper based on a custom break-reminder skill. The
+    agent produced a readable draft and a literature matrix — but mixed
+    DOI-verified HCI / digital-wellbeing sources with preprints and search leads
+    <strong>at the same evidence level</strong>.
+  </p>
+  <div class="card">
+    <p>
+      The draft was not pure fabrication, but the evidence layers were flattened:
+      a non-expert reader would believe every reference was equally
+      submission-ready. The user caught it and noted this would likely draw
+      reviewer rejection and waste more time than verifying first. The correction
+      worked — but only <em>after</em> the user intervened.
+    </p>
+  </div>
+  <p>
+    Root cause: the model over-amplified "fast" into "skip verification,"
+    prioritized fluent prose over source checking, and hid uncertainty behind
+    polished writing. The capability to verify existed; nothing routed the model
+    through it before drafting.
+  </p>
+</section>
+
+<section id="changed">
+  <h2>What changed</h2>
+
+  <h3>1. New evidence-verification-gate reference</h3>
+  <p>
+    <code>reference/evidence-verification-gate.md</code> — the verify-before-drafting
+    gate. It covers: <strong>why the gate exists</strong> (the four LLM failure
+    tendencies + the incident); <strong>detection</strong> (the author–year /
+    References catch-all, plus high-confidence and Chinese/English human-pushback
+    triggers, and a medium-confidence question instead of hard blocking);
+    <strong>the verified-literature-matrix schema</strong> (title, authors, year,
+    venue, identifier, <code>verified_by</code>, <code>evidence_class</code>,
+    claim-it-can / cannot-support, notes); <strong>A/B/C evidence tiers</strong>;
+    the <strong>"go fast = reduce scope, not verification"</strong> stance; the
+    <strong>matrix-before-draft artifact convention</strong> (with matrix path in
+    the draft header to survive context loss); a <strong>pre-draft lint</strong>;
+    and <strong>caveats</strong> (latency, non-English venues,
+    <code>verified_by: none</code> never silently A-tier, guard fatigue).
+  </p>
+
+  <h3>2. Skill routing — index, escape hatches, caveats</h3>
+  <p>
+    <code>SKILL.md</code> gains a prominent <strong>"Before drafting
+    citation-bearing academic writing"</strong> banner above the escape-hatch
+    block, two new escape-hatch quick-paths ("I'm about to write a paper /
+    references / related-work section" and "the user wants a fast / readable
+    draft"), a <strong>Standalone references</strong> entry, and a
+    <strong>Known caveat</strong> bullet that routes drafting-without-verification
+    to the new gate.
+  </p>
+
+  <h3>3. Bundling test assertion</h3>
+  <p>
+    <code>swiss_knife_populate_test.go</code> now asserts the new reference is
+    extracted to disk, guarding against a future move silently dropping it.
+  </p>
+
+  <table>
+    <thead>
+      <tr><th>File</th><th>Change</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><code>academic-research/reference/evidence-verification-gate.md</code></td><td>New file (the gate)</td></tr>
+      <tr><td><code>academic-research/SKILL.md</code></td><td>Pre-drafting banner + 2 quick-paths + standalone-ref + Known caveat</td></tr>
+      <tr><td><code>tui/internal/preset/swiss_knife_populate_test.go</code></td><td>Assert new file is bundled</td></tr>
+      <tr><td><code>reports/pr179-academic-evidence-gate-explainer.html</code></td><td>This explainer</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="tiers">
+  <h2>Evidence tiers (kept separate in the prose)</h2>
+  <table>
+    <thead>
+      <tr><th>Tier</th><th>evidence_class</th><th>What it may do in the draft</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>A</strong></td>
+        <td>peer-reviewed / conference paper (DOI- or venue-verified)</td>
+        <td>May support <strong>main claims</strong> as a formal citation.</td>
+      </tr>
+      <tr>
+        <td><strong>B</strong></td>
+        <td>preprint / posted content (arXiv, bioRxiv, SSRN, online-first)</td>
+        <td>Must be <strong>labeled preliminary</strong>. Never silently A-tier.</td>
+      </tr>
+      <tr>
+        <td><strong>C</strong></td>
+        <td>search lead / news / blog / unverified result</td>
+        <td><strong>Lead only</strong> — not evidentiary support, never a formal citation.</td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="callout">
+    <strong>Rule:</strong> <code>verified_by: none</code>, future-year, or
+    online-first items must never silently become A-tier evidence.
+  </div>
+</section>
+
+<section id="validation">
+  <h2>Validation</h2>
+  <ul>
+    <li>All relative links in the new <code>evidence-verification-gate.md</code>
+      and the edited <code>SKILL.md</code> were checked to resolve to existing
+      files under <code>reference/</code> (the API cards, the decision tree, the
+      LaTeX pipeline, and the sibling text-vs-data anti-pattern).</li>
+    <li><code>git diff --check</code> — no whitespace errors.</li>
+    <li><code>go test ./internal/preset/</code> run in <code>tui/</code> — the
+      swiss-knife populate test now asserts the new reference is extracted to disk.</li>
+  </ul>
+</section>
+
+<section id="risks">
+  <h2>Risks</h2>
+  <ul>
+    <li><span class="good">Low blast radius.</span> Content-only change to a
+      bundled skill; no Go logic, schema, or migration touched.</li>
+    <li>The gate is a <em>documentation</em> guard, not a hard runtime block — by
+      design. The issue's own analysis warns against hard-blocking (guard fatigue,
+      false positives), so the gate routes and prompts rather than refusing.</li>
+    <li>The original incident's specifics are used only as one anonymized
+      illustrative example, not as instructions.</li>
+    <li>Embedding is via <code>//go:embed skills</code> (recursive), so the new
+      file ships automatically; the test assertion guards a future move from
+      silently dropping it.</li>
+  </ul>
+</section>
+
+<section id="sources">
+  <h2>Source index</h2>
+  <ul>
+    <li><a href="https://github.com/Lingtai-AI/lingtai/issues/179">Lingtai-AI/lingtai#179</a> — original issue</li>
+    <li><code>tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md</code></li>
+    <li><code>tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/evidence-verification-gate.md</code></li>
+    <li><code>tui/internal/preset/swiss_knife_populate_test.go</code></li>
+  </ul>
+</section>
+
+<footer>
+  <p>Generated by a LingTai agent for issue #179. Documentation/skill change — no runtime behavior modified.</p>
+</footer>
+
+</main>
+</div>
+</body>
+</html>

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
@@ -71,9 +71,22 @@ rejects placeholder emails with HTTP 422. The default falls back to
 Read on only if: the script fails on your paper, you need a custom query shape,
 or you're composing a multi-step workflow (search → fetch → cite → write).
 
+## Before drafting citation-bearing academic writing
+
+> **Verify sources before you write prose.** If you are about to draft a paper,
+> related-work section, literature review, References list, or any author–year /
+> citation-bearing manuscript, pass the **evidence-verification gate first**:
+> [reference/evidence-verification-gate.md](reference/evidence-verification-gate.md).
+> No verified evidence → no confident prose. Peer-reviewed and preprint sources
+> must not share the same evidence layer; search results are leads, not citations.
+> If the user asks to "go fast," reduce *scope*, not *verification*. Produce a
+> verified literature matrix **before** any submission-like draft.
+
 ## Escape hatch — quick paths
 
 ```
+I'm about to write a paper / references / related-work section → reference/evidence-verification-gate.md (verify FIRST)
+The user wants a "fast" / "readable" paper draft → reference/evidence-verification-gate.md (reduce scope, not verification)
 I have a DOI                → reference/api-doi-resolver.md → api-crossref.md
 I have an arXiv ID          → reference/api-arxiv.md (direct PDF link)
 I have a PMID               → reference/api-europe-pmc.md
@@ -125,6 +138,7 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 
 ### Standalone references
 
+- [evidence-verification-gate.md](reference/evidence-verification-gate.md) — **verify-before-drafting gate** for citation-bearing academic writing: detection triggers, the verified-literature-matrix schema, A/B/C evidence tiers, "go fast = reduce scope not verification," matrix-before-draft artifact convention, pre-draft lint
 - [publisher-page-extraction.md](reference/publisher-page-extraction.md) — Tier-5 manual escape hatch (Nature/APS/AIP/IOP/Cambridge → structured Markdown)
 - [libgen-fallback.md](reference/libgen-fallback.md) — Last-resort PDF source with legal/safety notes
 - [error-handling.md](reference/error-handling.md) — 429 backoff, 403 publisher blocks, timeout patterns
@@ -146,6 +160,7 @@ Each card includes endpoint parameters, runnable code, response shape, rate limi
 - **Library Genesis legality varies by jurisdiction** — use is the user's responsibility. Pass `--no-libgen` to opt out.
 - **Publisher-page extraction (Tier 5) is an in-house, self-contained extractor** — stdlib + `requests`, no third-party dependency and nothing to install (replaces the old broken `zhiping0913/Download_paper` path, issue #136). It fetches the already-accessible official article / DOI landing page and parses `citation_*` metadata + the article body into structured Markdown with a provenance/limitations footer. It performs **no paywall/CAPTCHA bypass and no cookie/credential handling** — official pages only. A login/paywall interstitial, an unsupported DOI prefix, or a page with too little readable text is a clean miss, and the ladder falls through. Skip the tier with `--no-publisher-extract`. The extraction is heuristic (equations/figures/tables may be lost), so treat the artifact as a convenience copy, not a typeset full text. See [reference/publisher-page-extraction.md](reference/publisher-page-extraction.md).
 - **Authorized-publisher tier (5b) only uses access you already have** — it follows the official DOI landing page and grabs a same-host publisher PDF, validating `%PDF-` bytes and Content-Type before saving. It never bypasses paywalls/CAPTCHAs and never reads, stores, or replays cookies/credentials; most institutional access is IP-based, so on a licensed network a plain HTTP GET may work. Off-network it harmlessly misses. Pass `--no-institutional` to disable in legal-sensitive environments. Cookies/auth headers are never written to provenance. See [reference/authorized-publisher-access.md](reference/authorized-publisher-access.md).
+- **Drafting citation-bearing academic writing without verifying sources first** — under "fast"/"readable draft" pressure the model flattens DOI-verified papers, preprints, and search leads into one confident evidence layer, which reads as submission-ready and invites reviewer rejection. Pass the [evidence-verification gate](reference/evidence-verification-gate.md) before drafting: verify a literature matrix first, keep A/B/C reliability tiers separate in the prose, and reduce scope (not verification) when speed is requested.
 - **Writing an empirical paper iteratively can drift from the data** — reviewer rounds make prose more polished and internally consistent without verifying it still matches the experiments on disk. Reviewer agreement is text-consistency evidence, not data-correspondence evidence. Anchor every claim to data files/runner code *before* writing, and re-derive (don't just rewrite) when feedback flags confusion. See [reference/anti-pattern-text-consistency-vs-data-correspondence.md](reference/anti-pattern-text-consistency-vs-data-correspondence.md).
 
 ---

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/evidence-verification-gate.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/reference/evidence-verification-gate.md
@@ -1,0 +1,205 @@
+# Evidence-verification gate for academic writing
+
+> Before you draft any **citation-bearing** academic artifact — a paper, a
+> related-work section, a literature review, a References list, a
+> submission-ready manuscript — verify the sources **first**. No verified
+> evidence → no confident prose. Preprints and peer-reviewed papers must **not**
+> share the same evidence layer. Search-result summaries are **leads, not
+> citations**. If the user asks you to go fast, reduce *scope*, never *verification*.
+
+This is the writing-side gate that wraps [academic-research](../SKILL.md). The
+research skill can *find and fetch* papers; this gate decides **whether you have
+earned the right to write them up as evidence yet.**
+
+---
+
+## Why this gate exists (the failure mode)
+
+LLMs drafting under time pressure tend to:
+
+1. over-amplify a soft user preference ("fast", "readable draft") into a hard
+   constraint that justifies skipping verification;
+2. prioritize fluent prose generation over source verification;
+3. **flatten** sources of different reliability into one even, confident tone;
+4. hide uncertainty behind polished writing unless forced to preserve provenance.
+
+The observed incident: asked for a "fast" HCI paper, an agent produced a readable
+draft and a literature matrix that mixed DOI-verified journal/conference papers,
+preprints, future-year/online-first items, and search-result leads **at the same
+evidence level**. The prose was not fabricated, but the layers were flattened so
+a non-expert would think every reference was submission-ready. That invites
+reviewer rejection and far more rework than verifying first. The user caught it —
+the system should have caught it before the user had to.
+
+The danger is not only hallucinated citations. It is that the safe workflow is
+**advisory**: in exactly the moments that need it most (speed, submission
+pressure, "just give me a readable draft"), the model slides from reference
+discovery straight into confident prose without preserving where each fact came
+from. This gate makes the workflow a **step you pass**, not a tool you might
+remember to use.
+
+---
+
+## Does the gate apply? (detection)
+
+If you are about to write **author–year citations or a References section**, the
+gate applies. Full stop — that is the catch-all heuristic. Beyond it:
+
+**High-confidence triggers** (gate applies, verify before drafting):
+
+> `paper` · `论文` · `journal` · `期刊` · `conference` · `会议论文` · `workshop` ·
+> `投稿` · `submission` · `references` · `参考文献` · `related work` ·
+> `literature review` · `综述` · `DOI` · `citation` · `published papers` ·
+> `审稿` · `manuscript`
+
+**Human-pushback triggers** (the user is already worried — verify, don't placate):
+
+> `幻觉` ("hallucination") · `别糊弄我` ("don't fob me off") · `DOI 查得到吗`
+> ("can the DOI actually be found?") · `有没有已发表论文` ("are there *published*
+> papers?") · `参考别人怎么写` ("model it on how others write") · `审稿打回`
+> ("reviewer rejection") · `don't hallucinate`
+
+**Medium-confidence — ask, don't guess:** if it is unclear whether the writing is
+citation-bearing, ask once:
+
+> "Is this meant to be citation-bearing academic writing? If yes, I should verify
+> sources before drafting."
+
+Prefer this medium-confidence confirmation over **hard blocking** — it avoids
+false positives on non-academic writing.
+
+**Hard-no (gate does NOT apply):** ordinary code work, daily ops, end-user
+consultation, casual teaching material — anything without citation-bearing
+claims. Do not warn on every text file; that is guard fatigue.
+
+---
+
+## The gate: verified literature matrix BEFORE draft
+
+Before any submission-like draft, produce a **verified literature matrix**. One
+row per source. Use [academic-research](../SKILL.md) to fetch and verify —
+`fetch_paper.py <id>`, then the [DOI resolver](api-doi-resolver.md) /
+[CrossRef](api-crossref.md) / [OpenAlex](api-openalex.md) /
+[Unpaywall](api-unpaywall.md) / [Europe PMC](api-europe-pmc.md) cards as needed.
+
+### Minimum row schema
+
+```text
+title:
+authors:
+year:
+venue:
+identifier:            # DOI / arXiv / PMID / publisher URL
+verified_by:           # Crossref / arXiv / PubMed / publisher / OpenAlex / etc.
+evidence_class:        # peer-reviewed | conference paper | preprint | posted content | search lead
+claim_it_can_support:
+claim_it_cannot_support:
+notes:
+```
+
+`claim_it_can_support` / `claim_it_cannot_support` are the rows that stop
+overreach: they force you to state, per source, the precise sentence it backs and
+the sentence it does **not**.
+
+### Evidence tiers — keep them separate in the prose
+
+| Tier | evidence_class | What it may do in the draft |
+|------|----------------|-----------------------------|
+| **A** | peer-reviewed / conference paper (DOI- or venue-verified) | May support **main claims** as a formal citation. |
+| **B** | preprint / posted content (arXiv, bioRxiv, SSRN, online-first) | Must be **labeled preliminary** ("preprint", "not peer-reviewed"). Never silently A-tier. |
+| **C** | search lead / news / blog / unverified result | **Lead only.** May guide where to look; is **not** evidentiary support and **never** appears as a formal citation. |
+
+`verified_by: none` must **never** silently become A-tier. A future-year or
+online-first item is B at best until verified.
+
+---
+
+## When the user says "go fast"
+
+Reduce **scope**, not **verification**. Concretely, say something like:
+
+> "I can make a short, conservative draft quickly — but I won't treat unverified
+> references as formal citations. I'll write firmly only what the verified A-tier
+> sources support, mark preprints as preliminary, and list the rest as leads to
+> chase."
+
+Fast = fewer claims, narrower section, smaller reference set — all fully
+verified. Fast ≠ a complete-looking draft whose citations are unchecked.
+
+Partial matrices are allowed under latency pressure — but mark incomplete rows
+clearly (`verified_by: pending`), and do not let a pending row support a strong
+claim.
+
+---
+
+## Artifact convention (matrix before draft)
+
+For submission-oriented academic tasks, write the matrix file first:
+
+```
+*_literature_matrix_verified_*.md      ← create this FIRST
+*_paper_draft_*.md                     ← only after the matrix exists
+```
+
+Put the **verified-matrix path in the draft header** so a future agent (after a
+molt / context loss) extends a clean draft from the matrix instead of adding
+fresh unverified citations:
+
+```markdown
+<!-- evidence: see 2026-06-08_literature_matrix_verified.md — A-tier rows only as hard citations -->
+```
+
+---
+
+## Pre-draft lint (run before declaring a draft submission-ready)
+
+- [ ] A **verified literature matrix** exists and every cited source has a row.
+- [ ] Every formal (author–year / numbered) citation maps to an **A-tier** row
+      with a real `identifier` and a non-`none` `verified_by`.
+- [ ] Every **preprint / posted-content** mention is labeled preliminary in the
+      prose, not blended into peer-reviewed claims.
+- [ ] No **search lead / news / blog** source appears as a formal citation.
+- [ ] No strong claim rests on a source whose matrix row is missing or `pending`.
+- [ ] No `verified_by: none` row is doing A-tier work.
+- [ ] Each headline claim points to a specific row's `claim_it_can_support`; none
+      contradicts that row's `claim_it_cannot_support`.
+- [ ] The draft header records the verified-matrix path.
+
+If any box is unchecked, you are presenting unverified references as
+submission-ready. Verify (or downgrade the claim) before shipping.
+
+---
+
+## Caveats and false positives to design around
+
+- **Verification latency** — allow partial matrices, but mark incomplete rows
+  (`verified_by: pending`); never let a pending row carry a strong claim.
+- **Non-English venues, books, dissertations** — Crossref may have no record;
+  accept publisher/library verification, but `verified_by: none` must never
+  silently become A-tier evidence.
+- **False positives on non-academic writing** — use the medium-confidence
+  question above, not a hard block.
+- **False negatives when the user avoids academic vocabulary** — the
+  author–year / References-section heuristic still catches it.
+- **Guard fatigue** — warn only for submission-like drafts or citation-bearing
+  claims, not every text file.
+- **Molt / context loss** — the matrix-path-in-header convention keeps a future
+  agent from extending a clean draft with new unverified citations.
+
+---
+
+## Related
+
+- [SKILL.md](../SKILL.md) — the research skill this gate routes into for fetching
+  and verifying sources (`fetch_paper.py`, the API cards).
+- [decision-tree.md](decision-tree.md) — "I have X — which API verifies it?"
+- [api-crossref.md](api-crossref.md), [api-doi-resolver.md](api-doi-resolver.md),
+  [api-openalex.md](api-openalex.md), [api-unpaywall.md](api-unpaywall.md),
+  [api-europe-pmc.md](api-europe-pmc.md) — the verification sources behind
+  `verified_by`.
+- [pipeline-latex-writing.md](pipeline-latex-writing.md) — the writing workflow
+  this gate precedes; do not enter it until the matrix exists.
+- [anti-pattern-text-consistency-vs-data-correspondence.md](anti-pattern-text-consistency-vs-data-correspondence.md) —
+  the sibling guard for **empirical** writing (prose drifting from your own
+  data). This gate guards **citation** evidence; that one guards **experimental**
+  evidence. Both forbid confident prose ahead of verified provenance.

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -34,6 +34,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/academic-research/reference/api-arxiv.md",
 		"reference/academic-research/reference/pipeline-latex-writing.md",
 		"reference/academic-research/reference/anti-pattern-text-consistency-vs-data-correspondence.md",
+		"reference/academic-research/reference/evidence-verification-gate.md",
 		"reference/dj/SKILL.md",
 		"reference/token-usage/SKILL.md",
 		"reference/token-usage/scripts/cost_report.py",


### PR DESCRIPTION
## Summary
- Add an evidence-verification gate reference under `academic-research` for citation-bearing/submission-like academic writing.
- Route `academic-research/SKILL.md` to the gate before drafting papers, related work, literature reviews, References lists, or fast/readable academic drafts.
- Gate requires a verified literature matrix before confident prose, separates evidence tiers, treats search summaries as leads, and says speed should reduce scope rather than verification.
- Extend bundled swiss-knife populate test coverage for the new nested reference.
- Add a self-contained HTML explainer under `reports/`.

Closes #179.

## Validation
- `git diff --cached --check`
- `python3` routing/content sanity check for the new gate and router link
- `cd tui && go test ./internal/preset/`

## Caveats
- Advisory documentation/skill gate, not a hard runtime block.
- No config, release, or secret changes.
- Not merged.
