### PR TITLE
docs: mention /export in README slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Frequently used slash commands:
 | Command | Use |
 |---|---|
 | `/setup` | Change model, recipe, language, tools, or behavior. |
+| `/export` | Export a reusable recipe for sharing. |
 | `/kanban` | Inspect agent + project status. |
 | `/mcp` | Configure external channels (Telegram/Feishu/WeChat/WhatsApp/IMAP/…). |
 | `/skills` | Browse available skills and capabilities. |

--- a/README.zh.md
+++ b/README.zh.md
@@ -151,6 +151,7 @@ flowchart LR
 | 命令 | 用途 |
 |---|---|
 | `/setup` | 调整模型、配方、语言、工具、行为 |
+| `/export` | 导出可复用的配方以供分享 |
 | `/kanban` | 查看助理与项目状态 |
 | `/mcp` | 配置外部渠道（Telegram/飞书/微信/WhatsApp/IMAP/…） |
 | `/skills` | 浏览可用技能与能力 |


### PR DESCRIPTION
## Summary
- add /export to the English README slash-command table
- add the matching Chinese README row

## Validation
- not run (docs-only change)