### PR TITLE
Fix /help markdown viewer input routing

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -475,7 +475,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, tea.Quit
 		case "q":
 			// Only quit if not in a text input context
-			if a.currentView != appViewSetup && a.currentView != appViewFirstRun && a.currentView != appViewMail && a.currentView != appViewProps && a.currentView != appViewAddon && a.currentView != appViewNirvana && a.currentView != appViewLibrary && a.currentView != appViewProjects && a.currentView != appViewAgora && a.currentView != appViewLogin && a.currentView != appViewCodex && a.currentView != appViewMailbox && a.currentView != appViewSystem && a.currentView != appViewPresets && a.currentView != appViewDaemons {
+			if a.currentView != appViewSetup && a.currentView != appViewFirstRun && a.currentView != appViewMail && a.currentView != appViewProps && a.currentView != appViewAddon && a.currentView != appViewNirvana && a.currentView != appViewLibrary && a.currentView != appViewProjects && a.currentView != appViewAgora && a.currentView != appViewLogin && a.currentView != appViewCodex && a.currentView != appViewMailbox && a.currentView != appViewSystem && a.currentView != appViewPresets && a.currentView != appViewDaemons && a.currentView != appViewHelp {
 				return a, tea.Quit
 			}
 		}
@@ -550,6 +550,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case appViewDaemons:
 		updated, cmd := a.daemons.Update(msg)
 		a.daemons = updated
+		return a, cmd
+	case appViewHelp:
+		updated, cmd := a.help.Update(msg)
+		a.help = updated
 		return a, cmd
 	}
 

--- a/tui/internal/tui/app_test.go
+++ b/tui/internal/tui/app_test.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// runCmd executes a tea.Cmd and returns the message it produces (nil for a nil
+// cmd). Used to inspect what command an Update returned without running a full
+// program loop.
+func runCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+// helpApp builds an App parked in the /help view, sized so the inner markdown
+// viewport has real dimensions to scroll.
+func helpApp(t *testing.T) App {
+	t.Helper()
+	a := App{currentView: appViewHelp, help: NewHelpModel()}
+	m, _ := a.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	return m.(App)
+}
+
+// TestHelpViewQClosesNotQuit guards the regression where /help could not be
+// exited: with appViewHelp missing from the global "q" exclusion, pressing q
+// in the help view quit the whole app instead of closing the viewer. The fix
+// routes q into HelpModel, which emits MarkdownViewerCloseMsg.
+func TestHelpViewQClosesNotQuit(t *testing.T) {
+	a := helpApp(t)
+
+	updated, cmd := a.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+
+	if _, ok := runCmd(cmd).(tea.QuitMsg); ok {
+		t.Fatal("q in /help quit the app; want viewer close")
+	}
+	if _, ok := runCmd(cmd).(MarkdownViewerCloseMsg); !ok {
+		t.Fatalf("q in /help did not emit MarkdownViewerCloseMsg; cmd produced %T", runCmd(cmd))
+	}
+	_ = updated
+}
+
+// TestHelpViewCloseReturnsToMail verifies App routes MarkdownViewerCloseMsg
+// from the help viewer back to the mail view.
+func TestHelpViewCloseReturnsToMail(t *testing.T) {
+	a := helpApp(t)
+
+	updated, _ := a.Update(MarkdownViewerCloseMsg{})
+
+	if got := updated.(App).currentView; got != appViewMail {
+		t.Fatalf("after close, currentView = %v, want appViewMail", got)
+	}
+}
+
+// TestHelpViewScrollReachesViewport guards the regression where pgdown/scroll
+// keys never reached the markdown viewport because appViewHelp was omitted from
+// the "forward to current view" switch. A pgdown should move the right viewport
+// off its top position.
+func TestHelpViewScrollReachesViewport(t *testing.T) {
+	a := helpApp(t)
+
+	if !a.help.inner.rightVP.AtTop() {
+		t.Fatal("precondition: help viewport should start at top")
+	}
+	updated, _ := a.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	if updated.(App).help.inner.rightVP.AtTop() {
+		t.Fatal("pgdown in /help did not scroll viewport off the top")
+	}
+}
+
+// TestHelpViewMouseWheelReachesViewport is the mouse analogue: a wheel-down
+// event must reach the inner viewport and move it off its top position.
+func TestHelpViewMouseWheelReachesViewport(t *testing.T) {
+	a := helpApp(t)
+
+	if !a.help.inner.rightVP.AtTop() {
+		t.Fatal("precondition: help viewport should start at top")
+	}
+	updated, _ := a.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	if updated.(App).help.inner.rightVP.AtTop() {
+		t.Fatal("mouse wheel in /help did not scroll viewport off the top")
+	}
+}


### PR DESCRIPTION
## Summary
- route `/help` key and mouse events through `HelpModel` so the embedded markdown viewer can scroll and close
- keep `q` in `/help` from being handled as the global app quit shortcut
- add regression tests for close, return-to-mail, pgdown scrolling, and mouse-wheel scrolling

## Validation
- `git diff --check`
- `cd tui && go test ./...`
- `cd tui && make clean && make build`
