### PR TITLE
Avoid GitHub login prompts in install.sh

### DIFF
--- a/artifacts/install-sh-no-github-login-20260611/summary.md
+++ b/artifacts/install-sh-no-github-login-20260611/summary.md
@@ -1,0 +1,24 @@
+# install.sh no-GitHub-login repair — 2026-06-11
+
+Scope: follow-up after PR #305 because Jason saw `install.sh` ask for a GitHub account.
+
+Root cause / framing:
+- LingTai is public, so installation should not require a GitHub account.
+- The script used `git clone https://github.com/...`; on some machines git credential helpers, proxy config, or credential prompts can turn a public clone into an interactive login prompt.
+- Installers should be non-interactive and fail predictably.
+
+Change:
+- Replace normal source fetch from `git clone` with public GitHub codeload archive download: `https://codeload.github.com/Lingtai-AI/lingtai/tar.gz/<ref>`.
+- Remove normal `git` dependency.
+- Require/check `curl` and `tar` instead.
+- Keep Homebrew as the primary distribution path; `install.sh` remains a source-build helper.
+- Preserve writable bin fallback, PATH hint, CN mirror detection, and npm-missing portal skip.
+
+Validation:
+- `bash -n install.sh` passed.
+- `./install.sh --help` passed.
+- Invalid ref smoke test used the public archive URL and exited with a clear 404/error; stdout/stderr did not contain username/password/account prompts.
+- `git diff --check` passed.
+
+Not run:
+- Full source build/install, to avoid overwriting local binaries.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build lingtai-tui and lingtai-portal from source and install them.
+# Download LingTai's public source archive, build lingtai-tui and lingtai-portal, and install them.
 #
 # This is the source-build helper; Homebrew remains the primary install path
 # (brew install lingtai-ai/lingtai/lingtai-tui). Binaries are installed to the
@@ -14,13 +14,16 @@
 set -euo pipefail
 
 REF="main"
-REPO="https://github.com/Lingtai-AI/lingtai.git"
+ARCHIVE_BASE_URL="https://codeload.github.com/Lingtai-AI/lingtai/tar.gz"
 TMPDIR="${TMPDIR:-/tmp}"
-BUILD_DIR="$TMPDIR/lingtai-install-$$"
+WORK_DIR="$TMPDIR/lingtai-install-$$"
+ARCHIVE_FILE="$WORK_DIR/source.tar.gz"
+EXTRACT_DIR="$WORK_DIR/source"
+BUILD_DIR=""
 
 usage() {
   cat <<'EOF'
-Build lingtai-tui and lingtai-portal from source and install them.
+Download LingTai's public source archive, build lingtai-tui and lingtai-portal, and install them.
 
 Usage:
   curl -sSL https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/install.sh | bash
@@ -30,9 +33,10 @@ Options:
   --ref <ref>   Git branch, tag, or commit to build (default: main)
   -h, --help    Show this help
 
-Binaries are installed to the first of: Homebrew's bin directory, a writable
-/usr/local/bin, or ~/.local/bin. The portal is skipped when npm is missing.
-Homebrew remains the primary install path:
+The script downloads a public GitHub source archive instead of using `git clone`,
+so it should not ask for a GitHub account. Binaries are installed to the first
+of: Homebrew's bin directory, a writable /usr/local/bin, or ~/.local/bin. The
+portal is skipped when npm is missing. Homebrew remains the primary install path:
   brew install lingtai-ai/lingtai/lingtai-tui
 EOF
 }
@@ -48,7 +52,7 @@ done
 # Remove the build directory even when a build or install step fails midway.
 cleanup() {
   cd / 2>/dev/null || true
-  rm -rf "$BUILD_DIR"
+  rm -rf "$WORK_DIR"
 }
 trap cleanup EXIT
 
@@ -112,9 +116,14 @@ fi
 
 # Check dependencies — install via brew if available, otherwise point at the
 # system package manager.
-if ! command -v git &>/dev/null; then
-  echo "error: git is required but not found. Install it with:" >&2
-  suggest_install git
+if ! command -v curl &>/dev/null; then
+  echo "error: curl is required but not found. Install it with:" >&2
+  suggest_install curl
+  exit 1
+fi
+
+if ! command -v tar &>/dev/null; then
+  echo "error: tar is required but not found. Install it with your system package manager." >&2
   exit 1
 fi
 
@@ -129,21 +138,28 @@ if ! command -v go &>/dev/null; then
   fi
 fi
 
-echo "==> Cloning lingtai ($REF) ..."
-if ! git clone --depth 1 --branch "$REF" "$REPO" "$BUILD_DIR" 2>/dev/null; then
-  # --branch only resolves branches and tags; fall back to a default clone
-  # plus an explicit fetch for commit SHAs and other refs. If that fetch
-  # fails too, the ref does not exist — fail instead of silently building main.
-  git clone --depth 1 "$REPO" "$BUILD_DIR"
-  if [[ "$REF" != "main" ]]; then
-    if ! (cd "$BUILD_DIR" && git fetch --depth 1 origin "$REF" && git checkout --quiet FETCH_HEAD); then
-      echo "error: ref '$REF' not found in $REPO" >&2
-      exit 1
-    fi
-  fi
+echo "==> Downloading lingtai source archive ($REF) ..."
+mkdir -p "$EXTRACT_DIR"
+ARCHIVE_URL="$ARCHIVE_BASE_URL/$REF"
+if ! curl -fL --retry 2 --connect-timeout 10 "$ARCHIVE_URL" -o "$ARCHIVE_FILE"; then
+  echo "error: could not download public source archive for ref '$REF'." >&2
+  echo "       URL: $ARCHIVE_URL" >&2
+  echo "       Check the ref name and network access, then retry." >&2
+  exit 1
 fi
 
-VERSION=$(cd "$BUILD_DIR" && git describe --tags --always 2>/dev/null || echo "dev")
+if ! tar -xzf "$ARCHIVE_FILE" -C "$EXTRACT_DIR"; then
+  echo "error: downloaded source archive could not be extracted." >&2
+  exit 1
+fi
+
+BUILD_DIR=$(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+if [[ -z "$BUILD_DIR" || ! -d "$BUILD_DIR/tui" ]]; then
+  echo "error: downloaded archive did not contain the expected LingTai source tree." >&2
+  exit 1
+fi
+
+VERSION="$REF"
 
 echo "==> Building lingtai-tui ($VERSION) ..."
 (cd "$BUILD_DIR/tui" && CGO_ENABLED=0 go build -ldflags "-X main.version=$VERSION" -o "$BUILD_DIR/lingtai-tui" .)

--- a/reports/install-sh-no-github-login-20260611-explainer.html
+++ b/reports/install-sh-no-github-login-20260611-explainer.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>install.sh no-login source download repair</title>
+  <style>
+    :root { color-scheme: light dark; --bg:#0b1020; --card:#111827; --text:#e5e7eb; --muted:#9ca3af; --accent:#60a5fa; --ok:#34d399; --line:#253047; }
+    @media (prefers-color-scheme: light) { :root { --bg:#f8fafc; --card:#fff; --text:#111827; --muted:#4b5563; --accent:#2563eb; --ok:#059669; --line:#e5e7eb; } }
+    body { margin:0; font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--text); }
+    main { max-width:960px; margin:0 auto; padding:40px 20px 64px; }
+    h1 { font-size:34px; line-height:1.15; margin:0 0 10px; }
+    h2 { margin-top:26px; border-top:1px solid var(--line); padding-top:20px; }
+    .sub { color:var(--muted); margin-bottom:24px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:20px; margin:16px 0; }
+    ul { margin:8px 0 0 22px; padding:0; }
+    code { background:rgba(127,127,127,.16); padding:2px 6px; border-radius:6px; }
+    .ok { color:var(--ok); font-weight:700; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>install.sh no-login source download repair</h1>
+  <div class="sub">Follow-up after PR #305: make the source-build helper avoid GitHub account prompts.</div>
+
+  <section class="card">
+    <h2 style="margin-top:0;border-top:0;padding-top:0">Conclusion</h2>
+    <p><code>install.sh</code> should be non-interactive. Even though LingTai is public, using <code>git clone https://github.com/...</code> inside an installer can trigger local git credential helpers or network/proxy auth prompts on some machines. The fix is to download GitHub's public source archive via <code>codeload.github.com</code> instead of cloning.</p>
+  </section>
+
+  <section class="card">
+    <h2 style="margin-top:0;border-top:0;padding-top:0">What changed</h2>
+    <ul>
+      <li>Replaced <code>git clone</code> with <code>curl -fL https://codeload.github.com/Lingtai-AI/lingtai/tar.gz/&lt;ref&gt;</code>.</li>
+      <li>Removed the hard dependency on <code>git</code> for normal installer operation.</li>
+      <li>Added explicit <code>curl</code> and <code>tar</code> dependency checks.</li>
+      <li>Kept Homebrew as the primary distribution path; this remains a source-build helper.</li>
+      <li>Kept the writable install-dir fallback from #239/#240/#305.</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2 style="margin-top:0;border-top:0;padding-top:0">Validation</h2>
+    <ul>
+      <li><code>bash -n install.sh</code> — <span class="ok">passed</span></li>
+      <li><code>./install.sh --help</code> — <span class="ok">passed</span></li>
+      <li>Invalid ref smoke test downloads from public archive URL and exits with a clear 404/error, with no username/password prompt text — <span class="ok">passed</span></li>
+      <li><code>git diff --check</code> — <span class="ok">passed</span></li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## What

Follow-up to #305: make `install.sh` avoid GitHub account prompts during source download.

Changes:
- Replaces `git clone https://github.com/Lingtai-AI/lingtai.git` with a public GitHub codeload archive download: `https://codeload.github.com/Lingtai-AI/lingtai/tar.gz/<ref>`.
- Removes the normal `git` dependency from the source-build helper.
- Adds explicit `curl` and `tar` dependency checks.
- Keeps Homebrew as the primary distribution path; `install.sh` remains a source-build helper.
- Preserves writable bin fallback, PATH hint, China-friendly mirror detection, and npm-missing portal skip.

## Why

The repository is public, so the installer should not require a GitHub account. But using `git clone https://github.com/...` inside an installer can trigger local git credential helpers, proxy auth, or other interactive prompts on some machines. Installers should be non-interactive and fail predictably, so the script now uses the public archive endpoint instead.

## Validation

- `bash -n install.sh`
- `./install.sh --help`
- Invalid-ref smoke test: `TMPDIR=$(mktemp -d) ./install.sh --ref definitely-not-a-real-lingtai-ref-20260611` exits nonzero with a clear codeload 404/error and no username/password/account prompt text.
- `git diff --check`

Full source build/install not run during PR prep because it would compile and overwrite local binaries.

## Report

- `reports/install-sh-no-github-login-20260611-explainer.html`
- `artifacts/install-sh-no-github-login-20260611/summary.md`