### PR TITLE
docs: mention /help in README slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Frequently used slash commands:
 | `/sleep` · `/refresh` · `/cpr` · `/clear` | Lifecycle: pause, reload, revive, reset context. |
 | `/projects` | Switch or inspect known projects. |
 | `/doctor` | Diagnose installation/runtime issues. |
+| `/help` | Open the slash-command help browser. |
 
 Shell entrypoints when useful:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -159,6 +159,7 @@ flowchart LR
 | `/sleep` · `/refresh` · `/cpr` · `/clear` | 生命周期：休眠、重载、复苏、清空上下文 |
 | `/projects` | 切换或查看已知项目 |
 | `/doctor` | 排查安装/运行时问题 |
+| `/help` | 打开斜杠命令帮助浏览器 |
 
 常用 Shell 入口：
 


### PR DESCRIPTION
## Summary
- add /help to the English README slash-command table
- add the matching Chinese README row

## Validation
- not run (docs-only change)