### PR TITLE
feat: add goal request command

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -88,7 +88,7 @@ This repo depends on `lingtai-kernel` only at runtime (the Python agent it launc
   - `<agent>/init.json` — the agent's preset manifest (LLM + capabilities + allowed presets list).
   - `<agent>/.agent.json` / `.agent.heartbeat` / `.status.json` — written by the agent, read by the TUI/portal.
   - `<agent>/mailbox/{inbox,outbox,sent,archive}/<uuid>/message.json` — filesystem mailbox.
-  - `<agent>/.notification/<channel>.json` — `.notification/` filesystem-as-protocol payloads (email, soul, system events). Read-only from the TUI's perspective; the agent owns them.
+  - `<agent>/.notification/<channel>.json` — `.notification/` filesystem-as-protocol payloads (email, soul, system events). Mostly read-only from the TUI's perspective: `/notification` renders these files as an inspection surface, while `/goal` is the narrow write exception that appends a `goal.request` event to `<agent>/.notification/system.json` so the running agent can guide goal setup.
   - `human/` — the user's pseudo-agent (no admin, no heartbeat). Mailbox layout identical to a real agent.
   - `.tui-asset/` — TUI-owned per-project caches (remotes list, etc.).
   - `.portal/port` / `.portal/recordings/` — portal-owned files when running.

--- a/reports/goal-command-notification-20260610.html
+++ b/reports/goal-command-notification-20260610.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>/goal command notification — 2026-06-10</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.6; margin: 32px auto; max-width: 980px; color: #1f2937; }
+  h1, h2 { color: #111827; }
+  code { background: #f3f4f6; padding: 0.12rem 0.28rem; border-radius: 4px; }
+  pre { background: #111827; color: #f9fafb; padding: 16px; border-radius: 10px; overflow: auto; }
+  .summary { background: #ecfdf5; border: 1px solid #10b981; border-radius: 12px; padding: 16px 20px; }
+  .warn { background: #fffbeb; border: 1px solid #f59e0b; border-radius: 12px; padding: 16px 20px; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #e5e7eb; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #f9fafb; }
+</style>
+</head>
+<body>
+<h1>/goal command notification</h1>
+<div class="summary">
+  <strong>结论：</strong>本 PR 给 TUI 增加 <code>/goal</code> 命令。它不会直接替 agent 创建 goal；而是向当前 agent 的
+  <code>.notification/system.json</code> 追加一个 <code>source="goal.request"</code> system event，让 agent 阅读 goal manual，
+  引导 human 明确 objective / criteria / reminder / cancellation semantics，确认后再由 agent 写入
+  <code>.notification/goal.json</code>。
+</div>
+
+<h2>为什么这样做</h2>
+<p>Jason 希望通过 <code>/goal</code> 触发一个 system notification：提醒 agent human 想设置 goal，要求 agent 先读 goal manual，
+再 guide human to create a goal，并明确告知如何取消。TUI 只负责“发起引导”，不越过 agent/human 对话直接写死 goal。</p>
+
+<h2>实现概览</h2>
+<table>
+<tr><th>文件</th><th>变化</th></tr>
+<tr><td><code>tui/internal/tui/goal.go</code></td><td>新增 <code>writeGoalRequestNotification</code>：创建/读取 <code>.notification/system.json</code>，保留已有 <code>data.events</code>，追加 <code>goal.request</code>，最多保留 20 条，temp-file + rename 原子写入。</td></tr>
+<tr><td><code>tui/internal/tui/app.go</code></td><td><code>/goal [draft]</code> palette handler：检查当前 agent 存在且 alive，然后写入 system notification；失败时给本地 UI 提示。</td></tr>
+<tr><td><code>tui/internal/tui/palette.go</code> + <code>tui/i18n/*.json</code></td><td>把 <code>/goal</code> 加入 command palette，并补齐 EN/ZH/Wen 三语言文案。</td></tr>
+<tr><td><code>lingtai-tui-help/assets/slash-commands.*.md</code></td><td>三语言 <code>/help</code> 文档说明 <code>/goal</code> 是引导入口，不直接创建 goal 文件，并解释 reminder dismiss 与 cancel 的区别。</td></tr>
+<tr><td><code>ANATOMY.md</code>, <code>tui/internal/tui/ANATOMY.md</code></td><td>记录 <code>/goal</code> 是 TUI 对 <code>.notification/</code> 的窄写入例外。</td></tr>
+</table>
+
+<h2>写入的 system event 语义</h2>
+<pre>{
+  "source": "goal.request",
+  "ref_id": "goal.request:&lt;timestamp&gt;",
+  "body": "Human wants to set or revise an active goal...",
+  "at": "2026-06-10T...Z"
+}</pre>
+<p>正文要求 agent：</p>
+<ul>
+<li>阅读 system-manual 下的 goal manual；</li>
+<li>和 human 明确 objective、success criteria、可选 <code>reminder_delay_seconds</code> 与 constraints；</li>
+<li>明确说明：取消 goal 需要删除 <code>.notification/goal.json</code> 或把 <code>data.status</code> 标记为 inactive/cancelled/done；</li>
+<li>明确说明：dismiss <code>goal.reminder</code> 只隐藏提醒，不取消 goal；</li>
+<li>在 human 确认细节前，不创建或覆盖 <code>.notification/goal.json</code>。</li>
+</ul>
+
+<h2>验证</h2>
+<ul>
+<li><code>git diff --check</code> — pass</li>
+<li><code>cd tui &amp;&amp; go test ./internal/tui -run 'Goal|EveryCommandInAllAssets'</code> — pass</li>
+<li><code>cd tui &amp;&amp; go test ./internal/tui ./i18n</code> — pass</li>
+</ul>
+
+<div class="warn">
+  <strong>边界：</strong>kernel 的 goal manual 扩写在另一个 repo（<code>Lingtai-AI/lingtai-kernel</code>），会作为 linked docs PR 提交。
+  这个 TUI PR 只提供触发入口与通知 payload。
+</div>
+</body>
+</html>

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -612,5 +612,10 @@
   "daemons.started": "started",
   "daemons.updated": "updated",
   "daemons.completed": "completed",
-  "daemons.error": "error"
+  "daemons.error": "error",
+  "mail.goal_sent": "Goal request notification sent (%s). The agent will read the goal manual and guide goal creation.",
+  "mail.goal_failed": "Failed to send goal request notification: %s",
+  "mail.goal_no_agent": "No current agent is selected; cannot send a goal request.",
+  "palette.goal": "Guide goal creation",
+  "cmd.goal": "Goal guide — send a system notification asking the current agent to read the goal manual, guide the human through objective/criteria/reminder/cancellation semantics, and only create .notification/goal.json after confirmation"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -612,5 +612,10 @@
   "daemons.started": "始",
   "daemons.updated": "更",
   "daemons.completed": "毕",
-  "daemons.error": "误"
+  "daemons.error": "误",
+  "mail.goal_sent": "设愿之讯已遣（%s）。器灵将读 goal manual 而导人成愿。",
+  "mail.goal_failed": "设愿之讯遣败：%s",
+  "mail.goal_no_agent": "今无所择器灵，不可遣设愿之讯。",
+  "palette.goal": "导立愿",
+  "cmd.goal": "导立愿——投 system notification，使当前器灵读 goal manual，导人明 objective / criteria / reminder / 取消之义，待确认后方写 .notification/goal.json"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -612,5 +612,10 @@
   "daemons.started": "开始",
   "daemons.updated": "更新",
   "daemons.completed": "完成",
-  "daemons.error": "错误"
+  "daemons.error": "错误",
+  "mail.goal_sent": "已发送 goal 引导通知（%s）。Agent 会阅读 goal manual 并引导创建目标。",
+  "mail.goal_failed": "发送 goal 引导通知失败：%s",
+  "mail.goal_no_agent": "当前没有选中的 Agent，无法发送 goal 引导通知。",
+  "palette.goal": "引导创建 goal",
+  "cmd.goal": "Goal 引导——发送 system notification，让当前 Agent 阅读 goal manual，引导人类明确 objective / criteria / reminder / 取消语义，并只在确认后创建 .notification/goal.json"
 }

--- a/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.en.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.en.md
@@ -23,6 +23,7 @@ to `~/Downloads`. Press `Esc` or `q` to return to the mail view.
 ### Talking to the agent
 - `/btw` — ask a side question without interrupting the agent's work.
 - `/insights` — request 2–3 concrete observations about the current task now.
+- `/goal` — ask the current agent to guide creation or revision of an active goal.
 
 ### Agent lifecycle
 - `/sleep` — put the agent to sleep (resumable with `/cpr`).
@@ -81,6 +82,17 @@ Asks the agent to observe its current task right now and produce 2–3 concrete
 observations. Use it when you want an immediate, structured read on what the
 agent is seeing — without waiting for the auto-insights cadence (toggled in
 `/settings`).
+
+### `/goal` — guide creation of an active goal
+**Usage:** `/goal` · `/goal <draft goal>`
+
+Sends a `goal.request` event into the current agent's `.notification/system.json`.
+The agent is expected to read the goal manual, discuss objective, success
+criteria, reminder delay, and cancellation semantics with you, and only then
+write `.notification/goal.json` after you confirm the details. `/goal` does not
+create the goal file directly. Dismissing a later `goal.reminder` only hides that
+reminder; canceling the goal means deleting `.notification/goal.json` or marking
+its status inactive/cancelled/done.
 
 ### `/sleep` — put the agent to sleep
 **Usage:** `/sleep` (current agent) · `/sleep all` (every agent in the project)

--- a/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.wen.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.wen.md
@@ -19,6 +19,7 @@
 ### 与器灵言
 - `/btw` — 进一旁问，不扰器灵当下之务。
 - `/insights` — 即索当下之务二三确切之见。
+- `/goal` — 令当下器灵导人立或修一 active goal。
 
 ### 器灵之生死
 - `/sleep` — 令器灵眠（可以 `/cpr` 醒之）。
@@ -71,6 +72,15 @@
 
 令器灵即观当务，出二三确切之见。凡欲即得器灵所见之结构化读，而不待自动洞见之节（于
 `/settings` 中启闭）者用之。
+
+### `/goal` — 导立 active goal
+**用：** `/goal` · `/goal <愿之草稿>`
+
+投一 `goal.request` 事入当下器灵之 `.notification/system.json`。器灵当读
+goal manual，与人同明 objective、success criteria、reminder delay 与取消之义；待人
+确认诸目后，方可写 `.notification/goal.json`。`/goal` 自身不直造 goal 文卷。后若
+dismiss `goal.reminder`，但隐其提醒；真欲取消 goal，当删 `.notification/goal.json`，
+或置其 status 为 inactive/cancelled/done。
 
 ### `/sleep` — 令器灵眠
 **用：** `/sleep`（当下器灵）· `/sleep all`（项目内诸器灵）

--- a/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.zh.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.zh.md
@@ -19,6 +19,7 @@
 ### 与智能体对话
 - `/btw` — 提一个旁问，不打断智能体当前的工作。
 - `/insights` — 立即索取关于当前任务的 2–3 条具体观察。
+- `/goal` — 让当前 Agent 引导创建或修订一个 active goal。
 
 ### 智能体生命周期
 - `/sleep` — 让智能体休眠（可用 `/cpr` 唤醒）。
@@ -72,6 +73,15 @@
 
 让智能体立刻观察当前任务并给出 2–3 条具体观察。当你想立即、结构化地了解智能体所见，
 而不愿等待自动洞察节奏（在 `/settings` 中开关）时使用。
+
+### `/goal` — 引导创建 active goal
+**用法：** `/goal` · `/goal <目标草稿>`
+
+向当前 Agent 的 `.notification/system.json` 投递一个 `goal.request` 事件。
+Agent 应读取 goal manual，和你一起明确 objective、success criteria、reminder
+delay 与取消语义，并且只在你确认细节后才写入 `.notification/goal.json`。`/goal`
+本身不会直接创建 goal 文件。之后 dismiss `goal.reminder` 只会隐藏那条提醒；真正取消
+goal 需要删除 `.notification/goal.json`，或把其中 status 标为 inactive/cancelled/done。
 
 ### `/sleep` — 让智能体休眠
 **用法：** `/sleep`（当前智能体）· `/sleep all`（项目内全部智能体）

--- a/tui/internal/tui/ANATOMY.md
+++ b/tui/internal/tui/ANATOMY.md
@@ -4,7 +4,7 @@
 
 This is the ~20k LOC Bubble Tea v2 package that renders every screen of `lingtai-tui`. Each screen is a struct implementing `Init()`, `Update(msg)`, `View()`, living in its own `.go` file. The package is intentionally flat — breaking it into sub-packages would fight Bubble Tea's convention (every model must be the same `tea.Model` type for the dispatcher), and Go's single-type-per-package constraint makes this the grain that matches the framework.
 
-Screen routing is centralized in the `App` struct (`app.go`), which holds every screen as a field, dispatches commands via `switchToView`, and maps the slash-command palette (`/mail`, `/setup`, `/doctor`, `/daemons`, `/notification`, etc.) to view transitions.
+Screen routing is centralized in the `App` struct (`app.go`), which holds every screen as a field, dispatches commands via `switchToView`, and maps the slash-command palette (`/mail`, `/setup`, `/doctor`, `/daemons`, `/notification`, `/goal`, etc.) to view transitions or narrow file-protocol actions.
 
 ## Components
 
@@ -15,7 +15,7 @@ Screen routing is centralized in the `App` struct (`app.go`), which holds every 
 - **`app.go:91-177`** — `NewApp`: constructor deciding initial view — mail view (returning user), first-run wizard (new user or rehydration), or recovery mode (global config lost, agents intact).
 - **`app.go:179-187`** — `App.Init()`: delegates to the initial view's `Init()`.
 - **`app.go:191-561`** — `App.Update()`: the central dispatcher. Three layers: (1) `WindowSizeMsg` forwarded to current view, (2) cross-view messages (`ViewChangeMsg`, `FirstRunDoneMsg`, `SetupSavedMsg`, `NirvanaDoneMsg`, `AddonSavedMsg`, etc.), (3) `KeyPressMsg` for `ctrl+c`/`q` quit, (4) fallthrough to current view's `Update()`.
-- **`app.go:563-1170`** — `handlePaletteCommand`: maps slash-command strings to view transitions (`/doctor` → `appViewDoctor`, `/daemons` → `appViewDaemons`, `/notification` → `appViewNotification`, `/knowledge` → `appViewCodex` (canonical; hidden `/library` and `/codex` aliases), `/skills` → `appViewLibrary`, etc.) and direct actions (`/suspend`, `/cpr`, `/refresh`, `/clear`, `/molt`, `/btw`, `/export`).
+- **`app.go:563-1170`** — `handlePaletteCommand`: maps slash-command strings to view transitions (`/doctor` → `appViewDoctor`, `/daemons` → `appViewDaemons`, `/notification` → `appViewNotification`, `/knowledge` → `appViewCodex` (canonical; hidden `/library` and `/codex` aliases), `/skills` → `appViewLibrary`, etc.) and direct actions (`/suspend`, `/cpr`, `/refresh`, `/clear`, `/molt`, `/btw`, `/goal`, `/export`).
 - **`app.go:1211-1302`** — `switchToView(viewName string)`:  the canonical route-to-view dispatcher used by `ViewChangeMsg` and palette commands returning to a view. Reconstructs models fresh on entry.
 - **`app.go:1304-1356`** — `App.View()`:  delegates to current view's `View()`, wraps in `tea.NewView` with alt-screen + mouse mode.
 - **`app.go:1347-1529`** — portal launch, style helpers, `SetTUIVersion`.
@@ -38,6 +38,7 @@ Screen routing is centralized in the `App` struct (`app.go`), which holds every 
 - **`mailbox.go:18-295`** — `MailboxModel`. Per-agent mail folder browser (inbox/sent/archive). Constructor: `NewMailboxModel` (`mailbox.go:46`). Wired to `/mailbox`.
 - **`daemons.go:30-798`** — `DaemonsModel`. Read-only daemon run browser for `/daemons`: discovers agents with `fs.BuildNetwork`, opens a Ctrl+T agent picker, scans `<agent>/daemons/em-*/daemon.json`, `logs/events.jsonl`, `history/chat_history.jsonl`, and `result.txt`, then renders a left run list and right detail pane with task, metadata, full chat_history interactions, full event/tool records, and full result text. Constructor: `NewDaemonsModel` (`daemons.go:97`). Wired to `/daemons`.
 - **`notification.go:18-194`** — `NotificationModel`. Read-only `/notification` view over the current agent's `<agent>/.notification/*.json` files: renders an aggregate raw notification block plus one MarkdownViewer entry per channel file, with `r` to reload. Constructor: `NewNotificationModel` (`notification.go:156`).
+- **`goal.go:14-62`** — `/goal` filesystem writer. `writeGoalRequestNotification` appends a `source="goal.request"` event to the current agent's `.notification/system.json`, preserving existing `data.events`, capping at 20, and writing via temp-file + rename. The event asks the agent to read the goal manual, guide objective/criteria/reminder/cancel semantics with the human, and only then create `.notification/goal.json` after confirmation.
 - **`nirvana.go:47-209`** — `NirvanaModel`. Confirmation screen for wiping `.lingtai/`. Constructor: `NewNirvanaModel` (`nirvana.go:56`). Emits `NirvanaDoneMsg` → triggers first-run wizard flow.
 - **`projects.go:35-448`** — `ProjectsModel`. Global project list browser. Constructor: `NewProjectsModel` (`projects.go:50`). Wired to `/projects`.
 - **`mdviewer.go:40-518`** — `MarkdownViewerModel`. Generic markdown display with sidebar navigation. Used by `/skills` detail views, recipe previews, agora browse results, and `/help`.
@@ -47,7 +48,7 @@ Screen routing is centralized in the `App` struct (`app.go`), which holds every 
 ### Non-screen shared types and helpers
 
 - **`input.go:28-294`** — `InputModel`. Reusable compose widget with textarea, paste support, and multiline expand. Used by `MailModel`.
-- **`palette.go:28-232`** — `PaletteModel`. Slash-command palette widget (type `/` to trigger, `/help` lists commands). Used by `MailModel` and `SettingsModel`; `DefaultCommands` includes `/notification` (`palette.go:60`).
+- **`palette.go:28-232`** — `PaletteModel`. Slash-command palette widget (type `/` to trigger, `/help` lists commands). Used by `MailModel` and `SettingsModel`; `DefaultCommands` includes `/notification` and `/goal` (`palette.go:60-61`).
 - **`styles.go:1-471`** — Theme system: `Theme` type, `ActiveTheme()`, `SetThemeByName()`, `Color*` constants, `themedTextareaStyles()`, lipgloss rendering helpers.
 - **`codex_entries.go:13-88`** — `buildAgentCodexEntries`: scans `knowledge/<name>/KNOWLEDGE.md` folders (after a one-time migration of legacy `codex/codex.json` / `knowledge/knowledge.json` stores via `migrateLegacyJSONStores`), converts to `MarkdownEntry` slices for the `CodexModel`.
 - **`mailbox_entries.go:17-321`** — `buildMailboxEntries`: reads per-agent mailbox folders, converts to `MarkdownEntry` slices for the `MailboxModel`.

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -759,6 +759,22 @@ func (a App) handlePaletteCommand(command, args string) (tea.Model, tea.Cmd) {
 		a.currentView = appViewNotification
 		a.notification = NewNotificationModel(a.orchDir)
 		return a, tea.Batch(a.notification.Init(), a.sendSize())
+	case "goal":
+		if targetDir == "" {
+			addMsg(i18n.T("mail.goal_no_agent"))
+			return a, nil
+		}
+		if !fs.IsAlive(targetDir, 3.0) {
+			addMsg(i18n.T("mail.btw_suspended"))
+			return a, nil
+		}
+		eventID, err := writeGoalRequestNotification(targetDir, args, time.Now())
+		if err != nil {
+			addMsg(i18n.TF("mail.goal_failed", firstLine(err)))
+			return a, nil
+		}
+		addMsg(i18n.TF("mail.goal_sent", eventID))
+		return a, nil
 	case "skills":
 		a.currentView = appViewLibrary
 		// Agent-scoped: mirror what the skills capability would inject for

--- a/tui/internal/tui/goal.go
+++ b/tui/internal/tui/goal.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const goalRequestSource = "goal.request"
+
+func writeGoalRequestNotification(agentDir, humanRequest string, now time.Time) (string, error) {
+	if agentDir == "" {
+		return "", fmt.Errorf("no current agent is selected")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	notifDir := filepath.Join(agentDir, ".notification")
+	if err := os.MkdirAll(notifDir, 0o755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(notifDir, "system.json")
+
+	payload := readSystemNotificationPayload(path)
+	events := readSystemNotificationEvents(payload)
+
+	eventID := fmt.Sprintf("evt_%x_%s", now.UnixMilli(), randomHex(2))
+	refID := fmt.Sprintf("goal.request:%x", now.UnixMilli())
+	at := now.UTC().Format("2006-01-02T15:04:05Z")
+	events = append(events, map[string]any{
+		"event_id": eventID,
+		"source":   goalRequestSource,
+		"ref_id":   refID,
+		"body":     buildGoalRequestBody(humanRequest),
+		"at":       at,
+	})
+	if len(events) > 20 {
+		events = events[len(events)-20:]
+	}
+
+	data, _ := payload["data"].(map[string]any)
+	if data == nil {
+		data = map[string]any{}
+	}
+	data["events"] = events
+	payload["data"] = data
+	payload["header"] = fmt.Sprintf("%d system notification%s", len(events), pluralS(len(events)))
+	payload["icon"] = "🔔"
+	payload["priority"] = "normal"
+	payload["published_at"] = at
+	payload["instructions"] = "System events are multiplexed in data.events. For source=goal.request, read the goal manual under system-manual, then guide the human to define a goal before writing .notification/goal.json. Dismiss this request with system(action=\"dismiss\", channel=\"system\", ref_id=\"<ref_id>\") after handling it."
+
+	if err := writeJSONFile(path, payload); err != nil {
+		return "", err
+	}
+	return eventID, nil
+}
+
+func readSystemNotificationPayload(path string) map[string]any {
+	payload := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return payload
+	}
+	_ = json.Unmarshal(data, &payload)
+	return payload
+}
+
+func readSystemNotificationEvents(payload map[string]any) []any {
+	data, _ := payload["data"].(map[string]any)
+	rawEvents, _ := data["events"].([]any)
+	if len(rawEvents) == 0 {
+		return nil
+	}
+	events := make([]any, 0, len(rawEvents))
+	for _, ev := range rawEvents {
+		if ev == nil {
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func buildGoalRequestBody(humanRequest string) string {
+	request := strings.TrimSpace(humanRequest)
+	var b strings.Builder
+	b.WriteString("Human wants to set or revise an active goal. Read the goal manual under system-manual before acting. Guide the human to create a goal by clarifying objective, success criteria, optional reminder_delay_seconds, and any constraints. Explain clearly that canceling a goal requires deleting .notification/goal.json or marking data.status inactive/cancelled/done; dismissing a goal.reminder only hides that reminder and does not cancel the goal. Do not create or overwrite .notification/goal.json until the human confirms the goal details.")
+	if request != "" {
+		b.WriteString(" Human request: ")
+		b.WriteString(request)
+	} else {
+		b.WriteString(" No inline goal text was provided; ask the human what goal they want to create.")
+	}
+	return b.String()
+}
+
+func writeJSONFile(path string, payload any) error {
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".system.json.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func randomHex(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(buf)
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/tui/internal/tui/goal_test.go
+++ b/tui/internal/tui/goal_test.go
@@ -1,0 +1,163 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultCommandsIncludesGoal(t *testing.T) {
+	cmd, ok := findCommand("goal")
+	if !ok {
+		t.Fatal("DefaultCommands() missing goal command")
+	}
+	if cmd.Description != "palette.goal" || cmd.Detail != "cmd.goal" {
+		t.Fatalf("goal command keys = (%q, %q), want (palette.goal, cmd.goal)", cmd.Description, cmd.Detail)
+	}
+}
+
+func TestWriteGoalRequestNotificationCreatesSystemEvent(t *testing.T) {
+	agentDir := t.TempDir()
+	now := time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)
+
+	eventID, err := writeGoalRequestNotification(agentDir, "finish the linked /goal PR", now)
+	if err != nil {
+		t.Fatalf("writeGoalRequestNotification returned error: %v", err)
+	}
+	if eventID == "" {
+		t.Fatal("writeGoalRequestNotification returned empty event id")
+	}
+
+	payload := readGoalTestPayload(t, agentDir)
+	events := goalTestEvents(t, payload)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	event := events[0]
+	if event["event_id"] != eventID {
+		t.Fatalf("event_id = %q, want returned id %q", event["event_id"], eventID)
+	}
+	if event["source"] != goalRequestSource {
+		t.Fatalf("source = %q, want %q", event["source"], goalRequestSource)
+	}
+	if refID, ok := event["ref_id"].(string); !ok || !strings.HasPrefix(refID, "goal.request:") {
+		t.Fatalf("ref_id = %#v, want goal.request:<id>", event["ref_id"])
+	}
+
+	body, _ := event["body"].(string)
+	for _, want := range []string{
+		"goal manual",
+		"finish the linked /goal PR",
+		".notification/goal.json",
+		"dismissing a goal.reminder only hides",
+		"Do not create or overwrite .notification/goal.json until the human confirms",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("goal request body missing %q:\n%s", want, body)
+		}
+	}
+
+	instructions, _ := payload["instructions"].(string)
+	for _, want := range []string{
+		"source=goal.request",
+		"read the goal manual",
+		"system(action=\"dismiss\", channel=\"system\", ref_id=\"<ref_id>\")",
+	} {
+		if !strings.Contains(instructions, want) {
+			t.Fatalf("instructions missing %q:\n%s", want, instructions)
+		}
+	}
+}
+
+func TestWriteGoalRequestNotificationPreservesEventsAndCapsTwenty(t *testing.T) {
+	agentDir := t.TempDir()
+	notifDir := filepath.Join(agentDir, ".notification")
+	if err := os.MkdirAll(notifDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	seedEvents := make([]map[string]any, 20)
+	for i := range seedEvents {
+		seedEvents[i] = map[string]any{
+			"event_id": "seed",
+			"source":   "daemon.done",
+			"ref_id":   "old-" + string(rune('a'+i)),
+			"body":     "old event",
+		}
+	}
+	seed := map[string]any{
+		"header": "20 system notifications",
+		"data": map[string]any{
+			"events": seedEvents,
+			"other":  "preserved",
+		},
+		"instructions": "old instructions",
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(notifDir, "system.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = writeGoalRequestNotification(agentDir, "new goal", time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("writeGoalRequestNotification returned error: %v", err)
+	}
+
+	payload := readGoalTestPayload(t, agentDir)
+	events := goalTestEvents(t, payload)
+	if len(events) != 20 {
+		t.Fatalf("got %d events, want cap of 20", len(events))
+	}
+	if events[0]["ref_id"] != "old-b" {
+		t.Fatalf("first preserved event ref_id = %q, want old-b after dropping oldest", events[0]["ref_id"])
+	}
+	last := events[len(events)-1]
+	if last["source"] != goalRequestSource {
+		t.Fatalf("last source = %q, want %q", last["source"], goalRequestSource)
+	}
+	dataMap, _ := payload["data"].(map[string]any)
+	if dataMap["other"] != "preserved" {
+		t.Fatalf("data.other = %q, want preserved", dataMap["other"])
+	}
+}
+
+func readGoalTestPayload(t *testing.T, agentDir string) map[string]any {
+	t.Helper()
+	path := filepath.Join(agentDir, ".notification", "system.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return payload
+}
+
+func goalTestEvents(t *testing.T, payload map[string]any) []map[string]any {
+	t.Helper()
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.data missing or wrong type: %#v", payload["data"])
+	}
+	raw, ok := data["events"].([]any)
+	if !ok {
+		t.Fatalf("payload.data.events missing or wrong type: %#v", data["events"])
+	}
+	events := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		event, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("event has wrong type: %#v", item)
+		}
+		events = append(events, event)
+	}
+	return events
+}

--- a/tui/internal/tui/palette.go
+++ b/tui/internal/tui/palette.go
@@ -58,6 +58,7 @@ func DefaultCommands() []Command {
 		{Name: "kanban", Description: "palette.kanban", Detail: "cmd.kanban"},
 		{Name: "daemons", Description: "palette.daemons", Detail: "cmd.daemons"},
 		{Name: "notification", Description: "palette.notification", Detail: "cmd.notification"},
+		{Name: "goal", Description: "palette.goal", Detail: "cmd.goal"},
 		{Name: "projects", Description: "palette.projects", Detail: "cmd.projects"},
 		{Name: "agora", Description: "palette.agora", Detail: "cmd.agora"},
 		{Name: "export", Description: "palette.export", Detail: "cmd.export"},


### PR DESCRIPTION
## Summary
- add `/goal [draft]` as a TUI slash command
- write a `source="goal.request"` event into the current agent's `.notification/system.json`
- document `/goal` in EN/ZH/Wen help assets and anatomy
- add tests for command registration and system notification payload/capping

## Behavior
`/goal` does not directly create `.notification/goal.json`. It asks the current running agent to read the goal manual, guide the human through objective / success criteria / reminder cadence / cancellation semantics, and only write the goal file after confirmation.

Report: `/Users/huangzesen/work/GitHub/lingtai-devguide-html-pr/reports/goal-command-notification-20260610.html`

## Linked work
- Kernel `goal-manual` guided setup docs: https://github.com/Lingtai-AI/lingtai-kernel/pull/254

## Tests
- `git diff --check`
- `cd tui && go test ./internal/tui -run 'Goal|EveryCommandInAllAssets'`
- `cd tui && go test ./internal/tui ./i18n`
- `cd tui && go test ./...`
