### PR TITLE
docs: mention /molt in README lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Frequently used slash commands:
 | `/skills` | Browse available skills and capabilities. |
 | `/viz` | Open the network visualization. |
 | `/insights` | Ask the assistant for a reflective second look. |
-| `/sleep` · `/refresh` · `/cpr` · `/clear` | Lifecycle: pause, reload, revive, reset context. |
+| `/sleep` · `/refresh` · `/cpr` · `/clear` · `/molt` | Lifecycle: pause, reload, revive, reset or save-and-reset context. |
 | `/projects` | Switch or inspect known projects. |
 | `/doctor` | Diagnose installation/runtime issues. |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -156,7 +156,7 @@ flowchart LR
 | `/skills` | 浏览可用技能与能力 |
 | `/viz` | 打开网络可视化 |
 | `/insights` | 让助理对当前工作做一次自我反思 |
-| `/sleep` · `/refresh` · `/cpr` · `/clear` | 生命周期：休眠、重载、复苏、清空上下文 |
+| `/sleep` · `/refresh` · `/cpr` · `/clear` · `/molt` | 生命周期：休眠、重载、复苏、清空或保存后重置上下文 |
 | `/projects` | 切换或查看已知项目 |
 | `/doctor` | 排查安装/运行时问题 |
 


### PR DESCRIPTION
## Summary
- include /molt in the English README lifecycle slash-command row
- update the matching Chinese README row

## Validation
- not run (docs-only change)