### PR TITLE
fix(tui): hide nested knowledge from top catalog

### DIFF
--- a/tui/internal/tui/codex_entries.go
+++ b/tui/internal/tui/codex_entries.go
@@ -50,56 +50,44 @@ type knowledgeEntry struct {
 
 func buildAgentKnowledgeEntries(agentDir string) []MarkdownEntry {
 	knowledgeDir := filepath.Join(agentDir, "knowledge")
-	info, err := os.Stat(knowledgeDir)
-	if err != nil || !info.IsDir() {
+	dirents, err := os.ReadDir(knowledgeDir)
+	if err != nil {
 		return nil
 	}
 
+	// The top-level /knowledge catalog mirrors the kernel prompt catalog: only
+	// immediate knowledge/<name>/KNOWLEDGE.md entries appear here. Nested
+	// sub-knowledge entries are second-layer detail owned by their routing parent
+	// and remain reachable after pressing Enter to drill into that parent folder.
 	var entries []knowledgeEntry
-	_ = filepath.WalkDir(knowledgeDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil
+	for _, de := range dirents {
+		name := de.Name()
+		if !de.IsDir() || isHiddenEntry(name) {
+			continue
 		}
-		name := d.Name()
-		if d.IsDir() {
-			if isHiddenEntry(name) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if name != "KNOWLEDGE.md" {
-			return nil
-		}
+		path := filepath.Join(knowledgeDir, name, "KNOWLEDGE.md")
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil
+			continue
 		}
 		fm := parseFrontmatter(string(data))
 		if fm == nil {
-			return nil
+			continue
 		}
 		entryName := cleanFrontmatterScalar(fm["name"])
 		description := cleanFrontmatterScalar(fm["description"])
 		if entryName == "" || description == "" {
-			return nil
-		}
-		rel, err := filepath.Rel(knowledgeDir, filepath.Dir(path))
-		if err != nil || rel == "." {
-			rel = ""
+			continue
 		}
 		entries = append(entries, knowledgeEntry{
 			Name:        entryName,
 			Description: description,
 			Path:        path,
-			RelDir:      rel,
+			RelDir:      name,
 		})
-		return nil
-	})
+	}
 
 	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].RelDir != entries[j].RelDir {
-			return entries[i].RelDir < entries[j].RelDir
-		}
 		return entries[i].Name < entries[j].Name
 	})
 
@@ -109,14 +97,10 @@ func buildAgentKnowledgeEntries(agentDir string) []MarkdownEntry {
 		if len(label) > 30 {
 			label = label[:27] + "..."
 		}
-		group := "Knowledge"
-		if e.RelDir != "" {
-			group = e.RelDir
-		}
 		result = append(result, MarkdownEntry{
 			Label:       label,
 			Description: e.Description,
-			Group:       group,
+			Group:       "Knowledge",
 			Path:        e.Path,
 		})
 	}

--- a/tui/internal/tui/codex_entries_test.go
+++ b/tui/internal/tui/codex_entries_test.go
@@ -22,7 +22,7 @@ func TestDefaultCommandsIncludesKnowledge(t *testing.T) {
 
 func TestBuildAgentCodexEntries_ReadsFilesystemKnowledge(t *testing.T) {
 	agentDir := t.TempDir()
-	knowledgePath := filepath.Join(agentDir, "knowledge", "research", "mimo", "KNOWLEDGE.md")
+	knowledgePath := filepath.Join(agentDir, "knowledge", "mimo", "KNOWLEDGE.md")
 	if err := os.MkdirAll(filepath.Dir(knowledgePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -39,14 +39,54 @@ func TestBuildAgentCodexEntries_ReadsFilesystemKnowledge(t *testing.T) {
 	if got.Label != "MiMo provider notes" {
 		t.Errorf("label = %q, want %q", got.Label, "MiMo provider notes")
 	}
-	if got.Group != filepath.Join("research", "mimo") {
-		t.Errorf("group = %q, want %q", got.Group, filepath.Join("research", "mimo"))
+	if got.Group != "Knowledge" {
+		t.Errorf("group = %q, want %q", got.Group, "Knowledge")
 	}
 	if got.Path != knowledgePath {
 		t.Errorf("path = %q, want %q", got.Path, knowledgePath)
 	}
 	if got.Content != "" {
 		t.Errorf("filesystem knowledge entries should be path-backed, got content %q", got.Content)
+	}
+}
+
+func TestBuildAgentCodexEntries_HidesNestedSubKnowledgeFromTopLayer(t *testing.T) {
+	agentDir := t.TempDir()
+	parentPath := filepath.Join(agentDir, "knowledge", "session-journal", "KNOWLEDGE.md")
+	childPath := filepath.Join(agentDir, "knowledge", "session-journal", "2026-06-09-molt-1-child", "KNOWLEDGE.md")
+	if err := os.MkdirAll(filepath.Dir(childPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parentBody := "---\nname: session-journal\ndescription: Routing index for session journals.\n---\n# Session Journal Index\n"
+	childBody := "---\nname: child-entry\ndescription: Second layer detail that should not appear in the top-level catalog.\n---\n# Child Entry\n"
+	if err := os.WriteFile(parentPath, []byte(parentBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(childPath, []byte(childBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := buildAgentCodexEntries(agentDir)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 top-level parent only: %+v", len(entries), entries)
+	}
+	if entries[0].Label != "session-journal" {
+		t.Fatalf("top-level label = %q, want session-journal", entries[0].Label)
+	}
+	if entries[0].Path != parentPath {
+		t.Fatalf("top-level path = %q, want %q", entries[0].Path, parentPath)
+	}
+
+	drillInEntries := buildKnowledgeFolderEntries(filepath.Dir(entries[0].Path))
+	foundChild := false
+	for _, entry := range drillInEntries {
+		if entry.Path == childPath {
+			foundChild = true
+			break
+		}
+	}
+	if !foundChild {
+		t.Fatalf("nested sub-knowledge should remain reachable after drilling into the parent; entries=%+v", drillInEntries)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the top-level `/knowledge` markdown catalog list only immediate `knowledge/<name>/KNOWLEDGE.md` entries
- keep nested sub-knowledge entries reachable via drill-in, instead of surfacing them on the first layer
- add a regression test for the session-journal nested `KNOWLEDGE.md` case

## Why
The new session-journal / molt diary layout stores child entries under paths like:

`knowledge/session-journal/<date>/KNOWLEDGE.md`

The previous top-level `/knowledge` entry builder recursively walked all `KNOWLEDGE.md` files, so these second-layer entries appeared in the first-layer viewer. This patch gives `/knowledge` the same leaf-style behavior already used by `/skills`: top-level catalog shows the parent; nested details remain available after opening the parent.

## Review
GLM review: no blocking issues; OK to merge after final local tests.

Review artifact:
`reports/mdviewer-layer-bug/glm-review.md` in the dev-3 agent workspace.

## Tests
- `go test ./internal/tui -run 'TestBuildAgentCodexEntries|TestBuildKnowledgeFolderEntries|TestMarkdownViewer'`
- `go test ./internal/tui`
- `go test ./...` from `tui/`
- `git diff --check`
