### PR TITLE
docs: mention /daemons in README slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Frequently used slash commands:
 |---|---|
 | `/setup` | Change model, recipe, language, tools, or behavior. |
 | `/kanban` | Inspect agent + project status. |
+| `/daemons` | Inspect per-agent daemon runs and their records. |
 | `/mcp` | Configure external channels (Telegram/Feishu/WeChat/WhatsApp/IMAP/…). |
 | `/skills` | Browse available skills and capabilities. |
 | `/viz` | Open the network visualization. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -152,6 +152,7 @@ flowchart LR
 |---|---|
 | `/setup` | 调整模型、配方、语言、工具、行为 |
 | `/kanban` | 查看助理与项目状态 |
+| `/daemons` | 查看各 Agent 的 daemon 运行记录 |
 | `/mcp` | 配置外部渠道（Telegram/飞书/微信/WhatsApp/IMAP/…） |
 | `/skills` | 浏览可用技能与能力 |
 | `/viz` | 打开网络可视化 |


### PR DESCRIPTION
## Summary
- add /daemons to the English README slash-command table
- add the matching Chinese README row

## Validation
- not run (docs-only change)