### PR TITLE
Add Codex reasoning effort preset option

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -461,6 +461,7 @@
   "preset_editor.field_provider": "provider",
   "preset_editor.field_model": "model",
   "preset_editor.field_service_tier": "service_tier",
+  "preset_editor.field_thinking": "Reasoning effort",
   "preset_editor.field_api_compat": "api_compat",
   "preset_editor.field_base_url": "base_url",
   "preset_editor.field_api_key_env": "api_key_env",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -456,6 +456,7 @@
   "preset_editor.field_provider": "提供商",
   "preset_editor.field_model": "模型",
   "preset_editor.field_service_tier": "服务层",
+  "preset_editor.field_thinking": "推理强度",
   "preset_editor.field_api_compat": "API 兼容",
   "preset_editor.field_base_url": "端点",
   "preset_editor.field_api_key_env": "密钥环境变量",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -456,6 +456,7 @@
   "preset_editor.field_provider": "提供商",
   "preset_editor.field_model": "模型",
   "preset_editor.field_service_tier": "服务层级",
+  "preset_editor.field_thinking": "推理强度",
   "preset_editor.field_api_compat": "API 兼容",
   "preset_editor.field_base_url": "端点",
   "preset_editor.field_api_key_env": "密钥环境变量",

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -216,6 +216,9 @@ func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
 	if _, ok := llm["service_tier"]; ok {
 		t.Fatalf("codex preset default should omit llm.service_tier; got %#v", llm["service_tier"])
 	}
+	if _, ok := llm["thinking"]; ok {
+		t.Fatalf("codex preset default should omit llm.thinking; got %#v", llm["thinking"])
+	}
 
 	tmpDir := t.TempDir()
 	lingtaiDir := filepath.Join(tmpDir, ".lingtai")
@@ -239,6 +242,9 @@ func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
 	generatedLLM := manifest["llm"].(map[string]interface{})
 	if _, ok := generatedLLM["service_tier"]; ok {
 		t.Fatalf("generated codex init.json should omit llm.service_tier; got %#v", generatedLLM["service_tier"])
+	}
+	if _, ok := generatedLLM["thinking"]; ok {
+		t.Fatalf("generated codex init.json should omit llm.thinking; got %#v", generatedLLM["thinking"])
 	}
 }
 

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -49,6 +49,7 @@ const (
 	feProvider
 	feModel
 	feServiceTier
+	feThinking
 	feAPICompat
 	feBaseURL
 	feAPIKey
@@ -77,7 +78,7 @@ var capFieldNames = map[editorField]string{
 // optional/provider-conditional capabilities appear as editable rows.
 var editorFieldOrder = []editorField{
 	feName, feSummary, feTier, feGains, feLoses,
-	feProvider, feModel, feServiceTier, feAPICompat, feBaseURL, feAPIKey,
+	feProvider, feModel, feServiceTier, feThinking, feAPICompat, feBaseURL, feAPIKey,
 	feCapWebSearch, feCapVision,
 	feSave,
 }
@@ -140,6 +141,10 @@ var providerModels = map[string][]string{
 }
 
 var codexServiceTierOptions = []string{"normal", "fast"}
+
+var codexThinkingOptions = []string{"low", "medium", "high", "xhigh"}
+
+const presetEditorFieldLabelWidth = 18
 
 // modelHasVision reports whether a given model accepts image input.
 // Drives both the disabled-row rendering and the model-switch default
@@ -606,7 +611,7 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 			m.input.Focus()
 			m.mode = emInline
 		}
-	case feServiceTier:
+	case feServiceTier, feThinking:
 		if m.isCodexProvider() {
 			m.cycleFocused(+1)
 		}
@@ -866,6 +871,30 @@ func (m *PresetEditorModel) setCodexServiceTier(tier string) {
 	llm["service_tier"] = "fast"
 }
 
+func (m PresetEditorModel) codexThinking() string {
+	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
+	switch asString(llm["thinking"]) {
+	case "low", "medium", "high", "xhigh":
+		return asString(llm["thinking"])
+	default:
+		return "high"
+	}
+}
+
+func (m *PresetEditorModel) setCodexThinking(effort string) {
+	llm := m.llmMap()
+	if asString(llm["provider"]) != "codex" {
+		delete(llm, "thinking")
+		return
+	}
+	switch effort {
+	case "low", "medium", "xhigh":
+		llm["thinking"] = effort
+	default:
+		delete(llm, "thinking")
+	}
+}
+
 func normalizeServiceTier(manifest map[string]interface{}) {
 	llm, _ := manifest["llm"].(map[string]interface{})
 	if llm == nil || asString(llm["provider"]) != "codex" {
@@ -875,6 +904,28 @@ func normalizeServiceTier(manifest map[string]interface{}) {
 		return
 	}
 	delete(llm, "service_tier")
+}
+
+func normalizeThinking(manifest map[string]interface{}) {
+	llm, _ := manifest["llm"].(map[string]interface{})
+	if llm == nil {
+		return
+	}
+	if asString(llm["provider"]) != "codex" {
+		delete(llm, "thinking")
+		return
+	}
+	switch asString(llm["thinking"]) {
+	case "low", "medium", "xhigh":
+		return
+	default:
+		delete(llm, "thinking")
+	}
+}
+
+func normalizeLLMForCommit(manifest map[string]interface{}) {
+	normalizeServiceTier(manifest)
+	normalizeThinking(manifest)
 }
 
 // setExtra writes into Description.Extra, allocating the map on first
@@ -916,6 +967,9 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "openrouter", "codex", "custom"}
 		newProvider := cycleString(opts, m.fieldString(f), dir)
 		m.llmMap()["provider"] = newProvider
+		if newProvider != "codex" {
+			delete(m.llmMap(), "thinking")
+		}
 		// Reset model to the new provider's first canonical entry when the
 		// current model isn't valid for the new provider. Without this, a
 		// minimax→zhipu switch leaves "MiniMax-M3" in model
@@ -964,6 +1018,10 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feServiceTier:
 		if m.isCodexProvider() {
 			m.setCodexServiceTier(cycleString(codexServiceTierOptions, m.codexServiceTier(), dir))
+		}
+	case feThinking:
+		if m.isCodexProvider() {
+			m.setCodexThinking(cycleString(codexThinkingOptions, m.codexThinking(), dir))
 		}
 	case feTier:
 		// Cycle ""→1→2→3→4→5→"" with → and reverse with ←. tierValues
@@ -1036,7 +1094,7 @@ func (m PresetEditorModel) commit() (PresetEditorModel, tea.Cmd) {
 			delete(llm, "api_key_env")
 		}
 	}
-	normalizeServiceTier(committed.Manifest)
+	normalizeLLMForCommit(committed.Manifest)
 	return m, func() tea.Msg {
 		return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 	}
@@ -1070,7 +1128,7 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 		m.mode = emBrowse
 		m.cloneNameInput.Blur()
 		committed := clonePresetForEditor(m.working)
-		normalizeServiceTier(committed.Manifest)
+		normalizeLLMForCommit(committed.Manifest)
 		return m, func() tea.Msg {
 			return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 		}
@@ -1088,7 +1146,7 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 		m.mode = emBrowse
 		m.cloneNameInput.Blur()
 		committed := clonePresetForEditor(m.working)
-		normalizeServiceTier(committed.Manifest)
+		normalizeLLMForCommit(committed.Manifest)
 		return m, func() tea.Msg {
 			return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 		}
@@ -1135,6 +1193,8 @@ func (m PresetEditorModel) fieldString(f editorField) string {
 		return s
 	case feServiceTier:
 		return m.codexServiceTier()
+	case feThinking:
+		return m.codexThinking()
 	case feAPICompat:
 		s, _ := llm["api_compat"].(string)
 		return s
@@ -1304,6 +1364,9 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 	if m.fieldVisible(feServiceTier) {
 		rows = append(rows, row(feServiceTier, m.row(feServiceTier, lbl("service_tier"), m.codexServiceTier(), width-4)))
 	}
+	if m.fieldVisible(feThinking) {
+		rows = append(rows, row(feThinking, m.row(feThinking, lbl("thinking"), m.codexThinking(), width-4)))
+	}
 	rows = append(rows, row(feAPICompat, m.row(feAPICompat, lbl("api_compat"), asString(llm["api_compat"]), width-4)))
 	rows = append(rows, row(feBaseURL, m.row(feBaseURL, lbl("base_url"), asString(llm["base_url"]), width-4)))
 	rows = append(rows, row(feAPIKey, m.row(feAPIKey, lbl("api_key"), m.fieldString(feAPIKey), width-4)))
@@ -1338,7 +1401,7 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 // strip render when the provider has a known model list, so all
 // options are visible at once and ←/→ visibly moves the dot.
 func (m PresetEditorModel) row(f editorField, key, value string, width int) string {
-	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Width(15)
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Width(presetEditorFieldLabelWidth)
 	marker := "  "
 	valStyle := lipgloss.NewStyle()
 	focused := editorFieldOrder[m.cursor] == f
@@ -1359,6 +1422,11 @@ func (m PresetEditorModel) row(f editorField, key, value string, width int) stri
 			return marker + keyStyle.Render(key) + strip
 		}
 	}
+	if f == feThinking {
+		if strip := m.thinkingRadioStrip(focused, valStyle); strip != "" {
+			return marker + keyStyle.Render(key) + strip
+		}
+	}
 	if f == feBaseURL {
 		if strip := m.baseURLRadioStrip(focused, valStyle); strip != "" {
 			return marker + keyStyle.Render(key) + strip
@@ -1368,7 +1436,7 @@ func (m PresetEditorModel) row(f editorField, key, value string, width int) stri
 		value = "—"
 	}
 	if f != feTier {
-		value = truncate(value, width-lipgloss.Width(marker)-15)
+		value = truncate(value, width-lipgloss.Width(marker)-presetEditorFieldLabelWidth)
 	}
 	return marker + keyStyle.Render(key) + valStyle.Render(value)
 }
@@ -1544,6 +1612,27 @@ func (m PresetEditorModel) serviceTierRadioStrip(focused bool, valStyle lipgloss
 	return strings.Join(parts, "  ")
 }
 
+func (m PresetEditorModel) thinkingRadioStrip(focused bool, valStyle lipgloss.Style) string {
+	if !m.isCodexProvider() {
+		return ""
+	}
+	current := m.codexThinking()
+	subtle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	parts := make([]string, 0, len(codexThinkingOptions))
+	for _, effort := range codexThinkingOptions {
+		if effort == current {
+			if focused {
+				parts = append(parts, valStyle.Render("● "+effort))
+			} else {
+				parts = append(parts, "● "+effort)
+			}
+		} else {
+			parts = append(parts, subtle.Render("○ "+effort))
+		}
+	}
+	return strings.Join(parts, "  ")
+}
+
 // baseURLRadioStrip renders the base_url field as a horizontal radio
 // strip showing region labels (e.g. "● CN  ○ INTL") when the current
 // provider has regional endpoints. Returns "" when there's no region
@@ -1579,7 +1668,7 @@ func (m PresetEditorModel) isCyclable(f editorField) bool {
 	switch f {
 	case feProvider, feAPICompat, feTier:
 		return true
-	case feServiceTier:
+	case feServiceTier, feThinking:
 		return m.isCodexProvider()
 	case feModel:
 		provider := asString(m.llmMap()["provider"])
@@ -1716,7 +1805,7 @@ func (m *PresetEditorModel) ensureFocusedVisible() {
 
 func (m PresetEditorModel) fieldVisible(f editorField) bool {
 	switch f {
-	case feServiceTier:
+	case feServiceTier, feThinking:
 		return m.isCodexProvider()
 	default:
 		return true

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -41,6 +41,10 @@ func testPresetEditorPreset() preset.Preset {
 }
 
 func testCodexPresetEditorPreset(serviceTier interface{}) preset.Preset {
+	return testCodexPresetEditorPresetWithThinking(serviceTier, nil)
+}
+
+func testCodexPresetEditorPresetWithThinking(serviceTier interface{}, thinking interface{}) preset.Preset {
 	llm := map[string]interface{}{
 		"provider":    "codex",
 		"model":       "gpt-5.5",
@@ -50,6 +54,9 @@ func testCodexPresetEditorPreset(serviceTier interface{}) preset.Preset {
 	}
 	if serviceTier != nil {
 		llm["service_tier"] = serviceTier
+	}
+	if thinking != nil {
+		llm["thinking"] = thinking
 	}
 	return preset.Preset{
 		Name:        "codex-test",
@@ -397,6 +404,145 @@ func TestPresetEditorCodexServiceTierDisplayAndCommitNormalization(t *testing.T)
 				t.Fatalf("committed service_tier=%q, want fast", got)
 			}
 		})
+	}
+}
+
+func TestPresetEditorCodexThinkingRowAndOptions(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset(nil), "en", nil, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+	view := m.View()
+
+	if !m.fieldVisible(feThinking) {
+		t.Fatalf("codex reasoning effort row should be visible")
+	}
+	if got := m.fieldString(feThinking); got != "high" {
+		t.Fatalf("empty llm.thinking displays %q, want high", got)
+	}
+	if !strings.Contains(view, "Reasoning effort") {
+		t.Fatalf("codex editor should render Reasoning effort row; view:\n%s", view)
+	}
+	for _, effort := range codexThinkingOptions {
+		if !strings.Contains(view, effort) {
+			t.Fatalf("codex editor should render thinking option %q; view:\n%s", effort, view)
+		}
+	}
+}
+
+func TestPresetEditorCodexThinkingSelectionAndCommit(t *testing.T) {
+	cases := []struct {
+		effort    string
+		wantSaved bool
+	}{
+		{effort: "low", wantSaved: true},
+		{effort: "medium", wantSaved: true},
+		{effort: "high"},
+		{effort: "xhigh", wantSaved: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.effort, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset(nil), "en", nil, "", false)
+			m.cursor = editorFieldOrderIndex(t, feThinking)
+			m.setCodexThinking(tc.effort)
+			if got := m.fieldString(feThinking); got != tc.effort {
+				t.Fatalf("thinking display = %q, want %q", got, tc.effort)
+			}
+
+			_, cmd := m.commit()
+			commit := cmd().(PresetEditorCommitMsg)
+			llm := commit.Preset.Manifest["llm"].(map[string]interface{})
+			got, saved := llm["thinking"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("committed thinking saved=%v, want %v; value=%#v", saved, tc.wantSaved, llm["thinking"])
+			}
+			if saved && got != tc.effort {
+				t.Fatalf("committed thinking=%q, want %q", got, tc.effort)
+			}
+		})
+	}
+}
+
+func TestPresetEditorCodexThinkingDisplayAndCommitNormalization(t *testing.T) {
+	cases := []struct {
+		name        string
+		thinking    interface{}
+		wantDisplay string
+		wantSaved   bool
+		wantValue   string
+	}{
+		{name: "absent", thinking: nil, wantDisplay: "high"},
+		{name: "explicit high", thinking: "high", wantDisplay: "high"},
+		{name: "low", thinking: "low", wantDisplay: "low", wantSaved: true, wantValue: "low"},
+		{name: "unknown", thinking: "turbo", wantDisplay: "high"},
+		{name: "wrong type", thinking: 12, wantDisplay: "high"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPresetWithThinking(nil, tc.thinking), "en", nil, "", false)
+			if got := m.fieldString(feThinking); got != tc.wantDisplay {
+				t.Fatalf("thinking display = %q, want %q", got, tc.wantDisplay)
+			}
+			_, cmd := m.commit()
+			commit := cmd().(PresetEditorCommitMsg)
+			llm := commit.Preset.Manifest["llm"].(map[string]interface{})
+			got, saved := llm["thinking"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("committed thinking saved=%v, want %v; value=%#v", saved, tc.wantSaved, llm["thinking"])
+			}
+			if saved && got != tc.wantValue {
+				t.Fatalf("committed thinking=%q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestPresetEditorThinkingHiddenAndRemovedForNonCodex(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	llm["thinking"] = "low"
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+	view := m.View()
+
+	if m.fieldVisible(feThinking) {
+		t.Fatalf("reasoning effort row should be hidden for non-codex provider")
+	}
+	if strings.Contains(view, "Reasoning effort") || strings.Contains(view, "llm.thinking") {
+		t.Fatalf("non-codex editor should not render thinking row; view:\n%s", view)
+	}
+
+	m.cursor = editorFieldOrderIndex(t, feServiceTier)
+	m.normalizeCursor()
+	if editorFieldOrder[m.cursor] == feThinking {
+		t.Fatalf("cursor landed on hidden thinking field for non-codex preset")
+	}
+
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if _, ok := committedLLM["thinking"]; ok {
+		t.Fatalf("non-codex commit should remove llm.thinking; got %#v", committedLLM["thinking"])
+	}
+}
+
+func TestPresetEditorProviderSwitchClearsThinking(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPresetWithThinking(nil, "low"), "en", nil, "", false)
+	m.cursor = editorFieldOrderIndex(t, feProvider)
+
+	m.cycleFocused(+1) // codex -> custom in provider picker order.
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	if got := llm["provider"]; got != "custom" {
+		t.Fatalf("provider after cycling from codex = %#v, want custom", got)
+	}
+	if _, ok := llm["thinking"]; ok {
+		t.Fatalf("provider switch away from codex should remove llm.thinking; got %#v", llm["thinking"])
+	}
+
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if _, ok := committedLLM["thinking"]; ok {
+		t.Fatalf("non-codex commit after provider switch should omit llm.thinking; got %#v", committedLLM["thinking"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a Codex-only `Reasoning effort` row to the preset editor
- expose `low`, `medium`, `high`, and `xhigh`, writing non-default selections to `manifest.llm.thinking`
- treat `high` as the default/normal value and omit it from saved JSON, matching kernel PR #245's default behavior
- remove/clean `manifest.llm.thinking` for non-Codex providers and provider switches

## Design

This follows kernel PR Lingtai-AI/lingtai-kernel#245, which makes explicit `manifest.llm.thinking` Codex-only and accepts `low|medium|high|xhigh`.

The TUI mirrors that narrow scope:

- row is visible only for `provider="codex"`
- invalid existing Codex values display as the default `high` and are omitted on save
- switching away from Codex removes `thinking`
- generated default Codex presets still omit `llm.thinking`

## Verification

Daemon implementation plus independent orchestrator review/verification:

- `cd tui && go test ./internal/preset ./internal/tui` → passed
- `cd tui && go test ./...` → passed
- `git diff --check` → passed

## Related

- Kernel counterpart: Lingtai-AI/lingtai-kernel#245
