### PR TITLE
Repair install.sh source helper

### DIFF
--- a/artifacts/install-sh-repair-20260611/summary.md
+++ b/artifacts/install-sh-repair-20260611/summary.md
@@ -1,0 +1,19 @@
+# install.sh repair summary — 2026-06-11
+
+Scope kept narrow after direction change: Homebrew remains the primary distribution path; this patch only repairs `install.sh` as a source-build helper.
+
+Changes:
+- Corrected header/help text so `install.sh` no longer claims it always installs to Homebrew's bin directory.
+- Added `-h/--help` and clearer unknown flag errors.
+- Added EXIT trap cleanup for temporary build directory.
+- Made invalid `--ref` fail clearly rather than silently building `main`.
+- Added platform/package-manager hints for missing `git`, `go`, and optional `npm`.
+- Preserved existing #239/#240 behavior: brew bin preference, writable `/usr/local/bin`, `~/.local/bin` fallback, PATH hint, CN mirror detection, npm-missing portal skip.
+
+Validation:
+- `bash -n install.sh` passed.
+- `./install.sh --help` passed.
+- `git diff --check` passed.
+
+Not run:
+- Full install/source build, to avoid overwriting local binaries during PR prep.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Install lingtai-tui and lingtai-portal from source.
-# Builds from main branch and installs to Homebrew's bin directory.
+# Build lingtai-tui and lingtai-portal from source and install them.
+#
+# This is the source-build helper; Homebrew remains the primary install path
+# (brew install lingtai-ai/lingtai/lingtai-tui). Binaries are installed to the
+# first of: Homebrew's bin directory, a writable /usr/local/bin, or ~/.local/bin.
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/install.sh | bash
@@ -15,12 +18,70 @@ REPO="https://github.com/Lingtai-AI/lingtai.git"
 TMPDIR="${TMPDIR:-/tmp}"
 BUILD_DIR="$TMPDIR/lingtai-install-$$"
 
+usage() {
+  cat <<'EOF'
+Build lingtai-tui and lingtai-portal from source and install them.
+
+Usage:
+  curl -sSL https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/install.sh | bash
+  ./install.sh [--ref <branch|tag|commit>]
+
+Options:
+  --ref <ref>   Git branch, tag, or commit to build (default: main)
+  -h, --help    Show this help
+
+Binaries are installed to the first of: Homebrew's bin directory, a writable
+/usr/local/bin, or ~/.local/bin. The portal is skipped when npm is missing.
+Homebrew remains the primary install path:
+  brew install lingtai-ai/lingtai/lingtai-tui
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --ref) REF="$2"; shift 2 ;;
-    *) echo "unknown flag: $1"; exit 1 ;;
+    --ref) REF="${2:?error: --ref requires a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown flag: $1" >&2; usage >&2; exit 1 ;;
   esac
 done
+
+# Remove the build directory even when a build or install step fails midway.
+cleanup() {
+  cd / 2>/dev/null || true
+  rm -rf "$BUILD_DIR"
+}
+trap cleanup EXIT
+
+# Print a platform-appropriate install hint for a missing tool. Maps tool
+# names to the package each manager actually ships (go is golang-go on
+# Debian/Ubuntu, golang on Fedora, etc.).
+suggest_install() {
+  local tool="$1" pkg="$1"
+  if command -v brew &>/dev/null || [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "      brew install $tool" >&2
+    return
+  fi
+  if command -v apt-get &>/dev/null; then
+    [[ "$tool" == "go" ]] && pkg="golang-go"
+    [[ "$tool" == "npm" ]] && pkg="nodejs npm"
+    echo "      sudo apt-get update && sudo apt-get install -y $pkg" >&2
+  elif command -v dnf &>/dev/null; then
+    [[ "$tool" == "go" ]] && pkg="golang"
+    [[ "$tool" == "npm" ]] && pkg="nodejs npm"
+    echo "      sudo dnf install -y $pkg" >&2
+  elif command -v pacman &>/dev/null; then
+    [[ "$tool" == "npm" ]] && pkg="nodejs npm"
+    echo "      sudo pacman -S --needed $pkg" >&2
+  elif command -v apk &>/dev/null; then
+    [[ "$tool" == "npm" ]] && pkg="nodejs npm"
+    echo "      sudo apk add $pkg" >&2
+  elif command -v zypper &>/dev/null; then
+    [[ "$tool" == "npm" ]] && pkg="nodejs npm"
+    echo "      sudo zypper install $pkg" >&2
+  else
+    echo "      install '$tool' with your system package manager" >&2
+  fi
+}
 
 # Auto-detect CN-restricted networks. If proxy.golang.org is unreachable
 # within 3 seconds (typical on mainland China without VPN), fall back to
@@ -49,9 +110,11 @@ else
   mkdir -p "$BIN_DIR"
 fi
 
-# Check dependencies — install via brew if missing
+# Check dependencies — install via brew if available, otherwise point at the
+# system package manager.
 if ! command -v git &>/dev/null; then
-  echo "error: git is required but not found"
+  echo "error: git is required but not found. Install it with:" >&2
+  suggest_install git
   exit 1
 fi
 
@@ -60,32 +123,38 @@ if ! command -v go &>/dev/null; then
     echo "==> Installing Go via Homebrew ..."
     brew install go
   else
-    echo "error: go is required but not found (install with: brew install go)"
+    echo "error: go is required but not found. Install it with:" >&2
+    suggest_install go
     exit 1
   fi
 fi
 
 echo "==> Cloning lingtai ($REF) ..."
-git clone --depth 1 --branch "$REF" "$REPO" "$BUILD_DIR" 2>/dev/null || \
+if ! git clone --depth 1 --branch "$REF" "$REPO" "$BUILD_DIR" 2>/dev/null; then
+  # --branch only resolves branches and tags; fall back to a default clone
+  # plus an explicit fetch for commit SHAs and other refs. If that fetch
+  # fails too, the ref does not exist — fail instead of silently building main.
   git clone --depth 1 "$REPO" "$BUILD_DIR"
-
-if [[ "$REF" != "main" ]]; then
-  cd "$BUILD_DIR" && git fetch --depth 1 origin "$REF" && git checkout FETCH_HEAD 2>/dev/null || true
+  if [[ "$REF" != "main" ]]; then
+    if ! (cd "$BUILD_DIR" && git fetch --depth 1 origin "$REF" && git checkout --quiet FETCH_HEAD); then
+      echo "error: ref '$REF' not found in $REPO" >&2
+      exit 1
+    fi
+  fi
 fi
 
 VERSION=$(cd "$BUILD_DIR" && git describe --tags --always 2>/dev/null || echo "dev")
 
 echo "==> Building lingtai-tui ($VERSION) ..."
-cd "$BUILD_DIR/tui"
-CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-tui" .
+(cd "$BUILD_DIR/tui" && CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-tui" .)
 
 echo "==> Building lingtai-portal ($VERSION) ..."
-cd "$BUILD_DIR/portal"
 if command -v npm &>/dev/null; then
-  cd web && npm ci --silent && npm run build --silent && cd ..
-  CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-portal" .
+  (cd "$BUILD_DIR/portal/web" && npm ci --silent && npm run build --silent)
+  (cd "$BUILD_DIR/portal" && CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-portal" .)
 else
-  echo "    (skipping portal — npm not found)"
+  echo "    (skipping portal — npm not found; to include it, install npm and re-run:)"
+  suggest_install npm
 fi
 
 echo "==> Installing to $BIN_DIR ..."
@@ -100,9 +169,6 @@ fi
 if [[ -f "$BUILD_DIR/lingtai-portal" ]]; then
   install -m 755 "$BUILD_DIR/lingtai-portal" "$BIN_DIR/lingtai-portal"
 fi
-
-echo "==> Cleaning up ..."
-rm -rf "$BUILD_DIR"
 
 echo "==> Done. $("$BIN_DIR/lingtai-tui" version 2>&1 || echo "$VERSION")"
 

--- a/reports/install-sh-repair-20260611-explainer.html
+++ b/reports/install-sh-repair-20260611-explainer.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>install.sh source-helper repair — 2026-06-11</title>
+  <style>
+    :root { color-scheme: light dark; --bg:#0f172a; --card:#111827; --text:#e5e7eb; --muted:#9ca3af; --accent:#60a5fa; --ok:#34d399; --warn:#fbbf24; --line:#243044; }
+    @media (prefers-color-scheme: light) { :root { --bg:#f8fafc; --card:#ffffff; --text:#111827; --muted:#4b5563; --accent:#2563eb; --ok:#059669; --warn:#b45309; --line:#e5e7eb; } }
+    body { margin:0; font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--text); }
+    main { max-width:980px; margin:0 auto; padding:40px 20px 64px; }
+    h1 { font-size:34px; line-height:1.15; margin:0 0 10px; }
+    h2 { margin-top:28px; border-top:1px solid var(--line); padding-top:22px; }
+    .sub { color:var(--muted); margin-bottom:24px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:20px; margin:16px 0; box-shadow:0 10px 30px rgba(0,0,0,.12); }
+    ul { margin:10px 0 0 22px; padding:0; }
+    code { background:rgba(127,127,127,.16); padding:2px 6px; border-radius:6px; }
+    .ok { color:var(--ok); font-weight:700; }
+    .warn { color:var(--warn); font-weight:700; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:14px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>install.sh source-helper repair</h1>
+  <div class="sub">Focused repair for the source-build helper while keeping Homebrew as the primary distribution path.</div>
+
+  <section class="card">
+    <h2 style="margin-top:0;border-top:0;padding-top:0">Conclusion</h2>
+    <p><span class="ok">Scope kept narrow:</span> this patch does not replace Homebrew distribution, does not add release artifacts, and does not change TUI automatic upgrade. It only makes <code>install.sh</code> safer and clearer for people who use the source-build fallback.</p>
+  </section>
+
+  <section class="grid">
+    <div class="card">
+      <h2 style="margin-top:0;border-top:0;padding-top:0">What changed</h2>
+      <ul>
+        <li>Corrected the script header/help text: <code>install.sh</code> is a source-build helper; Homebrew remains primary.</li>
+        <li>Added <code>-h/--help</code> and clearer unknown-flag handling.</li>
+        <li>Added cleanup via <code>trap</code> so temporary build directories are removed on failures.</li>
+        <li>Made invalid <code>--ref</code> fail clearly instead of silently falling back to <code>main</code>.</li>
+        <li>Improved missing dependency hints for common package managers on macOS/Linux.</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2 style="margin-top:0;border-top:0;padding-top:0">Preserved behavior</h2>
+      <ul>
+        <li>Homebrew bin dir is still preferred when <code>brew</code> exists.</li>
+        <li>Non-Homebrew installs still fall back to writable <code>/usr/local/bin</code> or <code>~/.local/bin</code>.</li>
+        <li>Portal build is still skipped when <code>npm</code> is missing.</li>
+        <li>China-friendly Go/npm mirror auto-detection is unchanged.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2 style="margin-top:0;border-top:0;padding-top:0">Validation</h2>
+    <ul>
+      <li><code>bash -n install.sh</code> — <span class="ok">passed</span></li>
+      <li><code>./install.sh --help</code> — <span class="ok">passed</span></li>
+      <li><code>git diff --check</code> — <span class="ok">passed</span></li>
+    </ul>
+    <p class="sub"><span class="warn">Not run:</span> full source build/install, because that would compile and overwrite local binaries. The change is limited to shell control flow, help text, dependency hints, cleanup, and ref checkout behavior.</p>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## What

Focused repair for `install.sh` as a **source-build helper** while keeping Homebrew as the primary distribution path.

Changes:
- Corrects the script header/help text so it no longer implies Homebrew bin is the only install target.
- Adds `-h/--help` plus clearer unknown-flag errors.
- Adds an `EXIT` trap to clean the temporary build directory on failures.
- Makes invalid `--ref` fail clearly instead of silently building `main`.
- Improves missing dependency hints for common package managers (`brew`, `apt`, `dnf`, `pacman`, `apk`, `zypper`).
- Preserves the existing #239/#240 writable install-dir behavior: Homebrew bin → writable `/usr/local/bin` → `~/.local/bin` + PATH hint.

## Related issue context

This is a follow-up hardening PR for the installer area around #239/#240. It should **not** close #239 because #239 was already resolved by #240; this PR tightens the remaining source-helper ergonomics and failure modes found while revisiting that area.

## Intentional non-goals

- Does **not** replace Homebrew distribution.
- Does **not** add prebuilt release artifacts.
- Does **not** change TUI automatic upgrade behavior.
- Does **not** turn `install.sh` into a large dependency/bootstrap installer.

## Validation

- `bash -n install.sh`
- `./install.sh --help`
- `git diff --check`

Full source build/install not run during PR prep because it would compile and overwrite local binaries.

## Report

- `reports/install-sh-repair-20260611-explainer.html`
- `artifacts/install-sh-repair-20260611/summary.md`
