### PR TITLE
docs: move first-time install help to README top

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,39 @@ lingtai-tui
 
 On first run LingTai creates `.lingtai/`, provisions its own runtime, walks you through model/preset setup, and starts one resident assistant for the project.
 
+### First-time install troubleshooting
+
+Assume this is your first LingTai install. If the three commands above fail, start here — the common fixes are part of the install path, not a distant appendix.
+
+**`brew` is not installed (macOS or Linux).** Install Homebrew first, then re-run the `brew install` command above:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+The Homebrew installer ends by printing an `eval "$(... shellenv)"` line that adds `brew` to your `PATH`. Run that line (or open a new terminal) before continuing.
+
+**WSL / Ubuntu / Debian.** Homebrew on Linux needs basic build tools before it can install packages. Install the prerequisites first, then Homebrew, then LingTai:
+
+```bash
+sudo apt update
+sudo apt install -y build-essential curl git ca-certificates
+```
+
+**To upgrade later**, use Homebrew again and restart the TUI so the new binary takes over:
+
+```bash
+brew update
+brew upgrade lingtai-ai/lingtai/lingtai-tui
+lingtai-tui
+```
+
+**`brew install` fails while building.** A missing compiler toolchain is the usual cause. Install the prerequisites above, run `brew update`, and retry. If Homebrew still fails or is not available on your machine, use the [source build](#from-source) path below.
+
+> The `lingtai` PyPI package exists, but it is the Python runtime the TUI manages on your behalf. Use Homebrew (or the source build below) to install and upgrade; reach for `pip` only when you are developing or diagnosing the kernel itself.
+
+The first project you create will look like this:
+
 ```text
 project/
 └── .lingtai/
@@ -64,9 +97,7 @@ project/
         └── logs/           # inspectable runtime trace
 ```
 
-> The `lingtai` PyPI package exists, but it is the Python runtime the TUI manages on your behalf. Use Homebrew (or the source build below) to install and upgrade; reach for `pip` only when you are developing or diagnosing the kernel itself.
-
-For source builds, mainland-China mirror setup, from-tarball install paths, and first-time install troubleshooting (missing `brew`, WSL prerequisites), see [Install in detail](#install-in-detail).
+For source builds, mainland-China mirror setup, from-tarball install paths, and advanced runtime repair, see [Install in detail](#install-in-detail).
 
 ## What it is good at
 
@@ -240,26 +271,11 @@ brew upgrade lingtai-ai/lingtai/lingtai-tui
 
 After upgrading, restart the TUI so the new binary takes over. The TUI manages the Python runtime under `~/.lingtai-tui/runtime/venv/` — installing `lingtai` into your system Python does not affect a running project.
 
-### First-time install troubleshooting
-
-**`brew` is not installed (macOS or Linux).** Install Homebrew first, then re-run the `brew install` command above:
-
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-The installer ends by printing an `eval` line to add `brew` to your `PATH` — run it (or open a new terminal) before continuing.
-
-**WSL / Ubuntu / Debian.** Homebrew on Linux needs basic build tools before it can install packages. Install the prerequisites, then Homebrew, then LingTai:
-
-```bash
-sudo apt update
-sudo apt install build-essential curl git ca-certificates
-```
-
-**Homebrew is not an option.** Build from source instead — see [From source](#from-source) below. You need Go, `make`, and (for the portal) Node.js/npm.
+First-time install problems (missing `brew`, WSL/Ubuntu/Debian prerequisites, source-build failures) are covered up top in [First-time install troubleshooting](#first-time-install-troubleshooting).
 
 ### From source
+
+You need Go, `make`, and (for the portal) Node.js/npm.
 
 Use this when hacking on the TUI/portal itself or when Homebrew is unavailable:
 

--- a/reports/readme-top-install-first-20260610-explainer.html
+++ b/reports/readme-top-install-first-20260610-explainer.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>README first-time install path</title>
+  <style>
+    :root { color-scheme: light dark; --accent:#7dab8f; --ink:#1f2a24; --muted:#5f6f67; --bg:#f7faf8; --card:#ffffff; --line:#dce7e1; }
+    @media (prefers-color-scheme: dark) { :root { --ink:#e9f2ed; --muted:#a8b8b0; --bg:#101612; --card:#172019; --line:#2b3a31; } }
+    body { margin:0; font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; color:var(--ink); background:var(--bg); }
+    main { max-width:920px; margin:0 auto; padding:42px 22px 64px; }
+    .hero { background:linear-gradient(135deg, rgba(125,171,143,.22), rgba(212,168,83,.14)); border:1px solid var(--line); border-radius:24px; padding:28px; }
+    h1 { margin:0 0 8px; font-size:32px; line-height:1.15; }
+    h2 { margin-top:30px; font-size:22px; }
+    .muted { color:var(--muted); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:14px; margin-top:16px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:18px; }
+    code { background:rgba(125,171,143,.15); padding:2px 5px; border-radius:6px; }
+    ul { padding-left:22px; }
+    .verdict { display:inline-block; background:var(--accent); color:white; padding:4px 10px; border-radius:999px; font-weight:700; }
+  </style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <div class="verdict">Docs PR ready</div>
+    <h1>README install path now assumes first-time users</h1>
+    <p class="muted">The top quickstart now includes the common troubleshooting steps instead of sending new users to a distant section.</p>
+  </section>
+
+  <h2>What changed</h2>
+  <div class="grid">
+    <div class="card"><strong>Troubleshooting moved up</strong><br>The <code>First-time install troubleshooting</code> section now sits immediately after the three-command quickstart.</div>
+    <div class="card"><strong>Missing Homebrew handled</strong><br>Includes the official Homebrew install command and reminds users to run the printed <code>shellenv</code> line.</div>
+    <div class="card"><strong>WSL/Linux prerequisites included</strong><br>Shows <code>build-essential curl git ca-certificates</code> before Homebrew/source builds.</div>
+    <div class="card"><strong>Upgrade and fallback clarified</strong><br>Shows the Homebrew upgrade path near the top and points build failures to prerequisites or source install.</div>
+  </div>
+
+  <h2>Why</h2>
+  <p>Jason noted that installation remained confusing because basic fixes were hidden too far down. The README now treats missing <code>brew</code>, WSL prerequisites, and source-build failures as normal first-install steps.</p>
+
+  <h2>Validation</h2>
+  <ul>
+    <li><code>git diff --check</code></li>
+    <li>Anchor checks for <code>#first-time-install-troubleshooting</code>, <code>#install-in-detail</code>, and <code>#from-source</code></li>
+  </ul>
+
+  <h2>Scope</h2>
+  <p>Changed <code>README.md</code> and this explainer only. No runtime/code behavior changed.</p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move first-time install troubleshooting directly under the README quickstart
- include missing Homebrew setup, WSL/Ubuntu/Debian prerequisites, upgrade command, and source-build fallback near the top
- leave the detailed install section as a secondary reference that points back to the top troubleshooting path
- add a self-contained HTML explainer: `reports/readme-top-install-first-20260610-explainer.html`

## Why
Jason noted that installation is still confusing because simple troubleshooting is too far from the initial install path. This assumes every reader may be installing for the first time and puts the common fixes where they need them.

## Validation
- `git diff --check`
- README anchor/order checks for `#first-time-install-troubleshooting`, `#install-in-detail`, `#from-source`
- verified the top section includes Homebrew install guidance, WSL prerequisites, Homebrew upgrade, and the PyPI caveat
