### PR TITLE
Group tool-call display by API call

### DIFF
--- a/tui/internal/fs/session.go
+++ b/tui/internal/fs/session.go
@@ -23,10 +23,11 @@ type SessionEntry struct {
 	Body        string            `json:"body"`
 	Question    string            `json:"question,omitempty"`
 	Attachments []string          `json:"attachments,omitempty"`
-	Source      string            `json:"source,omitempty"`  // "human", "insight" — for inquiry entries
-	FireID      string            `json:"fire_id,omitempty"` // soul_flow fires — used to look up voices in soul_flow.jsonl
-	Sources     []string          `json:"sources,omitempty"` // notification entries — list of source keys (email, soul, system, ...)
-	Meta        *NotificationMeta `json:"meta,omitempty"`    // notification entries — vital signs at injection time (kernel build_meta + injection_seq)
+	Source      string            `json:"source,omitempty"`      // "human", "insight" — for inquiry entries
+	FireID      string            `json:"fire_id,omitempty"`     // soul_flow fires — used to look up voices in soul_flow.jsonl
+	Sources     []string          `json:"sources,omitempty"`     // notification entries — list of source keys (email, soul, system, ...)
+	Meta        *NotificationMeta `json:"meta,omitempty"`        // notification entries — vital signs at injection time (kernel build_meta + injection_seq)
+	ApiCallID   string            `json:"api_call_id,omitempty"` // llm/tool entries — one LLM API round-trip grouping id
 
 	// Delivered is a transient field propagated from MailMessage.Delivered.
 	// Only meaningful for Type == "mail". Not persisted to session.jsonl.
@@ -502,7 +503,7 @@ func parseEvent(line []byte) *SessionEntry {
 	}
 
 	switch eventType {
-	case "thinking", "diary", "text_input", "text_output", "tool_call", "tool_result", "insight", "soul_flow", "notification", "aed":
+	case "thinking", "diary", "text_input", "text_output", "tool_call", "tool_result", "llm_call", "llm_response", "insight", "soul_flow", "notification", "aed":
 		// ok
 	default:
 		return nil
@@ -522,6 +523,9 @@ func parseEvent(line []byte) *SessionEntry {
 		Ts:   ts,
 		Type: eventType,
 		Body: text,
+	}
+	if apiCallID, ok := raw["api_call_id"].(string); ok {
+		e.ApiCallID = apiCallID
 	}
 
 	if eventType == "insight" {
@@ -623,6 +627,13 @@ func extractSessionEventText(entry map[string]interface{}, eventType string) str
 			return fmt.Sprintf("(soul flow fired — %d voice(s))", int(count))
 		}
 		return strings.Join(lines, "\n")
+	case "llm_call":
+		if model, ok := entry["model"].(string); ok && model != "" {
+			return "llm call " + model
+		}
+		return "llm call"
+	case "llm_response":
+		return "llm response"
 	case "notification":
 		// Prefer the kernel-logged summary string when present (it
 		// already carries per-source counts in human-readable form).

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -44,6 +44,7 @@ type ChatMessage struct {
 	Sources     []string             // for Type=="notification": source keys (email, soul, system, ...)
 	Source      string               // for Type=="aed": subtype ("attempt" | "exhausted" | "timeout")
 	Meta        *fs.NotificationMeta // for Type=="notification": kernel vital signs at injection time (issue #40)
+	ApiCallID   string               // for tool_call/tool_result: LLM API round-trip grouping id
 }
 
 // ViewChangeMsg requests the app to switch views.
@@ -386,7 +387,24 @@ func (m *MailModel) buildMessages() {
 	allEntries := m.sessionCache.Entries()
 	chatMsgs := make([]ChatMessage, 0, len(allEntries))
 
+	currentApiCallID := ""
+	derivedApiCallSeq := 0
 	for _, e := range allEntries {
+		switch e.Type {
+		case "llm_response":
+			if e.ApiCallID != "" {
+				currentApiCallID = e.ApiCallID
+			} else {
+				derivedApiCallSeq++
+				currentApiCallID = fmt.Sprintf("derived:%d:%s", derivedApiCallSeq, e.Ts)
+			}
+		case "llm_call":
+			currentApiCallID = ""
+		case "tool_call", "tool_result":
+			if e.ApiCallID == "" {
+				e.ApiCallID = currentApiCallID
+			}
+		}
 		if !m.shouldShow(e) {
 			continue
 		}
@@ -421,6 +439,10 @@ func (m *MailModel) shouldShow(e fs.SessionEntry) bool {
 		return m.verbose >= verboseThinking
 	case "tool_call", "tool_result":
 		return m.verbose >= verboseExtended
+	case "llm_call", "llm_response":
+		// Hidden boundary markers used to derive tool-call grouping for older
+		// events that predate explicit api_call_id on tool events.
+		return false
 	case "insight":
 		// Human /btw inquiries (source "human") are always shown.
 		if e.Source == "human" {
@@ -503,6 +525,7 @@ func sessionEntryToChatMessage(e fs.SessionEntry, humanAddr string) ChatMessage 
 		Sources:     e.Sources,
 		Source:      e.Source,
 		Meta:        e.Meta,
+		ApiCallID:   e.ApiCallID,
 	}
 	if e.Type == "mail" {
 		cm.IsFromMe = e.From == "human"
@@ -868,7 +891,11 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 	sepStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
 
 	var b strings.Builder
+	var prevVisibleTool *ChatMessage
 	for _, msg := range msgs {
+		if !isToolMessageType(msg.Type) {
+			prevVisibleTool = nil
+		}
 		switch msg.Type {
 		case "thinking", "diary", "text_input", "text_output", "tool_call", "tool_result":
 			wrapWidth := m.width - 6
@@ -882,6 +909,9 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 			case "thinking", "diary", "text_input", "text_output":
 				evStyle = thinkingStyle
 			default:
+				if toolGroupSeparatorBefore(prevVisibleTool, msg) {
+					b.WriteString("\n")
+				}
 				evStyle = toolStyle
 				// Tool lines get a leading timestamp and honor the user's
 				// per-tool-call truncation setting (0 = full content, the default).
@@ -893,6 +923,10 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 			wrapped := lipgloss.NewStyle().Width(wrapWidth).Render(tsPrefix + "[" + msg.Type + "] " + body)
 			for _, line := range strings.Split(wrapped, "\n") {
 				b.WriteString(evStyle.Render("  "+RuneBullet+" "+line) + "\n")
+			}
+			if msg.Type == "tool_call" || msg.Type == "tool_result" {
+				msgCopy := msg
+				prevVisibleTool = &msgCopy
 			}
 
 		case "soul_flow":

--- a/tui/internal/tui/toolcall_display.go
+++ b/tui/internal/tui/toolcall_display.go
@@ -40,3 +40,25 @@ func truncateToolBody(body string, limit int) string {
 	hidden := len(runes) - limit
 	return string(runes[:limit]) + fmt.Sprintf("… (+%d chars)", hidden)
 }
+
+func isToolMessageType(t string) bool {
+	return t == "tool_call" || t == "tool_result"
+}
+
+// toolGroupSeparatorBefore reports whether a blank separator line should be
+// rendered before the current tool entry to visually group tool calls/results
+// by the LLM API response that produced them.
+func toolGroupSeparatorBefore(prev *ChatMessage, cur ChatMessage) bool {
+	if prev == nil || !isToolMessageType(prev.Type) || !isToolMessageType(cur.Type) {
+		return false
+	}
+	if prev.ApiCallID != "" || cur.ApiCallID != "" {
+		return prev.ApiCallID != cur.ApiCallID
+	}
+	// Fallback for already-built session streams that lack API grouping
+	// metadata entirely: a new tool_call immediately after a tool_result is
+	// the best visible boundary hint available. Fresh sessions should get
+	// either explicit api_call_id from the kernel or derived ids from hidden
+	// llm_response markers before reaching the renderer.
+	return prev.Type == "tool_result" && cur.Type == "tool_call"
+}

--- a/tui/internal/tui/toolcall_display_test.go
+++ b/tui/internal/tui/toolcall_display_test.go
@@ -83,6 +83,73 @@ func TestFormatToolTimestamp_GarbageIsEmpty(t *testing.T) {
 	}
 }
 
+func TestToolGroupSeparatorBefore_ExplicitApiCallIDChange(t *testing.T) {
+	prev := &ChatMessage{Type: "tool_result", ApiCallID: "api_one"}
+	cur := ChatMessage{Type: "tool_call", ApiCallID: "api_two"}
+	if !toolGroupSeparatorBefore(prev, cur) {
+		t.Errorf("tool entries from different api_call_id values should be separated")
+	}
+}
+
+func TestToolGroupSeparatorBefore_ExplicitApiCallIDSameGroup(t *testing.T) {
+	prev := &ChatMessage{Type: "tool_result", ApiCallID: "api_one"}
+	cur := ChatMessage{Type: "tool_call", ApiCallID: "api_one"}
+	if toolGroupSeparatorBefore(prev, cur) {
+		t.Errorf("tool entries from the same api_call_id should stay grouped")
+	}
+}
+
+func TestToolGroupSeparatorBefore_ConsecutiveCallsStayGrouped(t *testing.T) {
+	prev := &ChatMessage{Type: "tool_call"}
+	cur := ChatMessage{Type: "tool_call"}
+	if toolGroupSeparatorBefore(prev, cur) {
+		t.Errorf("consecutive tool_calls without grouping metadata should stay grouped")
+	}
+}
+
+func TestToolGroupSeparatorBefore_ResultAfterCallStaysGrouped(t *testing.T) {
+	prev := &ChatMessage{Type: "tool_call"}
+	cur := ChatMessage{Type: "tool_result"}
+	if toolGroupSeparatorBefore(prev, cur) {
+		t.Errorf("tool_result following its tool_call should not be separated")
+	}
+}
+
+func TestToolGroupSeparatorBefore_LegacyNewCallAfterResultFallback(t *testing.T) {
+	prev := &ChatMessage{Type: "tool_result"}
+	cur := ChatMessage{Type: "tool_call"}
+	if !toolGroupSeparatorBefore(prev, cur) {
+		t.Errorf("legacy tool_call after tool_result should get a fallback separator")
+	}
+}
+
+func TestToolGroupSeparatorBefore_FirstToolHasNoSeparator(t *testing.T) {
+	if toolGroupSeparatorBefore(nil, ChatMessage{Type: "tool_call"}) {
+		t.Errorf("first tool entry must not get a leading separator")
+	}
+	if toolGroupSeparatorBefore(nil, ChatMessage{Type: "tool_result"}) {
+		t.Errorf("first tool entry must not get a leading separator")
+	}
+}
+
+func TestToolGroupSeparatorBefore_NonToolBoundariesNoSeparator(t *testing.T) {
+	cases := []struct{ prev, cur string }{
+		{"thinking", "tool_call"},
+		{"text_output", "tool_call"},
+		{"mail", "tool_call"},
+		{"tool_result", "thinking"},
+		{"tool_call", "mail"},
+		{"thinking", "thinking"},
+	}
+	for _, c := range cases {
+		prev := &ChatMessage{Type: c.prev, ApiCallID: "api_one"}
+		cur := ChatMessage{Type: c.cur, ApiCallID: "api_two"}
+		if toolGroupSeparatorBefore(prev, cur) {
+			t.Errorf("non-tool boundary (%q→%q) must not get a tool-group separator", c.prev, c.cur)
+		}
+	}
+}
+
 func TestTruncateToolBody_DeterministicByRune(t *testing.T) {
 	// Multi-byte runes must not be split mid-codepoint.
 	body := strings.Repeat("世", 300) // each is 3 bytes, 1 rune
@@ -96,5 +163,32 @@ func TestTruncateToolBody_DeterministicByRune(t *testing.T) {
 	// First 100 runes retained.
 	if !strings.HasPrefix(got, strings.Repeat("世", 100)) {
 		t.Errorf("must retain first 100 runes intact")
+	}
+}
+
+func TestRenderMessages_InsertsBlankLineBetweenApiCallGroups(t *testing.T) {
+	m := MailModel{width: 100}
+	out := m.renderMessages([]ChatMessage{
+		{Type: "tool_call", Body: "read({})", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:26Z"},
+		{Type: "tool_result", Body: "read → ok", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:27Z"},
+		{Type: "tool_call", Body: "bash({})", ApiCallID: "api_two", Timestamp: "2026-06-08T07:08:28Z"},
+	})
+	if !strings.Contains(out, "read → ok") || !strings.Contains(out, "bash({})") {
+		t.Fatalf("rendered output missing tool bodies: %q", out)
+	}
+	if !strings.Contains(out, "read → ok") || !strings.Contains(out, "\n\n") {
+		t.Fatalf("expected a blank separator line between api groups, got %q", out)
+	}
+}
+
+func TestRenderMessages_DoesNotSeparateSameApiCallGroup(t *testing.T) {
+	m := MailModel{width: 100}
+	out := m.renderMessages([]ChatMessage{
+		{Type: "tool_call", Body: "read({})", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:26Z"},
+		{Type: "tool_result", Body: "read → ok", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:27Z"},
+		{Type: "tool_call", Body: "bash({})", ApiCallID: "api_one", Timestamp: "2026-06-08T07:08:28Z"},
+	})
+	if strings.Contains(out, "\n\n") {
+		t.Fatalf("same api_call_id should render as one group without blank separator: %q", out)
 	}
 }


### PR DESCRIPTION
## Summary\n- carry api_call_id from session events into chat messages\n- keep llm_call/llm_response as hidden grouping markers and derive groups for older logs without explicit tool ids\n- insert blank lines between rendered tool-call batches from different LLM API responses, with legacy fallback\n\nDepends on Lingtai-AI/lingtai-kernel#247 for explicit api_call_id stamping on fresh runtime events; includes fallback behavior for older logs.\n\n## Validation\n- git diff --check\n- cd tui && go test ./internal/fs ./internal/tui -count=1\n- cd tui && go test ./...\n- cd tui && make clean && make build