### PR TITLE
docs: add CLI-Anything swiss-knife skill

### DIFF
--- a/reports/pr310-cli-anything-skill-explainer.html
+++ b/reports/pr310-cli-anything-skill-explainer.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PR #310 — CLI-Anything swiss-knife skill with web-browsing cross-route</title>
+<style>
+:root{--bg:#f6f8fc;--card:#fff;--ink:#172033;--muted:#5d6880;--line:#d8deea;--accent:#2457d6;--ok:#166534;--warn:#9a3412;--soft:#eef4ff}body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}main{max-width:1100px;margin:0 auto;padding:32px 20px 48px}.card{background:var(--card);border:1px solid var(--line);border-radius:18px;padding:24px;margin:18px 0;box-shadow:0 10px 30px rgba(28,43,78,.06)}h1{font-size:32px;line-height:1.15;margin:0 0 12px}h2{margin:0 0 14px;font-size:22px}.muted{color:var(--muted)}.badges{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}.badge{border:1px solid var(--line);border-radius:999px;padding:5px 10px;background:var(--soft);font-size:13px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(245px,1fr));gap:14px}.kpi{border:1px solid var(--line);border-radius:14px;padding:14px;background:#fbfcff}.kpi b{display:block;margin-bottom:8px}code{background:#f1f4f9;border:1px solid #dbe2ee;border-radius:6px;padding:1px 5px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.92em}.ok{color:var(--ok);font-weight:700}.warn{color:var(--warn);font-weight:700}ul{padding-left:22px}li{margin:7px 0}.flow{display:grid;grid-template-columns:1fr auto 1fr;gap:12px;align-items:center}.box{border:1px solid var(--line);border-radius:14px;padding:14px;background:#fbfcff}.arrow{font-size:24px;color:var(--accent);font-weight:700}@media(max-width:700px){.flow{grid-template-columns:1fr}.arrow{transform:rotate(90deg);text-align:center}}</style>
+</head>
+<body><main>
+<section class="card"><h1>PR #310: CLI-Anything as a swiss-knife skill, cross-routed from web-browsing</h1>
+<p class="muted">Issue <a href="https://github.com/Lingtai-AI/lingtai/issues/193">#193</a> asks whether LingTai can build and operate browser-based CLIs for authenticated websites. After reviewing <a href="https://github.com/HKUDS/CLI-Anything">HKUDS/CLI-Anything</a> and Claude Code fable's placement review, this PR keeps CLI-Anything in Swiss Knife while making web-browsing explicitly route action-taking site workflows to it.</p>
+<div class="badges"><span class="badge">Refs #193</span><span class="badge">Swiss Knife child skill</span><span class="badge">web-browsing cross-reference</span><span class="badge">Docs/skill only</span><span class="badge">No runtime behavior change</span></div></section>
+
+<section class="card"><h2>What changed</h2><div class="grid">
+<div class="kpi"><b>New skill reference</b><code>tui/internal/preset/skills/swiss-knife/reference/cli-anything/SKILL.md</code></div>
+<div class="kpi"><b>Swiss Knife router</b><code>swiss-knife/SKILL.md</code> now routes CLI-Anything, browser-based CLI, authenticated-site harness, and GUI/software/web workflow requests.</div>
+<div class="kpi"><b>web-browsing router</b><code>web-browsing/SKILL.md</code> now points action-taking authenticated-site workflows to the CLI-Anything reference instead of forcing them into the read/extract pipeline.</div>
+<div class="kpi"><b>PR scope corrected</b>The earlier broad core-feature proposal was removed; this is a reusable agent workflow/skill, not a browser automation substrate implementation.</div>
+</div></section>
+
+<section class="card"><h2>Routing model</h2>
+<div class="flow"><div class="box"><b>web-browsing</b><br>Use for reading: fetch, extract, scrape, search, JS-render, or inspect pages without side effects.</div><div class="arrow">⇄</div><div class="box"><b>swiss-knife / cli-anything</b><br>Use for acting/wrapping: browser-based CLI, authenticated-site operation, site-specific harnesses, and GUI/software/web workflow CLIs with explicit approval.</div></div>
+<p>The seam is <b>read vs. act</b>, not merely “web vs. CLI.” This avoids broadening web-browsing into a side-effecting automation manual while still making the CLI-Anything reference discoverable from the most likely entry point.</p></section>
+
+<section class="card"><h2>Safety and scope</h2>
+<ul>
+<li><span class="ok">Official APIs/MCPs first:</span> CLI-Anything is for cases where a stable API/MCP does not exist or the GUI workflow is the source of truth.</li>
+<li><span class="ok">Narrow harnesses:</span> prefer site-specific, testable commands with dry-run and structured output; do not promise arbitrary authenticated website automation.</li>
+<li><span class="ok">Explicit approval:</span> installing tools, launching apps, using logged-in sessions, sending messages, submitting forms, modifying records, deleting, buying, or other side effects require human authorization.</li>
+<li><span class="ok">No secret capture:</span> do not store raw credentials, cookies, MFA codes, recovery codes, or long-lived tokens in skills, reports, logs, or prompts.</li>
+<li><span class="warn">Anti-bot reality:</span> LinkedIn-like sites involve ToS, bot detection, rate limits, account safety, duplicate submission risks, and commercial-grade anti-automation challenges. CLI-Anything is a harness pattern, not a magic bypass.</li>
+</ul></section>
+
+<section class="card"><h2>Open-source references captured in the skill</h2>
+<p>The new reference distinguishes CLI harnesses from the deeper agent-native browser substrate and points agents to projects worth evaluating:</p>
+<ul>
+<li>Browser Use</li><li>Stagehand</li><li>Skyvern</li><li>BrowserOS</li><li>Steel Browser</li><li>DOMShell</li><li>LaVague</li><li>CLI-Anything</li>
+</ul></section>
+
+<section class="card"><h2>Validation status</h2>
+<ul>
+<li><code>git diff --check</code> passed after the skill/router edits.</li>
+<li><code>go test ./internal/preset</code> is the relevant bundled-skill/package smoke check.</li>
+<li>Jason requested extra independent daemon opinions after the skill edits; review artifacts were captured in the agent workspace and their actionable nits were folded into this diff.</li>
+</ul></section>
+</main></body></html>

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -9,7 +9,9 @@ description: >
   transcription and music analysis; academic-research for fetching papers,
   citation networks, and LaTeX writing; dj for journal-inspired music
   generation; token-usage for token/cost reports; html-report for standalone
-  browser deliverables; xiaomi-mimo for Xiaomi MiMo provider discovery;
+  browser deliverables; cli-anything for authenticated websites without APIs,
+  browser-based or site-specific CLI harnesses, and agent-native
+  GUI/software/web workflows; xiaomi-mimo for Xiaomi MiMo provider discovery;
   zhipu-coding-plan for Z.AI / BigModel coding-plan capabilities; headless-bot
   for provisioning fresh LingTai bot projects such as Telegram bots from
   `lingtai-tui spawn`; find-something-to-do for idle curiosity practice;
@@ -17,7 +19,7 @@ description: >
   keys, missing credentials, unreachable endpoints, invalid model/config). This
   parent is the route map; each nested reference is self-contained under
   `reference/<name>/SKILL.md`.
-version: 2.3.0
+version: 2.4.0
 tags: [utilities, umbrella, toolkit, nested-skill]
 ---
 
@@ -96,6 +98,14 @@ nested_references:
       Nested swiss-knife reference for standalone HTML deliverables. Read this
       when the human asks for a polished browser-openable report, dashboard,
       memo, comparison, or any HTML artifact with MathJax equations.
+  - name: cli-anything
+    location: reference/cli-anything/SKILL.md
+    description: >
+      Nested swiss-knife reference for CLI-Anything. Read this when the human
+      asks whether to use CLI-Anything, wants a browser-based or site-specific
+      CLI harness, needs a practical way to approach authenticated websites
+      without public APIs, or wants an agent-native harness for a GUI/software/web
+      workflow using CLI-Hub, existing harnesses, or a scoped new harness design.
   - name: xiaomi-mimo
     location: reference/xiaomi-mimo/SKILL.md
     description: >
@@ -147,6 +157,7 @@ nested_references:
 | Compose music from a project journal, session mood, or requested genre | `reference/dj/SKILL.md` |
 | Report token usage or model costs | `reference/token-usage/SKILL.md` |
 | Produce standalone HTML reports/dashboards/memos | `reference/html-report/SKILL.md` |
+| Use CLI-Anything / CLI-Hub; design a browser-based or site-specific CLI harness; operate an authenticated site with explicit approval; wrap GUI/software/web workflows for agents | `reference/cli-anything/SKILL.md` |
 | Discover/configure Xiaomi MiMo | `reference/xiaomi-mimo/SKILL.md` |
 | Discover/configure Zhipu / Z.AI coding-plan capabilities | `reference/zhipu-coding-plan/SKILL.md` |
 | Create or automate a headless LingTai bot project, including Telegram bots | `reference/headless-bot/SKILL.md` |

--- a/tui/internal/preset/skills/swiss-knife/reference/cli-anything/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/cli-anything/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: cli-anything
+description: >
+  Nested swiss-knife reference for CLI-Anything. Use this for authenticated
+  websites without public APIs, browser-based CLIs, site-specific harnesses,
+  CLI-Hub discovery, or agent-native CLI harnesses for GUI, desktop software,
+  web-service, and browser workflows. If the task is only to fetch, extract,
+  scrape, or search web content, use the web-browsing skill instead.
+version: 1.0.0
+tags: [cli, automation, cli-anything, cli-hub, browser, gui, harness, web-browsing, authenticated-site]
+---
+
+# CLI-Anything — Agent-Native CLI Harnesses
+
+[CLI-Anything](https://github.com/HKUDS/CLI-Anything) is an ecosystem for making
+software “agent-native” by wrapping GUI applications, services, and workflows in
+command-line harnesses. Its README describes two entry points:
+
+1. **CLI-Hub** — `pip install cli-anything-hub`, then `cli-hub list/search/info/install/launch` to discover and run existing harnesses.
+2. **Harness generation / plugin workflow** — a SKILL/plugin-guided workflow that builds a new harness, tests it, documents it, and installs it as a CLI.
+
+Use this reference as the LingTai swiss-knife bridge: first look for an existing
+CLI-Hub harness; if none fits, design a narrow harness with explicit safety,
+tests, and audit logging.
+
+**Read vs. act boundary:** if the task is only to fetch, extract, scrape, search,
+or JS-render a webpage, route back to `web-browsing` and its `extract_page.py`
+pipeline. Use this reference when the goal is to expose an application workflow as
+a command interface or operate an authenticated site under explicit approval.
+
+## Read this when
+
+- The human asks “can we use CLI-Anything for this?”
+- A task asks for a browser-based CLI, site-specific harness, or practical path
+  for an authenticated website with no clean public API.
+- A task needs a reusable command interface for GUI software, desktop apps,
+  browser workflows, web services, or authenticated websites without a clean API.
+- You are considering turning a repeated browser/manual workflow into a LingTai
+  skill or local CLI.
+- You arrived from `web-browsing` because the need changed from reading content
+  to operating a site or wrapping a workflow.
+- A GitHub issue asks for “browser-based CLI”, “site-specific CLI harness”,
+  “agent-native software”, or similar.
+
+## Hard safety rules
+
+- **Do not install packages, launch external apps, or operate authenticated
+  websites without explicit human approval.** Discovery and repo inspection are
+  fine; installation/execution against real accounts is a side effect.
+- **Prefer official APIs and MCPs first.** CLI-Anything is most useful when no
+  stable API/MCP exists, or when a GUI workflow is the source of truth.
+- **Do not ask agents to handle credentials, cookies, session storage,
+  `localStorage`, MFA codes, recovery codes, or long-lived tokens.** Do not pass
+  them through CLI flags, environment variables, prompts, logs, or skill files. If
+  a browser harness needs login, prefer a human-owned local browser/profile/session
+  and document only the non-secret setup.
+- **Separate read/draft/action modes.** Read-only inspection is safer; sending
+  messages, submitting forms, changing records, or bulk operations need explicit
+  approval and an audit log.
+- **Respect site terms and rate limits.** Do not use browser automation to bypass
+  access controls, CAPTCHAs, anti-bot systems, or terms-of-service restrictions.
+
+## Quick decision tree
+
+1. **Is there an official API or existing LingTai MCP?** Use that instead of a
+   browser/GUI harness.
+2. **Is there an existing CLI-Hub harness?** Search CLI-Hub; if one matches,
+   inspect its README/SKILL before installing.
+3. **Is the task one-off?** If yes, do not build a harness; use normal browser,
+   web, or manual handoff.
+4. **Is the workflow repeated and structured?** Design a narrow CLI harness with
+   a manifest, JSON output, tests, and logs.
+5. **Does it touch authenticated external state?** Start with `read_only`, then
+   `draft_only`, then `approve_before_action`. Treat `full_action` as a future,
+   explicit, allowlisted mode only.
+
+## Inspect CLI-Anything / CLI-Hub
+
+Use a temporary workspace first. Do not install globally unless the human asks.
+
+```bash
+# Read-only repo inspection
+cd /tmp
+git clone --depth 1 https://github.com/HKUDS/CLI-Anything.git
+cd CLI-Anything
+grep -n "^##" README.md | head -80
+find . -maxdepth 2 -type f | sort | head -120
+```
+
+If the human approves installing the hub, prefer a project-local venv:
+
+```bash
+python3 -m venv .venv-cli-hub
+. .venv-cli-hub/bin/activate
+python -m pip install --upgrade pip
+python -m pip install cli-anything-hub
+
+cli-hub list
+cli-hub search browser
+cli-hub info browser
+cli-hub info web-yu-pri
+```
+
+CLI-Hub commands from the upstream README:
+
+| Command | Use |
+|---|---|
+| `cli-hub list` | Browse registry |
+| `cli-hub search <query>` | Search by keyword |
+| `cli-hub info <name>` | Inspect one harness |
+| `cli-hub install <name>` | Install a harness |
+| `cli-hub update <name>` | Update an installed harness |
+| `cli-hub uninstall <name>` | Remove an installed harness |
+| `cli-hub launch <name> [args...]` | Run an installed harness |
+
+Some harnesses require upstream software such as Blender, GIMP, Chrome/Edge,
+DOMShell, Playwright, or a specific service account. Check `cli-hub info` and the
+harness README before use.
+
+## Important distinction: harness vs agent-native browser
+
+For issue #193-style requests, be precise about the layer:
+
+- A **harness** exposes a known workflow as commands (`search`, `read`, `draft`,
+  `submit`) once the underlying app/browser can be controlled reliably.
+- An **agent-native browser** is the lower substrate that makes arbitrary pages
+  observable and actionable for agents: stable page state, handles/semantic tree,
+  browser sessions, screenshots/traces, action execution, and safety controls.
+
+LingTai should not pretend that a single generated harness can solve arbitrary
+authenticated websites. The practical path is to study or integrate an
+agent-native browser/browser-agent substrate, then build narrow harnesses on top
+of it for repeated workflows.
+
+## Open-source projects to review
+
+When the human asks for agent-native browser projects, start with these candidates
+(read their READMEs and licenses before recommending adoption):
+
+| Project | What it is useful for | Notes |
+|---|---|---|
+| [`browser-use/browser-use`](https://github.com/browser-use/browser-use) | Python library to make websites accessible to AI agents using browser automation. | Strong general-purpose browser-agent reference; Playwright-oriented. |
+| [`browserbase/stagehand`](https://github.com/browserbase/stagehand) | SDK for browser agents combining code and natural-language browser actions. | Good for production-ish browser workflows where code plus AI fallbacks are both useful. |
+| [`Skyvern-AI/skyvern`](https://github.com/Skyvern-AI/skyvern) | AI browser workflow automation using LLMs/computer vision. | Closer to workflow automation/RPA for websites; useful comparison for action reliability. |
+| [`browseros-ai/BrowserOS`](https://github.com/browseros-ai/BrowserOS) | Open-source agentic browser. | More “browser product” shaped than a harness; useful when the problem is the browser substrate itself. |
+| [`steel-dev/steel-browser`](https://github.com/steel-dev/steel-browser) | Open-source browser API/sandbox for AI agents and apps. | Useful if the need is managed browser infrastructure/API rather than per-site CLI. |
+| [`apireno/DOMShell`](https://github.com/apireno/DOMShell) | Maps Chrome accessibility/browser state toward a shell/MCP-like interface. | Relevant to filesystem/handle-addressable browser control; CLI-Anything has a `browser` harness using DOMShell. |
+| [`lavague-ai/LaVague`](https://github.com/lavague-ai/LaVague) | Large Action Model framework for AI web agents. | Older but still conceptually useful for natural-language-to-browser-action pipelines. |
+| [`HKUDS/CLI-Anything`](https://github.com/HKUDS/CLI-Anything) | Ecosystem for agent-native CLI harnesses and CLI-Hub discovery. | Best treated as the harness/workflow layer; not by itself a full agent-native browser. |
+
+Use these as references, not as a blanket endorsement. For each concrete task,
+verify current maintenance state, install model, runtime requirements, licenses,
+security posture, and whether authenticated sessions are handled safely.
+
+## Relationship to web-browsing
+
+Use `web-browsing` first for **reading**: fetch, extract, scrape, search,
+JavaScript-render, or inspect a page without side effects. Use this CLI-Anything
+reference for **acting/wrapping**: authenticated workflows, browser-based CLIs,
+site-specific harnesses, command interfaces for repeated manual steps, and any
+workflow that could submit, modify, send, delete, buy, or otherwise mutate
+external state.
+
+This cross-reference is intentional: `web-browsing` is the read/extract/search
+router; Swiss Knife owns small tool/harness references. Agents should move
+between the two based on the read-vs-act boundary, not just on whether a browser
+is involved.
+
+## Relevance to browser/authenticated-site work
+
+CLI-Anything is relevant to raw browser-site issues because its registry already
+contains web/browser-oriented examples, including:
+
+- `browser` — browser automation via DOMShell MCP, mapping Chrome's Accessibility
+  Tree to a virtual filesystem for navigation.
+- `web-yu-pri` — an example of a site-specific browser workflow harness for a
+  real web service, including login/inspection/screenshot/dry-run style tasks.
+- other web CLIs in the registry, such as browser/search/form-oriented tools.
+
+That means LingTai does **not** need to invent the entire idea from scratch. For
+an issue asking for “browser-based CLIs for websites with no API”, the practical
+LingTai response is usually:
+
+1. Add/use this swiss-knife skill.
+2. Search CLI-Hub for an existing harness.
+3. If none exists, create a scoped site-specific harness following the safety
+   contract below.
+4. Record usage in a LingTai skill so future agents can call the CLI correctly.
+
+## New harness safety contract
+
+For a new site or app harness, require these before action-taking use:
+
+- **Manifest / README:** name, target site/app, prerequisites, install commands,
+  command list, and risk mode for each command.
+- **Modes:** classify commands as `read_only`, `draft_only`,
+  `approve_before_action`, or explicitly opt-in `full_action`.
+- **Structured output:** commands should support JSON output.
+- **No secret handling:** do not store or print raw credentials/session cookies.
+- **Audit log:** append command, timestamp, redacted args, target identifiers,
+  result status, and screenshots/traces where useful.
+- **Idempotency / duplicate protection:** especially for send/submit/update
+  commands.
+- **Tests:** at least command parsing, output schema, dry-run behavior, and one
+  fixture/mocked workflow where possible.
+- **Human-readable skill:** write or update a LingTai skill that tells agents
+  exactly when and how to use the harness.
+
+## Suggested LingTai workflow
+
+When asked to use CLI-Anything for a task:
+
+1. **Acknowledge** the human and state that install/account actions require
+   explicit approval.
+2. **Inspect** the upstream repo/registry read-only.
+3. **Search** for an existing harness by app/site/domain.
+4. **Report fit:** direct fit, partial fit, or no fit.
+5. If direct fit and approved, install in an isolated venv/worktree and run a
+   harmless `--help` / read-only command first.
+6. If no fit, propose a narrow harness scope: commands, modes, prerequisites,
+   test plan, and audit log format.
+7. Only after approval, implement the harness and corresponding LingTai skill.
+
+## Example answer pattern
+
+```text
+CLI-Anything is a good fit as the harness layer, not as a magic full solution.
+I found/ did not find an existing CLI-Hub harness for <site>. If we proceed, I
+recommend starting with read-only commands:
+
+- <site>-cli inspect-session
+- <site>-cli search ... --json
+- <site>-cli read-item <id> --json
+
+Action commands such as send/update/submit should be draft-only or
+approve-before-action until the workflow has tests and an audit log.
+```
+
+## Notes for issue #193-style requests
+
+For requests like “Let LingTai build and operate browser-based CLIs for any
+website”, do **not** claim the issue is solved by installing CLI-Anything alone.
+CLI-Anything provides the right ecosystem/pattern, but each authenticated site
+still needs review, a scoped harness, user-owned session handling, and safety
+mode design.
+
+A small first PR should therefore add this skill and document the operational
+workflow. A later PR can add a concrete harness for one low-risk site or demo.

--- a/tui/internal/preset/skills/web-browsing/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/SKILL.md
@@ -5,8 +5,12 @@ description: >
   `python3 <skill-path>/scripts/extract_page.py <URL>`: it auto-tiers across
   PDFs, metadata APIs, trafilatura, BeautifulSoup, Playwright, Jina, and AI
   search. Read this router when the script fails, you need site/tier routing,
-  or you are composing a multi-step web/research pipeline.
-version: 3.1.0
+  or you are composing a multi-step web/research pipeline. If the task is to
+  operate an authenticated site or build a browser-based/site-specific CLI
+  harness instead of reading content, route to swiss-knife's CLI-Anything
+  reference.
+version: 3.2.0
+tags: [web, browsing, extraction, scraping, search, cli-anything, browser-harness]
 ---
 
 # web-browsing — Router
@@ -41,6 +45,11 @@ python3 <skill-path>/scripts/extract_page.py "https://example.com" --json out.js
 Read further only if that returns nothing useful, you need a custom extraction
 shape, or you are composing a multi-step pipeline such as academic search → DOI
 → free PDF → text.
+
+If the goal is not to read/extract/search content but to **operate** an
+authenticated site, submit actions, or design a browser-based/site-specific CLI
+harness, do not force it into the extractor pipeline. Route to Swiss Knife's
+CLI-Anything reference: `../swiss-knife/reference/cli-anything/SKILL.md`.
 
 ## Nested reference catalog
 
@@ -77,7 +86,8 @@ URL arrives → run scripts/extract_page.py first
   ├─ Needs structured scraping?   → Tier 2 BeautifulSoup
   ├─ JS-rendered/protected?       → Tier 3 Playwright stealth
   ├─ Still failing?               → Tier 4 Jina Reader / Firecrawl
-  └─ Need to discover content?    → Tier 5 search / AI-native search
+  ├─ Need to discover content?    → Tier 5 search / AI-native search
+  └─ Need to operate a site?      → Swiss Knife CLI-Anything reference
 ```
 
 ## Router table
@@ -86,6 +96,7 @@ URL arrives → run scripts/extract_page.py first
 |---|---|
 | Specific tier commands; manual PDF/API/Trafilatura/BeautifulSoup/Playwright/Jina/Firecrawl/search examples | `reference/tier-quick-refs/SKILL.md` |
 | Auto-tier misroutes a page; choose a tier; per-site recommendations; limitations; real-time data endpoints | `reference/routing-and-sites/SKILL.md` |
+| Operate an authenticated website; submit actions; build a browser-based CLI; design a site-specific harness; use CLI-Anything / CLI-Hub for a web workflow with side effects | `../swiss-knife/reference/cli-anything/SKILL.md` (sibling skill path from the bundled skills root) |
 | Editing or validating this skill; bundled JSON asset files; deep-dive reference index; semantic sweep and dirty-first testing | `reference/maintenance-bundles/SKILL.md` |
 
 ## Tier overview
@@ -109,5 +120,8 @@ URL arrives → run scripts/extract_page.py first
 - Prefer source-specific APIs for structured/current data when available.
 - Do not use web browsing for content already in the conversation or when an MCP
   or first-class tool covers the source more cleanly.
+- Do not use this skill to justify side-effecting authenticated-site automation.
+  For browser-based CLIs or site-specific harnesses, route to Swiss Knife's
+  CLI-Anything reference and require explicit human authorization.
 - When changing this skill, run the maintenance reference's semantic sweep so the
   script, JSON asset files, and docs stay aligned.

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -41,6 +41,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/token-usage/scripts/custom_pricing.json",
 		"reference/html-report/SKILL.md",
 		"reference/html-report/assets/template.html",
+		"reference/cli-anything/SKILL.md",
 		"reference/headless-bot/SKILL.md",
 		"reference/headless-bot/scripts/create_telegram_bot_project.py",
 		"reference/xiaomi-mimo/SKILL.md",


### PR DESCRIPTION
## Summary

Refs Lingtai-AI/lingtai#193 (the broad issue is now closed manually as `not planned` after a detailed explanation; this PR keeps the narrow reusable workflow).

This PR adds a **Swiss Knife child skill for CLI-Anything / agent-native browser harness research** instead of a broad core-feature proposal. The goal is to give LingTai agents a practical, reusable workflow for issue #193-style requests: discover/use existing CLI-Anything harnesses first, distinguish read-only web browsing from side-effecting website operation, understand when the real need is an agent-native browser substrate, and only design a narrow new harness when explicitly authorized.

Changes:
- Adds `tui/internal/preset/skills/swiss-knife/reference/cli-anything/SKILL.md`.
- Updates `tui/internal/preset/skills/swiss-knife/SKILL.md` to route CLI-Anything / CLI-Hub / browser-based CLI / site-specific harness / authenticated-site workflow requests.
- Updates `tui/internal/preset/skills/web-browsing/SKILL.md` with a cross-route: web-browsing remains the read/extract/search router, while side-effecting authenticated-site operation or harness design routes to Swiss Knife's CLI-Anything reference.
- Updates `tui/internal/preset/swiss_knife_populate_test.go` so the bundled-library test guards the new `reference/cli-anything/SKILL.md` file.
- Adds a refreshed standalone PR explainer: `reports/pr310-cli-anything-skill-explainer.html`.

The skill covers:
- when to use CLI-Anything vs official APIs/MCPs;
- CLI-Hub discovery commands (`cli-hub list/search/info/install/launch`);
- the distinction between a workflow **harness** and an **agent-native browser** substrate;
- the read-vs-act boundary between `web-browsing` and `swiss-knife/reference/cli-anything`;
- open-source projects to review: Browser Use, Stagehand, Skyvern, BrowserOS, Steel Browser, DOMShell, LaVague, and CLI-Anything;
- existing browser/web relevance from CLI-Anything (`browser`, `web-yu-pri`, and web-category harnesses);
- safe workflow for authenticated websites with no public API;
- strict rules for credentials, cookies, session storage, localStorage, tokens, action modes, approval, and audit logs;
- how to scope a future site-specific harness without claiming #193 is fully solved.

## Validation

Docs/skill-only change; no runtime behavior change.

- `git diff --check`
- `go test ./internal/preset` from `tui/`
- Manual router sanity check: parent `swiss-knife` catalog/routing table points to `reference/cli-anything/SKILL.md`; `web-browsing` points side-effecting website/harness tasks to the same reference.
- Extra review passes: Claude Code fable plus Zhipu, MiMo, DeepSeek, and MiniMax daemon reviews. The one concrete blocker found by MiMo (new skill not covered by the bundled-library population test) was fixed.

## Notes

This PR intentionally keeps `Refs #193` rather than `Closes #193` in the code-facing narrative. It gives LingTai agents a concrete CLI-Anything / agent-native-browser research workflow for the request, but arbitrary authenticated website automation still needs a separate browser-agent substrate, user-owned session handling, tests, and audit logging before any action-taking use.