### PR TITLE
feat(skills): add textbook distillation guide

### DIFF
--- a/reports/issue174-textbook-distillation-explainer.html
+++ b/reports/issue174-textbook-distillation-explainer.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Textbook Distillation Skill — Explainer (Issue #174)</title>
+<style>
+  :root{
+    --bg:#0f1117; --panel:#171a22; --fg:#e7e9ee; --muted:#9aa0ac;
+    --accent:#6ea8fe; --accent-2:#c08cff; --ok:#5cd6a0; --warn:#e0a458;
+    --border:#262a34; --code:#1d2029; --maxw:60rem; --radius:12px;
+    --font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);font-family:var(--font);
+    line-height:1.65;font-size:17px}
+  header.hero{background:linear-gradient(135deg,#1a2238,#241a38);
+    border-bottom:1px solid var(--border);padding:3rem 1.5rem}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 1.5rem}
+  header.hero .wrap{padding:0}
+  .kicker{color:var(--accent);font-weight:700;letter-spacing:.08em;
+    text-transform:uppercase;font-size:.78rem}
+  h1{font-size:2.2rem;margin:.4rem 0 .6rem;line-height:1.15}
+  .lede{color:var(--muted);font-size:1.15rem;max-width:46rem}
+  main{padding:2.5rem 0}
+  section{margin:0 0 2.5rem}
+  h2{font-size:1.5rem;margin-top:0;padding-bottom:.3rem;border-bottom:2px solid var(--accent)}
+  h3{font-size:1.12rem;color:var(--accent-2)}
+  a{color:var(--accent)}
+  code{background:var(--code);padding:.12em .4em;border-radius:6px;
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em}
+  pre{background:var(--code);border:1px solid var(--border);border-radius:8px;
+    padding:1rem;overflow-x:auto}
+  .panel{background:var(--panel);border:1px solid var(--border);
+    border-radius:var(--radius);padding:1.3rem 1.5rem}
+  .grid{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .flow{display:flex;flex-wrap:wrap;gap:.5rem;align-items:stretch;margin:1rem 0}
+  .step{flex:1 1 150px;background:var(--panel);border:1px solid var(--border);
+    border-radius:10px;padding:.9rem 1rem;position:relative}
+  .step .n{display:inline-block;background:var(--accent);color:#0f1117;font-weight:700;
+    border-radius:50%;width:1.5rem;height:1.5rem;text-align:center;line-height:1.5rem;
+    font-size:.85rem;margin-bottom:.4rem}
+  .step h4{margin:.2rem 0 .3rem;font-size:1rem}
+  .step p{margin:0;color:var(--muted);font-size:.86rem}
+  .arrow{align-self:center;color:var(--muted);font-size:1.4rem}
+  table{border-collapse:collapse;width:100%;margin:1rem 0}
+  th,td{border:1px solid var(--border);padding:.55rem .7rem;text-align:left;vertical-align:top}
+  th{background:var(--code)}
+  .callout{border-left:5px solid var(--warn);background:#2a2114;border-radius:10px;
+    padding:.9rem 1.1rem;margin:1.2rem 0}
+  .callout.safe{border-color:var(--ok);background:#11251c}
+  .callout .label{font-weight:700;text-transform:uppercase;font-size:.75rem;
+    letter-spacing:.05em;display:block;margin-bottom:.35rem}
+  ul.checks{list-style:none;padding-left:0}
+  ul.checks li{padding:.3rem 0 .3rem 1.7rem;position:relative}
+  ul.checks li::before{content:"✓";position:absolute;left:0;color:var(--ok);font-weight:700}
+  .muted{color:var(--muted)}
+  footer{border-top:1px solid var(--border);color:var(--muted);font-size:.85rem;
+    padding:1.5rem 0;margin-top:2rem}
+  @media print{
+    body{background:#fff;color:#111;font-size:12pt}
+    header.hero{background:none;border-bottom:1px solid #ccc}
+    .panel,.step,pre,code{background:#f5f5f5;border-color:#ccc}
+    a{color:#1a4fd0}
+  }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="kicker">LingTai · Issue #174 · Feature Explainer</div>
+    <h1>Textbook Distillation Skill</h1>
+    <p class="lede">Teach yourself from any book, no instructor required. LingTai
+      distills a textbook into a structured learning track and ships
+      self-contained HTML lecture notes in the style you ask for — with worked
+      examples, exercises, and checkpoints to tell you when you're ready to move on.</p>
+  </div>
+</header>
+
+<main class="wrap">
+
+  <section>
+    <h2>What it does</h2>
+    <p>This adds a bundled utility skill,
+      <code>textbook-distillation</code>, under
+      <code>tui/internal/preset/skills/</code>. When you ask LingTai to help you
+      study a book on your own, the agent loads this skill and runs a five-phase,
+      human-in-the-loop workflow that turns the source into lessons you can work
+      through at your own pace.</p>
+    <div class="grid">
+      <div class="panel"><h3>Distill, don't copy</h3><p class="muted">Concepts are
+        re-explained in the agent's own words with fresh examples — never a
+        reproduction of the author's text.</p></div>
+      <div class="panel"><h3>Your style</h3><p class="muted">Palette, layout,
+        emphasis pattern, tone, and density are yours to specify. The notes are
+        built for that style from the start.</p></div>
+      <div class="panel"><h3>Active learning</h3><p class="muted">Every lesson
+        carries worked examples, graded exercises, and a checkpoint with
+        collapsible answers.</p></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>The workflow</h2>
+    <div class="flow">
+      <div class="step"><span class="n">1</span><h4>Intake</h4>
+        <p>Identify the source, confirm authorized access, capture the learning
+          goal and style.</p></div>
+      <div class="arrow">→</div>
+      <div class="step"><span class="n">2</span><h4>Chapter map</h4>
+        <p>Skeleton of units, core concepts, prerequisites, weight, and source
+          locations. <em>You approve scope.</em></p></div>
+      <div class="arrow">→</div>
+      <div class="step"><span class="n">3</span><h4>Lesson plan</h4>
+        <p>A sequence of one-sitting lessons with objectives, examples,
+          exercises, checkpoints. <em>You approve granularity.</em></p></div>
+      <div class="arrow">→</div>
+      <div class="step"><span class="n">4</span><h4>HTML notes</h4>
+        <p>One self-contained styled <code>.html</code> per lesson, MathJax-ready,
+          validated.</p></div>
+      <div class="arrow">→</div>
+      <div class="step"><span class="n">5</span><h4>Review loop</h4>
+        <p>React to lesson 1, then batch the rest plus an index page.</p></div>
+    </div>
+    <p class="muted">Phases 2 and 3 are approval gates: nothing gets generated as
+      HTML until you've confirmed the map and the plan match <em>your</em> goal.</p>
+  </section>
+
+  <section>
+    <h2>What a lesson contains</h2>
+    <table>
+      <tr><th>Section</th><th>Purpose</th></tr>
+      <tr><td>Header &amp; provenance</td><td>Title, objective, source citation
+        (title/author/edition/pages), timestamp, and a caveat that these are
+        re-explained notes — not the original.</td></tr>
+      <tr><td>Prerequisites</td><td>Links back to the lessons you should have done.</td></tr>
+      <tr><td>Concept exposition</td><td>The teaching, in the agent's own words,
+        with definitions boxed and math rendered via MathJax.</td></tr>
+      <tr><td>Worked example</td><td>The reasoning stepped through explicitly.</td></tr>
+      <tr><td>Exercises</td><td>2–5 problems, easy → hard, solutions hidden behind
+        <code>&lt;details&gt;</code> so you try first.</td></tr>
+      <tr><td>Checkpoint</td><td>3–6 self-check questions with collapsible answers —
+        passing them is the signal to advance.</td></tr>
+    </table>
+  </section>
+
+  <section>
+    <h2>Customizable HTML</h2>
+    <p>A bundled template at
+      <code>assets/lesson-template.html</code> wires up the hard parts so the agent
+      can focus on teaching:</p>
+    <ul class="checks">
+      <li>CSS variables at the top of <code>&lt;style&gt;</code> for palette, accent, and density</li>
+      <li>MathJax configured for <code>\( … \)</code> inline and <code>\[ … \]</code> display math</li>
+      <li>Definition / key-formula / warning callout boxes for a consistent emphasis hierarchy</li>
+      <li>Collapsible exercise solutions and checkpoint answers</li>
+      <li>A print stylesheet that drops navigation and expands answers</li>
+      <li>One file, no external assets except the MathJax CDN — open it anywhere</li>
+    </ul>
+    <p class="muted">HTML mechanics (skeleton, MathJax rules, validation checklist)
+      are reused from the existing <code>swiss-knife → html-report</code> reference
+      rather than duplicated, so equation handling stays consistent across LingTai.</p>
+  </section>
+
+  <section>
+    <h2 id="safety">Source limits, copyright &amp; safety</h2>
+    <div class="callout">
+      <span class="label">Boundaries — not optional</span>
+      The skill is built to help you learn from a book, not to pirate it.
+    </div>
+    <ul class="checks">
+      <li><strong>Distill, do not reproduce</strong> — re-explain concepts; no
+        pasted chapters, no copied prose, no recreated figures.</li>
+      <li><strong>No piracy enabler</strong> — requests like "summarize the whole
+        book so I don't have to buy it" are declined in favor of legitimate study aids.</li>
+      <li><strong>Always cite the source</strong> — every artifact names the
+        title, author, edition, and page range, with a provenance caveat.</li>
+      <li><strong>Confirm authorized access</strong> — the agent only works from
+        material you can point to a legitimate source for.</li>
+      <li><strong>Flag knowledge limits</strong> — when teaching from general
+        knowledge rather than the specific edition, it says so and tells you to
+        verify against the source.</li>
+    </ul>
+    <div class="callout safe">
+      <span class="label">Net effect</span>
+      You get a study guide you can trust: cited, honest about its limits, and
+      designed around active practice rather than passive summary.
+    </div>
+  </section>
+
+  <section>
+    <h2>How it ships</h2>
+    <p>Preset skills are auto-discovered through a Go <code>//go:embed skills</code>
+      directive, so adding the <code>textbook-distillation/</code> directory is all
+      that's needed — no registry or index edit. On TUI startup the bundle is
+      extracted to <code>~/.lingtai-tui/utilities/</code> where agents read it.
+      Frontmatter and catalog integrity are covered by the existing
+      <code>internal/preset</code> and <code>internal/tui</code> Go tests.</p>
+    <pre>tui/internal/preset/skills/textbook-distillation/
+├── SKILL.md                      ← the five-phase workflow
+└── assets/
+    └── lesson-template.html       ← themeable, MathJax-ready lesson scaffold</pre>
+  </section>
+
+</main>
+
+<footer class="wrap">
+  Generated 2026-06-09T03:42:25Z · LingTai issue #174 ·
+  Self-contained explainer for the Textbook Distillation skill.
+</footer>
+
+</body>
+</html>

--- a/tui/internal/preset/skills/textbook-distillation/SKILL.md
+++ b/tui/internal/preset/skills/textbook-distillation/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: textbook-distillation
+description: >
+  Turn a textbook or long-form source into a self-paced learning track:
+  intake the material, build a chapter map, draft a lesson plan, then
+  generate self-contained HTML lecture notes in a style the human
+  specifies (layout, palette, emphasis), each lesson carrying worked
+  examples, exercises, and checkpoint questions. Read this when the human
+  wants to study a book without a teacher, asks for "lecture notes" /
+  "study notes" / "course" / "syllabus" from a textbook or PDF, wants a
+  customized HTML study guide, or wants a chapter distilled into
+  teachable lessons. Do NOT use to reproduce or redistribute a
+  copyrighted book verbatim, to "summarize so I don't have to buy it,"
+  or for one-off factual lookups (just answer those directly).
+version: 1.0.0
+tags: [learning, study, textbook, lecture-notes, html, curriculum, self-paced]
+---
+
+# Textbook Distillation — Self-Paced Learning Tracks
+
+You are helping a human teach themselves from a textbook (or a long technical
+document, lecture transcript, or paper set) without a live instructor. Your job
+is to **distill** the source into a structured learning track and ship
+**self-contained HTML lecture notes** in the style the human asks for — not to
+copy the book.
+
+Distillation means: extract the concepts, structure, and worked logic, then
+re-explain them in your own words with your own examples. It does **not** mean
+reproducing the author's text. See [Source limits & safety](#source-limits--copyright--safety)
+before you intake anything — those boundaries shape every later step.
+
+## When to use
+
+- The human wants to study a book/course/PDF on their own and asks for notes,
+  a syllabus, a curriculum, or a "course" built from it.
+- The human wants a chapter (or the whole book) turned into teachable lessons
+  with exercises and checkpoints.
+- The human wants a **customized HTML study guide** — a specific look, palette,
+  or emphasis (e.g. "dark theme, lots of diagrams, define every term in a box").
+
+**Do NOT use** when:
+
+- The ask is a single factual question — answer it directly.
+- The human wants the book reproduced verbatim, a chapter pasted out, or a
+  "summary so I can skip buying it." That crosses the copyright line below —
+  decline and offer a legitimate distillation instead.
+- The source is something the human is not authorized to use (see safety).
+
+## Workflow at a glance
+
+```
+intake → chapter map → lesson plan → (per lesson) HTML lecture notes → review loop
+```
+
+Work the phases in order. Do not jump to generating HTML before the human has
+seen and approved the chapter map and lesson plan — that approval is what keeps
+the track aligned to *their* goal, not your guess at it. This is a multi-round,
+human-in-the-loop flow: **talk to the human through the active user-facing channel
+(mail/email or the relevant chat bridge), not internal scratch/text output**,
+because each phase needs their input.
+
+## Phase 1 — Intake the source
+
+Goal: know exactly what you are distilling and confirm you are allowed to.
+
+1. **Identify the source precisely.** Title, author, edition, and the format you
+   have access to (a PDF in the project, a URL, the human's own notes, a file the
+   human pasted). Record the path or link — you will cite it in every artifact.
+2. **Confirm authorization and scope.** Ask the human: do they own/have legal
+   access to this material? Which parts do they want covered — whole book, a
+   range of chapters, one topic? Do not proceed on material they cannot point to
+   a legitimate source for.
+3. **Capture the learning goal.** Why are they studying it — exam, project,
+   curiosity, teaching it onward? Their level (beginner / refresher / advanced)?
+   Time budget (one weekend vs. a semester)? These set lesson granularity.
+4. **Capture style constraints early** (see [Style constraints](#style-constraints-from-the-human)).
+   Collect them now so the lesson plan and the HTML are designed for them, not
+   retrofitted.
+
+If you only have a partial source (e.g. a table of contents but not the body),
+say so explicitly — you will distill structure from the ToC and re-teach concepts
+from your own knowledge, clearly labeled, rather than inventing the book's
+specific treatment.
+
+## Phase 2 — Build the chapter map
+
+A **chapter map** is the skeleton: the source's structure plus what each unit is
+*about* and what it depends on. It is the contract the human approves before any
+lesson is written.
+
+For each chapter / major section, capture:
+
+- **Unit** — chapter or section title and number.
+- **Core concepts** — the 3–8 ideas a learner must walk away with.
+- **Prerequisites** — which earlier units (or outside knowledge) it assumes.
+- **Difficulty / weight** — rough effort, so the track can be paced.
+- **Source location** — page range or section anchor, for citation.
+
+Render the map as a table and send it to the human. Ask: *Is this the right
+scope and ordering? Anything to drop, merge, or go deeper on?* Iterate until they
+approve. The map may reorder or merge the book's units to fit the learning goal —
+note where you deviate from the book's own order and why.
+
+## Phase 3 — Draft the lesson plan
+
+Turn the approved chapter map into a sequence of **lessons**. A lesson is one
+sitting's worth of learning — usually one chapter, or a slice of a dense one.
+
+For each lesson define:
+
+- **Title and one-line objective** ("After this lesson you can …").
+- **Concepts covered** — drawn from the chapter map, scoped to one sitting.
+- **Prerequisite lessons** — what must come first.
+- **Worked example(s)** — the concrete problem you will walk through.
+- **Exercises** — 2–5 practice problems, easy → hard.
+- **Checkpoint** — 3–6 self-check questions (with answers, collapsible) that
+  tell the learner whether they can move on.
+- **Estimated time.**
+
+Send the lesson plan for approval. This is the last gate before you generate
+HTML, so make sure granularity, ordering, and exercise depth match what the
+human wanted.
+
+## Phase 4 — Generate the HTML lecture notes
+
+Now produce the deliverable: **one self-contained HTML file per lesson** (or a
+single file for a short track), in the human's style.
+
+**Mechanics of good standalone HTML are owned by the `html-report` reference.**
+Read `~/.lingtai-tui/utilities/swiss-knife/reference/html-report/SKILL.md` (or
+load the `swiss-knife` skill and route to `html-report`) for the skeleton,
+artifact hygiene, the validation checklist, and — critically — **MathJax setup**,
+since lecture notes for technical books almost always contain equations. Do not
+duplicate that guidance here; follow it.
+
+A bundled starting template lives at
+`~/.lingtai-tui/utilities/textbook-distillation/assets/lesson-template.html`.
+Copy it, then apply the human's style and fill the lesson content. It already
+wires MathJax, a print stylesheet, collapsible checkpoint answers, callout
+boxes, and CSS variables for theming.
+
+Each lesson's HTML should contain, in order:
+
+1. **Header block** — lesson title, objective, source citation (title, author,
+   edition, page range), generation timestamp (`date -u +%Y-%m-%dT%H:%M:%SZ`),
+   and a one-line provenance caveat ("Distilled study notes — re-explained from
+   the source, not a reproduction of it.").
+2. **Prerequisites** — a short "before this lesson" note linking prior lessons.
+3. **Concept exposition** — the teaching, in *your own words*, with diagrams /
+   tables / analogies as the style calls for. Define terms in callout boxes.
+4. **Worked example(s)** — step through the reasoning explicitly.
+5. **Exercises** — numbered, increasing difficulty. Hide solutions behind a
+   `<details>` element so the learner attempts first.
+6. **Checkpoint** — self-check questions with collapsible answers; passing them
+   is the signal to advance.
+7. **Footer** — "next lesson" link and the source citation again.
+
+After writing each file, run the `html-report` validation checklist (file exists
+and non-empty, MathJax wired if math is present, no equations stuck in
+`<pre>`/`<code>`, links absolute, HTML parses). Write the files to a project-local
+path the human can find (e.g. `study/<book-slug>/lesson-NN.html`), never `/tmp`.
+
+## Phase 5 — Review loop
+
+Send the first lesson and ask the human to react to **both** the teaching and the
+style before you batch the rest — it is far cheaper to adjust the template once
+than to regenerate twenty files. Then proceed lesson by lesson (or in small
+batches), checking in. Offer an index page linking all lessons once the track is
+built.
+
+## Style constraints from the human
+
+Capture these in Phase 1 and apply them in Phase 4. If the human is vague,
+propose a default and confirm:
+
+- **Theme / palette** — light or dark, accent color, any brand colors. The
+  template exposes these as CSS variables at the top of `<style>`.
+- **Layout** — single column vs. sidebar nav; density (airy vs. compact).
+- **Emphasis pattern** — what gets boxed/highlighted (definitions, theorems,
+  warnings, key formulas). Honor the human's emphasis hierarchy consistently.
+- **Tone** — formal textbook, friendly tutor, terse cheat-sheet.
+- **Visual aids** — how much diagramming, whether to use tables for comparisons,
+  whether to include figures (describe-and-draw with HTML/SVG, do not copy the
+  book's figures — see safety).
+- **Length per lesson** — full exposition vs. condensed review.
+
+When the human gives a style, *reflect it back* in one line before generating, so
+a mismatch is caught before twenty files are produced.
+
+## Source limits, copyright & safety
+
+These boundaries are not optional. They apply from intake onward.
+
+- **Distill, do not reproduce.** Re-explain concepts in your own words with your
+  own examples. Do not copy the author's prose, do not paste chapters or long
+  passages, and do not recreate the book's figures/tables verbatim. Short quotes
+  for commentary are fine; wholesale reproduction is not.
+- **No piracy enabler.** Decline requests framed as "summarize the whole book so
+  I don't have to buy/read it" or "give me the full text." Offer legitimate
+  distillation (concepts, your own worked examples, study aids) instead.
+- **Always cite the source.** Every artifact names title, author, edition, and
+  the page/section range it draws from, plus a provenance caveat that these are
+  re-explained study notes, not the original.
+- **Confirm authorized access.** Only work from material the human can point to a
+  legitimate source for (owned copy, library/institutional access, open-access,
+  their own notes). If they cannot, stop and say so.
+- **Flag the limits of your knowledge.** When you teach from your own knowledge
+  rather than the specific source (e.g. you only have the ToC), label it clearly
+  so the learner knows what is the book's treatment vs. general background. Note
+  that your knowledge has a cutoff and the edition may differ — tell the human to
+  verify specifics against the actual source.
+- **Stay in the learner's interest.** No fabricated citations, no invented page
+  numbers, no confidently wrong technical claims. If unsure of a fact, say so and
+  point the learner to the source section to confirm.
+
+## Quick reference
+
+| Phase | Output | Gate before next phase |
+|---|---|---|
+| 1 Intake | source identified, goal + style captured, access confirmed | — |
+| 2 Chapter map | table: units, concepts, prereqs, weight, source location | human approves scope/order |
+| 3 Lesson plan | sequenced lessons w/ objective, examples, exercises, checkpoint | human approves granularity |
+| 4 HTML notes | one self-contained styled `.html` per lesson | passes html-report checklist |
+| 5 Review loop | first lesson reviewed, then batch + index page | human reacts to lesson 1 |
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Generating HTML before map/plan approval | Gate on human approval at phases 2 and 3 |
+| Pasting/paraphrasing the book closely | Re-explain in your own words with your own examples |
+| Equations inside `<pre>`/`<code>` | Follow `html-report` MathJax rules — they won't render otherwise |
+| Skipping exercises/checkpoints | A learning track without practice is just a summary |
+| Ignoring stated style, then regenerating all files | Reflect style back, review lesson 1 before batching |
+| Writing files to `/tmp` | Write to `study/<book-slug>/` so the human can find them |
+| Inventing the book's specific treatment from memory | Label own-knowledge sections; cite the source for specifics |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/tui/internal/preset/skills/textbook-distillation/assets/lesson-template.html
+++ b/tui/internal/preset/skills/textbook-distillation/assets/lesson-template.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- TODO: set a descriptive title — shows in browser tabs and saved filenames -->
+<title>Lesson NN — <!-- TODO lesson title --> | <!-- TODO book title --></title>
+
+<!-- MathJax: required if the lesson contains equations. Write inline math as
+     \( ... \) and display math as \[ ... \]. Never put equations in <pre>/<code>. -->
+<script>
+window.MathJax = {
+  tex: {
+    inlineMath: [['\\(', '\\)']],
+    displayMath: [['\\[', '\\]'], ['$$', '$$']],
+    processEscapes: true
+  },
+  svg: { fontCache: 'global' }
+};
+</script>
+<script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+
+<style>
+/* ─────────────────────────────────────────────────────────────────────
+   THEME — edit these CSS variables to match the human's requested style.
+   (palette, accent, density). Everything below references them.
+   ───────────────────────────────────────────────────────────────────── */
+:root {
+  --bg:        #ffffff;
+  --fg:        #1c1c1e;
+  --muted:     #6b6b70;
+  --accent:    #2563eb;   /* links, headings rule, primary emphasis */
+  --accent-2:  #7c3aed;   /* secondary emphasis */
+  --def-bg:    #eef4ff;   /* definition callout */
+  --def-bd:    #2563eb;
+  --warn-bg:   #fff4e5;   /* warning callout */
+  --warn-bd:   #d97706;
+  --key-bg:    #f3eaff;   /* key-formula / theorem callout */
+  --key-bd:    #7c3aed;
+  --code-bg:   #f4f4f6;
+  --border:    #e3e3e8;
+  --maxw:      52rem;     /* content width — lower = denser */
+  --pad:       1.5rem;
+  --radius:    10px;
+  --font:      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+/* Dark theme example — uncomment / adapt if the human asked for dark:
+:root {
+  --bg:#15171c; --fg:#e6e6ea; --muted:#9a9aa3; --accent:#6ea8fe; --accent-2:#c08cff;
+  --def-bg:#1b2740; --def-bd:#6ea8fe; --warn-bg:#3a2c14; --warn-bd:#e0a458;
+  --key-bg:#2a2140; --key-bd:#c08cff; --code-bg:#1d1f25; --border:#2c2f37;
+}
+*/
+
+* { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+body {
+  margin: 0; background: var(--bg); color: var(--fg);
+  font-family: var(--font); line-height: 1.65; font-size: 17px;
+}
+main { max-width: var(--maxw); margin: 0 auto; padding: var(--pad); }
+
+h1, h2, h3 { line-height: 1.25; }
+h1 { font-size: 1.9rem; margin: 0 0 .3rem; }
+h2 { font-size: 1.4rem; margin-top: 2.2rem; padding-bottom: .25rem;
+     border-bottom: 2px solid var(--accent); }
+h3 { font-size: 1.12rem; margin-top: 1.6rem; color: var(--accent-2); }
+a { color: var(--accent); }
+code, pre { background: var(--code-bg); border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+code { padding: .1em .35em; font-size: .92em; }
+pre { padding: 1rem; overflow-x: auto; border: 1px solid var(--border); }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid var(--border); padding: .5rem .7rem; text-align: left; }
+th { background: var(--code-bg); }
+
+/* Header / provenance block */
+.lesson-head { border: 1px solid var(--border); border-radius: var(--radius);
+  padding: var(--pad); margin-bottom: 1.5rem; }
+.lesson-head .objective { font-weight: 600; }
+.provenance { color: var(--muted); font-size: .85rem; margin-top: .6rem; }
+
+/* Callout boxes — emphasis hierarchy. Re-map to the human's requested pattern. */
+.callout { border-left: 5px solid var(--accent); border-radius: var(--radius);
+  padding: .8rem 1rem; margin: 1.1rem 0; }
+.callout .label { font-weight: 700; font-size: .78rem; letter-spacing: .04em;
+  text-transform: uppercase; display: block; margin-bottom: .3rem; }
+.def  { background: var(--def-bg);  border-color: var(--def-bd); }
+.warn { background: var(--warn-bg); border-color: var(--warn-bd); }
+.key  { background: var(--key-bg);  border-color: var(--key-bd); }
+
+/* Worked example */
+.example { border: 1px dashed var(--border); border-radius: var(--radius);
+  padding: 1rem; margin: 1.2rem 0; }
+.example > .label { font-weight: 700; color: var(--accent-2); }
+
+/* Exercises & checkpoint — solutions/answers collapsed so the learner tries first */
+details { border: 1px solid var(--border); border-radius: 8px; padding: .5rem .8rem;
+  margin: .6rem 0; background: var(--code-bg); }
+summary { cursor: pointer; font-weight: 600; }
+details[open] summary { margin-bottom: .5rem; }
+ol.exercises > li { margin: .9rem 0; }
+
+nav.lesson-nav { display: flex; justify-content: space-between;
+  border-top: 1px solid var(--border); margin-top: 2.5rem; padding-top: 1rem; }
+
+/* Print: drop nav, widen margins, keep callouts readable */
+@media print {
+  nav.lesson-nav { display: none; }
+  body { font-size: 12pt; }
+  main { max-width: none; }
+  /* Reveal collapsed answers on paper without requiring the open attribute. */
+  details:not([open]) > *:not(summary) { display: revert; }
+}
+</style>
+</head>
+<body>
+<main>
+
+  <!-- ── Header / provenance ─────────────────────────────────────────── -->
+  <header class="lesson-head">
+    <h1>Lesson NN — <!-- TODO lesson title --></h1>
+    <p class="objective">Objective: After this lesson you can <!-- TODO --></p>
+    <p>Prerequisites: <a href="lesson-(NN-1).html"><!-- TODO prior lesson --></a></p>
+    <p class="provenance">
+      Source: <!-- TODO Title, Author, Edition -->, pp. <!-- TODO range -->.
+      Generated <!-- TODO YYYY-MM-DDTHH:MM:SSZ -->.
+      Distilled study notes — concepts re-explained from the source, not a
+      reproduction of it.
+    </p>
+  </header>
+
+  <!-- ── Concept exposition (your own words) ─────────────────────────── -->
+  <section id="concepts">
+    <h2>Concepts</h2>
+
+    <div class="callout def">
+      <span class="label">Definition</span>
+      <!-- TODO define a key term -->
+    </div>
+
+    <p><!-- TODO teach the concept in your own words. Inline math like \(x^2\). --></p>
+
+    <p>Display math renders centered:</p>
+    \[ <!-- TODO equation, e.g. --> E = mc^2 \]
+
+    <div class="callout key">
+      <span class="label">Key formula</span>
+      <!-- TODO the formula or theorem the learner must remember -->
+    </div>
+
+    <div class="callout warn">
+      <span class="label">Watch out</span>
+      <!-- TODO a common pitfall or misconception -->
+    </div>
+  </section>
+
+  <!-- ── Worked example ──────────────────────────────────────────────── -->
+  <section id="worked-example">
+    <h2>Worked example</h2>
+    <div class="example">
+      <span class="label">Example</span>
+      <p><!-- TODO state the problem --></p>
+      <p><!-- TODO step through the reasoning explicitly, step by step --></p>
+    </div>
+  </section>
+
+  <!-- ── Exercises (solutions hidden) ────────────────────────────────── -->
+  <section id="exercises">
+    <h2>Exercises</h2>
+    <ol class="exercises">
+      <li><!-- TODO easy -->
+        <details><summary>Show solution</summary><!-- TODO --></details>
+      </li>
+      <li><!-- TODO medium -->
+        <details><summary>Show solution</summary><!-- TODO --></details>
+      </li>
+      <li><!-- TODO hard -->
+        <details><summary>Show solution</summary><!-- TODO --></details>
+      </li>
+    </ol>
+  </section>
+
+  <!-- ── Checkpoint: pass these before advancing ─────────────────────── -->
+  <section id="checkpoint">
+    <h2>Checkpoint</h2>
+    <p>If you can answer these without looking back, you are ready for the next lesson.</p>
+    <details><summary>1. <!-- TODO question --></summary><!-- TODO answer --></details>
+    <details><summary>2. <!-- TODO question --></summary><!-- TODO answer --></details>
+    <details><summary>3. <!-- TODO question --></summary><!-- TODO answer --></details>
+  </section>
+
+  <nav class="lesson-nav">
+    <a href="lesson-(NN-1).html">&larr; Previous</a>
+    <a href="index.html">Index</a>
+    <a href="lesson-(NN+1).html">Next &rarr;</a>
+  </nav>
+
+  <footer class="provenance">
+    Source: <!-- TODO Title, Author, Edition -->. Re-explained study notes, not
+    the original text. Verify specifics against the source.
+  </footer>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a textbook-distillation skill and HTML lesson template for self-paced learning tracks, with source/copyright guardrails and review fixes for channel wording and print CSS.

Closes #174.

## Validation

- `cd tui && go test ./internal/preset/`
- `git diff --check HEAD`
- HTML parser sanity check for the PR explainer under `reports/`

## Review

Jason requested four-model review before opening PR. Reports are local under:
`/Users/huangzesen/work/projects/lingtai-dev/dev-3/.lingtai/lingtaidev3bot/reports/five-simple-issues-20260609/multimodel-review`

- Codex: reviewed all five branches; no BLOCK findings. WARNs on #172/#174 were addressed before this PR was opened.
- GLM: reviewed all five branches; no BLOCK findings. Suggested #145 content anchor test was added before this PR was opened.
- DeepSeek: reviewed all five branches; no BLOCK findings. Suggested #172 cache/wording hygiene was addressed before this PR was opened.
- MiMo: reviewed all five branches; all PASS; cosmetic #196 stale comment was fixed before this PR was opened.

## Explainer

See `reports/` in this branch for the self-contained HTML explainer.
