### PR TITLE
docs: mention /goal in README slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Frequently used slash commands:
 | `/skills` | Browse available skills and capabilities. |
 | `/viz` | Open the network visualization. |
 | `/insights` | Ask the assistant for a reflective second look. |
+| `/goal` | Ask the current agent to guide creation or revision of an active goal. |
 | `/sleep` · `/refresh` · `/cpr` · `/clear` | Lifecycle: pause, reload, revive, reset context. |
 | `/projects` | Switch or inspect known projects. |
 | `/doctor` | Diagnose installation/runtime issues. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -156,6 +156,7 @@ flowchart LR
 | `/skills` | 浏览可用技能与能力 |
 | `/viz` | 打开网络可视化 |
 | `/insights` | 让助理对当前工作做一次自我反思 |
+| `/goal` | 让当前 Agent 引导创建或修订 active goal |
 | `/sleep` · `/refresh` · `/cpr` · `/clear` | 生命周期：休眠、重载、复苏、清空上下文 |
 | `/projects` | 切换或查看已知项目 |
 | `/doctor` | 排查安装/运行时问题 |


### PR DESCRIPTION
## Summary
- add /goal to the English README slash-command table
- add the matching Chinese README row

## Validation
- not run (docs-only change)