### PR TITLE
Raise default agent max_turns to 500

### DIFF
--- a/examples/init.jsonc
+++ b/examples/init.jsonc
@@ -158,9 +158,10 @@
     // Empty = use default molt behavior.
     "molt_prompt": "",
 
-    // Max LLM request turns per wake cycle.
-    // Safety limit — agent sleeps after this many turns.
-    "max_turns": 50,
+    // Per-wake loop budget: max iterations of the LLM/tool-call loop per
+    // wake cycle. Every tool call counts as a turn, not just LLM requests.
+    // Safety limit — agent sleeps once the budget is exhausted.
+    "max_turns": 500,
 
     // -------------------------------------------------------
     // Admin privileges

--- a/reports/pr317-max-turns-500-explainer.html
+++ b/reports/pr317-max-turns-500-explainer.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Raise default agent max_turns to 500</title>
+  <style>
+    :root { color-scheme: light; --bg:#f7f4ef; --card:#fffaf2; --ink:#24211d; --muted:#6f665c; --line:#dfd4c5; --accent:#9b4d2e; --ok:#28724f; --code:#2f2923; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--ink); line-height:1.55; }
+    main { max-width:980px; margin:0 auto; padding:40px 22px 64px; }
+    header { margin-bottom:26px; }
+    .eyebrow { text-transform:uppercase; letter-spacing:.12em; color:var(--accent); font-weight:700; font-size:12px; }
+    h1 { font-size:34px; line-height:1.1; margin:8px 0 12px; }
+    h2 { margin-top:30px; border-top:1px solid var(--line); padding-top:20px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:18px 20px; box-shadow:0 1px 2px rgba(0,0,0,.04); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:14px; }
+    .muted { color:var(--muted); }
+    code, pre { font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+    pre { overflow:auto; background:var(--code); color:#fff6e8; padding:14px 16px; border-radius:12px; font-size:13px; }
+    .ok { color:var(--ok); font-weight:700; }
+    ul { padding-left:22px; }
+    .pill { display:inline-block; border:1px solid var(--line); border-radius:999px; padding:3px 10px; margin:3px 4px 3px 0; background:#fff; color:var(--muted); font-size:13px; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div class="eyebrow">LingTai TUI PR explainer</div>
+    <h1>Raise normal agent loop budget defaults to <code>max_turns: 500</code></h1>
+    <p class="muted">Prepared 2026-06-12 for PR #317. This is the separate follow-up PR Jason requested after the loop-guard investigation.</p>
+  </header>
+
+  <section class="card">
+    <h2 style="border:0;padding-top:0;margin-top:0">TL;DR</h2>
+    <p>The TUI-created agent default now writes <code>manifest.max_turns = 500</code> instead of 100. The shipped init templates/examples now describe <code>max_turns</code> as the per-wake LLM/tool-call loop budget, because tool-heavy work consumes the same guard budget.</p>
+  </section>
+
+  <h2>Baseline</h2>
+  <div class="grid">
+    <div class="card"><strong>Observed problem</strong><br><span class="muted">Long review/polling sessions can hit <code>tool_loop_limit</code> because the normal agent guard budget is only 100 for TUI-created agents.</span></div>
+    <div class="card"><strong>Root cause</strong><br><span class="muted"><code>max_turns</code> is currently used as a per-wake loop/tool-call budget, not merely an LLM request count.</span></div>
+    <div class="card"><strong>Requested decision</strong><br><span class="muted">Jason asked to be generous and set the default directly to 500.</span></div>
+  </div>
+
+  <h2>What changed</h2>
+  <p><span class="pill">tui/internal/preset/preset.go</span><span class="pill">templates/init.jsonc</span><span class="pill">examples/init.jsonc</span><span class="pill">setup-playground.sh</span><span class="pill">preset_test.go</span></p>
+  <pre><code>// TUI-generated init.json default
+manifest["max_turns"] = 500</code></pre>
+  <pre><code>// Per-wake loop budget: max iterations of the LLM/tool-call loop per
+// wake cycle. Every tool call counts as a turn, not just LLM requests.
+// Safety limit — agent sleeps once the budget is exhausted.
+"max_turns": 500</code></pre>
+  <p>The playground setup script now matches the wizard default. The preset test now pins generated <code>manifest.max_turns == 500</code> so the default cannot drift silently.</p>
+
+  <h2>Validation</h2>
+  <ul>
+    <li><span class="ok">Passed</span>: <code>cd tui &amp;&amp; go test ./internal/preset -count=1</code></li>
+    <li><span class="ok">Passed</span>: <code>git diff --check</code></li>
+    <li>Reviewed all repo <code>max_turns</code> mentions; daemon override docs and old kernel design notes were left out of scope.</li>
+  </ul>
+
+  <h2>Risks and decisions</h2>
+  <ul>
+    <li>This does not remove the loop guard; it only raises the normal TUI-created agent default.</li>
+    <li>This does not change daemon-specific budgets, duplicate-call protection, invalid-tool handling, or polling behavior.</li>
+    <li>Existing agents keep their current <code>init.json</code> value until manually changed; this PR affects newly generated configs/templates/playgrounds.</li>
+  </ul>
+
+  <h2>Next steps</h2>
+  <p>Review the small diff, then merge only with explicit approval. No release/tag work is included in this PR.</p>
+
+  <h2>Source index</h2>
+  <ul>
+    <li><code>tui/internal/preset/preset.go</code> — generated init default.</li>
+    <li><code>tui/internal/preset/preset_test.go</code> — focused default assertion.</li>
+    <li><code>tui/internal/preset/templates/init.jsonc</code> and <code>examples/init.jsonc</code> — shipped config references.</li>
+    <li><code>tui/scripts/setup-playground.sh</code> — local playground seed config.</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1386,7 +1386,10 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 	manifest["context_limit"] = opts.ContextLimit
 	manifest["molt_pressure"] = opts.MoltPressure
 	manifest["molt_prompt"] = ""
-	manifest["max_turns"] = 100
+	// Per-wake loop budget: every iteration of the LLM/tool-call loop
+	// counts as a turn, not just LLM requests, so tool-heavy work burns
+	// through it quickly. The agent sleeps when the budget is exhausted.
+	manifest["max_turns"] = 500
 	manifest["max_rpm"] = opts.MaxRpm
 	// AED max-attempts: normalize through ClampAedAttempts so a zero-value
 	// AgentOpts (caller didn't set it) still writes a valid default rather

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -198,6 +198,9 @@ func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 		if manifest["agent_name"] != "test-agent" {
 			t.Errorf("agent_name = %v, want %q", manifest["agent_name"], "test-agent")
 		}
+		if got, want := manifest["max_turns"], float64(500); got != want {
+			t.Errorf("max_turns = %v, want %v", got, want)
+		}
 
 		// Check .agent.json exists
 		agentPath := filepath.Join(lingtaiDir, "test-agent", ".agent.json")

--- a/tui/internal/preset/templates/init.jsonc
+++ b/tui/internal/preset/templates/init.jsonc
@@ -126,9 +126,10 @@
     // Empty = use default molt behavior.
     "molt_prompt": "",
 
-    // Max LLM request turns per wake cycle.
-    // Safety limit — agent sleeps after this many turns.
-    "max_turns": 50,
+    // Per-wake loop budget: max iterations of the LLM/tool-call loop per
+    // wake cycle. Every tool call counts as a turn, not just LLM requests.
+    // Safety limit — agent sleeps once the budget is exhausted.
+    "max_turns": 500,
 
     // Max LLM API requests per minute, gated at the adapter layer.
     // Shared across all agents in the same TUI process that use the same

--- a/tui/scripts/setup-playground.sh
+++ b/tui/scripts/setup-playground.sh
@@ -57,7 +57,7 @@ cat > "$ORCH_DIR/init.json" << INITEOF
     "context_limit": null,
     "molt_pressure": 0.8,
     "molt_prompt": "",
-    "max_turns": 100,
+    "max_turns": 500,
     "admin": {"karma": true},
     "streaming": true
   },


### PR DESCRIPTION
## Summary
- raise the TUI-generated normal agent `manifest.max_turns` default from 100 to 500
- update shipped init templates/examples to describe `max_turns` as the per-wake LLM/tool-call loop budget
- pin the generated default in `tui/internal/preset` tests and align the playground seed config
- add a self-contained PR explainer at `reports/pr317-max-turns-500-explainer.html`

## Validation
- `cd tui && go test ./internal/preset -count=1`
- `git diff --check`

## Notes
- Existing agents keep their current `init.json`; this affects newly generated configs/templates/playgrounds.
- This does not remove the loop guard or change daemon-specific budgets.