### PR TITLE
docs: mention multiline input shortcuts in help

### DIFF
--- a/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.en.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.en.md
@@ -9,6 +9,7 @@ views, manage the agent lifecycle, and configure the runtime.
 - Keep typing to filter. Matching is fuzzy: `/skl` finds `skills`, `/ref` finds
   `refresh`.
 - `↑`/`↓` move the selection, `Enter` runs the highlighted command.
+- In the message box, `Enter` sends; `Shift+Enter` or `Ctrl+J` inserts a newline.
 - Some commands take an argument typed after the name, e.g. `/sleep all` or
   `/refresh mimo`.
 

--- a/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.wen.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.wen.md
@@ -7,6 +7,7 @@
 - 于讯框中入 `/`，则**命令面板**启。
 - 续输以滤之，许模糊相合：`/skl` 合 `skills`，`/ref` 合 `refresh`。
 - `↑`/`↓` 移其选，`Enter` 行所明之命。
+- 于讯框中，`Enter` 发送；`Shift+Enter` 或 `Ctrl+J` 入换行。
 - 有命于名后系参，如 `/sleep all`、`/refresh mimo`。
 
 ## 阅此帮助

--- a/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.zh.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/assets/slash-commands.zh.md
@@ -7,6 +7,7 @@
 - 在消息框中输入 `/` 打开**命令面板**。
 - 继续输入即可过滤，支持模糊匹配：`/skl` 匹配 `skills`，`/ref` 匹配 `refresh`。
 - `↑`/`↓` 移动选择，`Enter` 运行高亮的命令。
+- 在消息框中，`Enter` 发送；`Shift+Enter` 或 `Ctrl+J` 插入换行。
 - 部分命令在名称后接参数，例如 `/sleep all` 或 `/refresh mimo`。
 
 ## 浏览本帮助


### PR DESCRIPTION
## Summary
- document Enter vs Shift+Enter/Ctrl+J behavior in the English slash-command help
- add matching Chinese and wen help text

## Validation
- go test ./internal/tui