### PR TITLE
Fix kanban capabilities and daemon detail layout

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -606,6 +606,7 @@
   "daemons.interactions": "Interactions (full chat_history)",
   "daemons.result": "Result",
   "daemons.backend": "backend",
+  "daemons.preset": "preset",
   "daemons.current_tool": "current tool",
   "daemons.turn": "turn",
   "daemons.started": "started",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -606,6 +606,7 @@
   "daemons.interactions": "交互之程（全量 chat_history）",
   "daemons.result": "结果",
   "daemons.backend": "后端",
+  "daemons.preset": "禀赋",
   "daemons.current_tool": "当前之器",
   "daemons.turn": "轮",
   "daemons.started": "始",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -606,6 +606,7 @@
   "daemons.interactions": "交互过程（全量 chat_history）",
   "daemons.result": "结果",
   "daemons.backend": "后端",
+  "daemons.preset": "预设",
   "daemons.current_tool": "当前工具",
   "daemons.turn": "轮次",
   "daemons.started": "开始",

--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -13,6 +13,7 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 | **agent.go** | | |
 | `ReadAgent(dir)` | `tui/internal/fs/agent.go:26` | reads `.agent.json` → `AgentNode` (address, name, state, is_human, capabilities, location) |
 | `ParseCapabilities(raw)` | `tui/internal/fs/agent.go:56` | handles `[]string` and `[["name", {}], ...]` tuple formats |
+| `CapabilitiesForDisplay(manifest)` | `tui/internal/fs/agent.go:93` | prepends intrinsic caps (`system, soul, email, psyche`) to manifest caps, deduped, for operator display (kanban/props) |
 | `ReadInitManifest(dir)` | `tui/internal/fs/agent.go:85` | reads `init.json`, extracts manifest, flattens `llm.*` and `soul.delay` |
 | `DiscoverAgents(baseDir)` | `tui/internal/fs/agent.go:151` | scans for all subdirectories with `.agent.json` |
 | `ReadStatus(dir)` | `tui/internal/fs/agent.go:193` | reads `.status.json` → `AgentStatus` (tokens, runtime) |

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -80,6 +80,34 @@ func ParseCapabilities(raw json.RawMessage) []string {
 	return nil
 }
 
+// intrinsicCapabilities are the agent capabilities that always exist on a
+// live agent (the kernel wires them in unconditionally) but are not listed
+// in .agent.json's `capabilities` field. The kanban/props view should still
+// present them so the operator sees the complete capability surface.
+var intrinsicCapabilities = []string{"system", "soul", "email", "psyche"}
+
+// CapabilitiesForDisplay returns the operator-visible capability list:
+// the intrinsic capabilities first, followed by the manifest capabilities in
+// their original order, with duplicates removed. Manifest entries that
+// duplicate an intrinsic are dropped (the intrinsic keeps its leading slot).
+func CapabilitiesForDisplay(manifest []string) []string {
+	out := make([]string, 0, len(intrinsicCapabilities)+len(manifest))
+	seen := make(map[string]bool, len(intrinsicCapabilities)+len(manifest))
+	for _, c := range intrinsicCapabilities {
+		if !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	for _, c := range manifest {
+		if !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // ReadInitManifest reads init.json from dir, extracts manifest fields,
 // and flattens the llm sub-object (model, provider, base_url) to top level.
 func ReadInitManifest(dir string) (map[string]interface{}, error) {

--- a/tui/internal/fs/agent_test.go
+++ b/tui/internal/fs/agent_test.go
@@ -93,3 +93,83 @@ func TestReadAgent_NoManifest(t *testing.T) {
 		t.Error("expected error for missing .agent.json")
 	}
 }
+
+func TestCapabilitiesForDisplay_AugmentsIntrinsics(t *testing.T) {
+	// .agent.json manifest capabilities, as the kanban/props view sees them.
+	manifest := []string{
+		"knowledge", "skills", "bash", "avatar", "daemon", "mcp",
+		"read", "write", "edit", "glob", "grep", "vision", "web_search",
+	}
+
+	got := CapabilitiesForDisplay(manifest)
+
+	// The four intrinsic agent capabilities must be present.
+	for _, want := range []string{"system", "soul", "email", "psyche"} {
+		if !contains(got, want) {
+			t.Errorf("CapabilitiesForDisplay() missing intrinsic %q; got %v", want, got)
+		}
+	}
+
+	// Intrinsics lead, manifest capabilities follow in their original order.
+	want := []string{
+		"system", "soul", "email", "psyche",
+		"knowledge", "skills", "bash", "avatar", "daemon", "mcp",
+		"read", "write", "edit", "glob", "grep", "vision", "web_search",
+	}
+	if !equalSlices(got, want) {
+		t.Errorf("CapabilitiesForDisplay() = %v, want %v", got, want)
+	}
+}
+
+func TestCapabilitiesForDisplay_NoDuplicates(t *testing.T) {
+	// A manifest that already lists some intrinsics must not get them twice.
+	manifest := []string{"email", "bash", "soul", "read"}
+
+	got := CapabilitiesForDisplay(manifest)
+
+	seen := map[string]int{}
+	for _, c := range got {
+		seen[c]++
+	}
+	for c, n := range seen {
+		if n > 1 {
+			t.Errorf("capability %q appears %d times, want 1; got %v", c, n, got)
+		}
+	}
+
+	// Intrinsics still lead (deduped against the manifest), then the
+	// remaining manifest entries keep their original order.
+	want := []string{"system", "soul", "email", "psyche", "bash", "read"}
+	if !equalSlices(got, want) {
+		t.Errorf("CapabilitiesForDisplay() = %v, want %v", got, want)
+	}
+}
+
+func TestCapabilitiesForDisplay_EmptyManifest(t *testing.T) {
+	got := CapabilitiesForDisplay(nil)
+	want := []string{"system", "soul", "email", "psyche"}
+	if !equalSlices(got, want) {
+		t.Errorf("CapabilitiesForDisplay(nil) = %v, want %v", got, want)
+	}
+}
+
+func contains(xs []string, target string) bool {
+	for _, x := range xs {
+		if x == target {
+			return true
+		}
+	}
+	return false
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tui/internal/tui/daemons.go
+++ b/tui/internal/tui/daemons.go
@@ -60,6 +60,7 @@ type daemonSummary struct {
 	State        string
 	Task         string
 	Backend      string
+	Preset       string
 	StartedAt    string
 	UpdatedAt    string
 	CompletedAt  string
@@ -415,6 +416,7 @@ func (m DaemonsModel) renderDetail(maxW int) string {
 	lines = append(lines, sectionStyle.Render(i18n.T("daemons.metadata")))
 	meta := []struct{ label, value string }{
 		{i18n.T("daemons.backend"), d.Backend},
+		{i18n.T("daemons.preset"), d.Preset},
 		{i18n.T("daemons.current_tool"), d.CurrentTool},
 		{i18n.T("daemons.turn"), turnText(d.Turn, d.MaxTurns)},
 		{i18n.T("daemons.started"), d.StartedAt},
@@ -428,25 +430,12 @@ func (m DaemonsModel) renderDetail(maxW int) string {
 		lines = append(lines, fmt.Sprintf("%s %s", labelStyle.Render(row.label+":"), valueStyle.Render(row.value)))
 	}
 	lines = append(lines, fmt.Sprintf("%s %s", labelStyle.Render("events:"), valueStyle.Render(fmt.Sprintf("%d (%d tools)", d.EventCount, d.ToolCount))))
+
+	// Important information first: task → interactions → result. The raw
+	// event/trajectory log goes last so it never buries the summary above it.
 	lines = append(lines, "")
 	lines = append(lines, sectionStyle.Render(i18n.T("daemons.task")))
 	lines = appendWrappedFull(lines, d.Task, maxW, "  ")
-	if len(d.Events) > 0 {
-		lines = append(lines, "")
-		lines = append(lines, sectionStyle.Render(i18n.T("daemons.events")))
-		for _, ev := range d.Events {
-			label := strings.TrimSpace(strings.Join([]string{shortTime(ev.TS), ev.Event, ev.Name, ev.Status}, " "))
-			if label == "" {
-				label = "event"
-			}
-			lines = append(lines, muted.Render("  "+label))
-			body := ev.Raw
-			if body == "" {
-				body = firstNonEmpty(ev.Message, ev.Error)
-			}
-			lines = appendWrappedFull(lines, body, maxW, "    ")
-		}
-	}
 	if len(d.Chats) > 0 {
 		lines = append(lines, "")
 		lines = append(lines, sectionStyle.Render(i18n.T("daemons.interactions")))
@@ -467,6 +456,22 @@ func (m DaemonsModel) renderDetail(maxW int) string {
 		lines = append(lines, "")
 		lines = append(lines, sectionStyle.Render(i18n.T("daemons.result")))
 		lines = appendWrappedFull(lines, d.Result, maxW, "  ")
+	}
+	if len(d.Events) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, sectionStyle.Render(i18n.T("daemons.events")))
+		for _, ev := range d.Events {
+			label := strings.TrimSpace(strings.Join([]string{shortTime(ev.TS), ev.Event, ev.Name, ev.Status}, " "))
+			if label == "" {
+				label = "event"
+			}
+			lines = append(lines, muted.Render("  "+label))
+			body := ev.Raw
+			if body == "" {
+				body = firstNonEmpty(ev.Message, ev.Error)
+			}
+			lines = appendWrappedFull(lines, body, maxW, "    ")
+		}
 	}
 	return strings.Join(lines, "\n")
 }
@@ -555,6 +560,7 @@ func readDaemonSummary(dir string) (daemonSummary, error) {
 	item.Task = stringField(raw, "task")
 	item.State = stringField(raw, "state")
 	item.Backend = stringField(raw, "backend")
+	item.Preset = daemonPreset(raw)
 	item.StartedAt = stringField(raw, "started_at")
 	item.UpdatedAt = stringField(raw, "updated_at")
 	item.CompletedAt = stringField(raw, "completed_at")
@@ -710,6 +716,27 @@ func intField(raw map[string]any, key string) int {
 	default:
 		return 0
 	}
+}
+
+// daemonPreset derives an operator-visible preset label from daemon.json.
+// preset_name is authoritative when present; otherwise fall back through the
+// preset's provider/model, then the run's model, so the row is still useful
+// for older daemons that predate preset_name (where it is null/absent).
+func daemonPreset(raw map[string]any) string {
+	if name := stringField(raw, "preset_name"); name != "" {
+		return name
+	}
+	provider := stringField(raw, "preset_provider")
+	model := stringField(raw, "preset_model")
+	switch {
+	case provider != "" && model != "":
+		return provider + ":" + model
+	case model != "":
+		return model
+	case provider != "":
+		return provider
+	}
+	return stringField(raw, "model")
 }
 
 func firstNonEmpty(values ...string) string {

--- a/tui/internal/tui/daemons_test.go
+++ b/tui/internal/tui/daemons_test.go
@@ -81,3 +81,96 @@ func TestLoadDaemonSummariesReadsMetadataEventsAndChats(t *testing.T) {
 		t.Fatalf("result = %q", got.Result)
 	}
 }
+
+func TestReadDaemonSummaryParsesPreset(t *testing.T) {
+	dir := t.TempDir()
+	write := func(body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, "daemon.json"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// preset_name present → used verbatim.
+	write(`{"backend":"lingtai","preset_name":"deepseek-coder","preset_provider":"deepseek","preset_model":"deepseek-chat","model":"deepseek-chat"}`)
+	got, err := readDaemonSummary(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Preset != "deepseek-coder" {
+		t.Fatalf("preset = %q, want %q", got.Preset, "deepseek-coder")
+	}
+
+	// preset_name null → fall back to provider:model.
+	write(`{"backend":"lingtai","preset_name":null,"preset_provider":"deepseek","preset_model":"deepseek-chat","model":"deepseek-chat"}`)
+	got, err = readDaemonSummary(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Preset != "deepseek:deepseek-chat" {
+		t.Fatalf("preset fallback = %q, want %q", got.Preset, "deepseek:deepseek-chat")
+	}
+
+	// only model present → fall back to model.
+	write(`{"backend":"lingtai","model":"glm-4"}`)
+	got, err = readDaemonSummary(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Preset != "glm-4" {
+		t.Fatalf("preset model fallback = %q, want %q", got.Preset, "glm-4")
+	}
+}
+
+func TestRenderDetailShowsPresetNearBackend(t *testing.T) {
+	m := DaemonsModel{
+		items: []daemonSummary{{
+			Dir:     "/tmp/daemons/em-7",
+			State:   "done",
+			Backend: "lingtai",
+			Preset:  "deepseek-coder",
+		}},
+	}
+	out := m.renderDetail(80)
+	if !strings.Contains(out, "deepseek-coder") {
+		t.Fatalf("renderDetail missing preset; got:\n%s", out)
+	}
+	// preset row sits in the metadata block, right after backend.
+	bi := strings.Index(out, "lingtai")
+	pi := strings.Index(out, "deepseek-coder")
+	if bi < 0 || pi < 0 {
+		t.Fatalf("backend or preset missing; got:\n%s", out)
+	}
+	if pi < bi {
+		t.Fatalf("preset rendered before backend; backend=%d preset=%d", bi, pi)
+	}
+}
+
+func TestRenderDetailPutsEventsLast(t *testing.T) {
+	m := DaemonsModel{
+		items: []daemonSummary{{
+			Dir:     "/tmp/daemons/em-7",
+			State:   "done",
+			Backend: "lingtai",
+			Task:    "do the thing",
+			Result:  "all done",
+			Chats:   []daemonChat{{Role: "assistant", Text: "chat line"}},
+			Events:  []daemonEvent{{Event: "tool_call", Name: "read", Raw: `{"event":"tool_call"}`}},
+		}},
+	}
+	out := m.renderDetail(80)
+
+	taskIdx := strings.Index(out, "do the thing")
+	resultIdx := strings.Index(out, "all done")
+	chatIdx := strings.Index(out, "chat line")
+	eventsIdx := strings.Index(out, "tool_call")
+
+	for name, idx := range map[string]int{"task": taskIdx, "result": resultIdx, "chat": chatIdx, "events": eventsIdx} {
+		if idx < 0 {
+			t.Fatalf("%s section missing from detail:\n%s", name, out)
+		}
+	}
+	if !(taskIdx < eventsIdx && resultIdx < eventsIdx && chatIdx < eventsIdx) {
+		t.Fatalf("events not last: task=%d result=%d chat=%d events=%d", taskIdx, resultIdx, chatIdx, eventsIdx)
+	}
+}

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -543,7 +543,7 @@ func (m PropsModel) renderLeft(maxW int) string {
 		lines = append(lines, "  "+sectionStyle.Render(i18n.T("props.section_capabilities")))
 		lines = append(lines, "")
 		capsJSON, _ := json.Marshal(caps)
-		capNames := fs.ParseCapabilities(capsJSON)
+		capNames := fs.CapabilitiesForDisplay(fs.ParseCapabilities(capsJSON))
 		if len(capNames) > 0 {
 			capStr := strings.Join(capNames, ", ")
 			wrapped := lipgloss.NewStyle().Width(maxW - 6).Render(capStr)


### PR DESCRIPTION
## Summary
- show intrinsic agent capabilities (`system`, `soul`, `email`, `psyche`) in the `/kanban` capability list alongside manifest capabilities
- show the selected daemon's preset in `/daemons` metadata, with fallbacks for older daemon.json records
- move raw daemon event/trajectory output to the end of the detail pane so task/interactions/result remain visible first

## Validation
- `git diff --check`
- `cd tui && go test ./internal/fs ./internal/tui -count=1`
- `cd tui && go vet ./internal/fs ./internal/tui`
- `cd tui && go test ./...`

## Review plan
- Per Jason's request, run GLM and mimo reviews before merge consideration.