### PR TITLE
docs(dev-guide): add stale worktree cleanup procedure

### DIFF
--- a/reports/stale-worktree-cleanup-guide-20260612.html
+++ b/reports/stale-worktree-cleanup-guide-20260612.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stale Worktree Cleanup Guide — docs PR explainer</title>
+<style>
+  :root {
+    --ink: #2b2620; --paper: #faf6ef; --card: #ffffff; --accent: #9a6b2f;
+    --line: #e3d9c8; --code-bg: #f3ede1; --good: #3a7d44; --warn: #a05c12;
+  }
+  body { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+         background: var(--paper); color: var(--ink); margin: 0; line-height: 1.55; }
+  main { max-width: 860px; margin: 0 auto; padding: 2rem 1.2rem 4rem; }
+  h1 { font-size: 1.5rem; border-bottom: 3px solid var(--accent); padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; color: var(--accent); margin-top: 2rem; }
+  .meta { font-size: .85rem; color: #6f6455; }
+  section { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+            padding: 1rem 1.3rem; margin-top: 1rem; }
+  code, pre { font-family: "SF Mono", Menlo, Consolas, monospace; font-size: .85em; }
+  code { background: var(--code-bg); padding: .1em .35em; border-radius: 4px; }
+  pre { background: var(--code-bg); padding: .8rem 1rem; border-radius: 6px;
+        overflow-x: auto; line-height: 1.4; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; font-size: .9rem; }
+  th, td { border: 1px solid var(--line); padding: .4rem .6rem; text-align: left; vertical-align: top; }
+  th { background: var(--code-bg); }
+  .ok { color: var(--good); font-weight: 600; }
+  .keep { color: var(--warn); font-weight: 600; }
+  ul { padding-left: 1.3rem; }
+  .diff-add { color: var(--good); }
+</style>
+</head>
+<body>
+<main>
+<h1>Stale Worktree Cleanup Guide</h1>
+<p class="meta">Docs PR · branch <code>docs/stale-worktree-cleanup-guide-20260612</code> · 2026-06-12 · requested by Jason</p>
+
+<section>
+<h2>TL;DR</h2>
+<p>The dev guide's worktree loop said "clean up the worktree" but never explained how, so stale
+worktrees accumulate across agents and repos. This PR adds a <strong>"Worktree hygiene"</strong>
+section to <code>reference/contributing/SKILL.md</code> — audit recipe, removal criteria,
+keep/skip list, removal commands, record-and-report step — and routes to it from the top-level
+<code>lingtai-dev-guide</code> router. Docs only; no code changes.</p>
+</section>
+
+<section>
+<h2>Baseline</h2>
+<p>An actual cleanup on 2026-06-12 swept secondary worktrees in <code>Lingtai-AI/lingtai</code> and
+<code>Lingtai-AI/lingtai-kernel</code>. The policy that emerged (merged-only, remote-gone-only,
+skip source-dirty, protect the live release target, force-remove only generated dirt) existed
+nowhere in the dev guide. This PR encodes it so future agents don't re-derive it — or get it wrong.</p>
+</section>
+
+<section>
+<h2>What was done</h2>
+<table>
+<tr><th>File</th><th>Change</th></tr>
+<tr><td><code>tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md</code></td>
+<td>New <strong>"Worktree hygiene: cleaning stale local worktrees"</strong> section (5 steps below);
+pointer added at step 4 of the issue→worktree→PR→merge loop; description + version bumped to 1.1.0.</td></tr>
+<tr><td><code>tui/internal/preset/skills/lingtai-dev-guide/SKILL.md</code></td>
+<td>Catalog description for <code>dev-guide-contributing</code> now mentions worktree hygiene;
+new routing example <em>"Local worktrees are piling up"</em>; version bumped to 2.2.0.</td></tr>
+<tr><td><code>reports/stale-worktree-cleanup-guide-20260612.html</code></td>
+<td>This explainer.</td></tr>
+</table>
+
+<p>The new section's shape:</p>
+<ol>
+  <li><strong>Audit first</strong> — <code>git fetch --prune</code>, then a shell loop over
+  <code>git worktree list --porcelain</code> printing per-worktree
+  <code>branch / merged / remote / dirty_files</code>. Dry-run only; inspect dirty trees by hand.</li>
+  <li><strong>Removal criteria (all must hold)</strong> — secondary worktree; HEAD is ancestor of
+  <code>origin/main</code>; remote branch gone or detached HEAD; clean or generated-only dirt
+  (<code>logs/</code>, <code>artifacts/</code>, review-tool outputs).</li>
+  <li><strong>Keep/skip list</strong> <span class="keep">— when in doubt, skip:</span> primary checkout;
+  live release/binary-target worktrees (e.g. <code>release-vX.Y.Z-&lt;date&gt;</code>); unmerged
+  branches; remote branch still exists (likely open PR); source-dirty even if merged;
+  other agents' worktrees unless explicitly in scope.</li>
+  <li><strong>Remove</strong> — <code>git worktree remove</code> (<code>--force</code> only for
+  generated-only dirt), <code>git worktree prune</code>, <code>git branch -d</code> (never
+  escalate to <code>-D</code>; a refusal means re-check the audit).</li>
+  <li><strong>Record and report</strong> — log removed paths/branches/SHAs and skipped+reason,
+  save a report file, tell the human. SHAs are the recovery path.</li>
+</ol>
+</section>
+
+<section>
+<h2>Validation</h2>
+<ul>
+  <li><span class="ok">Audit recipe dry-run</span> — executed read-only against the real
+  <code>lingtai</code> repo (26 secondary worktrees enumerated). Output correctly classified
+  merged/unmerged, remote exists/gone, dirty counts — and flagged the live
+  <code>release-v0.8.16-20260612</code> worktree as merged+remote-gone, the exact case the
+  keep/skip list protects.</li>
+  <li><span class="ok">Frontmatter sanity</span> — YAML frontmatter of both edited SKILL.md files
+  parses cleanly.</li>
+  <li><span class="ok">git diff --check</span> — no whitespace errors.</li>
+</ul>
+</section>
+
+<section>
+<h2>Risks / decisions</h2>
+<ul>
+  <li>Placed the procedure in <code>contributing/SKILL.md</code> (not <code>gotchas</code>) because
+  it is a workflow, not a footgun; the gotchas file only mentions worktrees in passing.</li>
+  <li>The recipe deliberately fails safe: every ambiguous state (dirty, unmerged, remote exists,
+  detached-but-protected) lands on "skip". The only force path is generated-only dirt.</li>
+  <li>Real cleanup-report paths from the 2026-06-12 sweep are referenced generically
+  ("save a report file") rather than embedding private absolute paths.</li>
+</ul>
+</section>
+
+<section>
+<h2>Next steps</h2>
+<ul>
+  <li>Jason reviews; push + PR are intentionally left to the human.</li>
+  <li>Rename this file to <code>pr&lt;NUMBER&gt;-stale-worktree-cleanup-guide-explainer.html</code>
+  once the PR number exists.</li>
+</ul>
+</section>
+
+<section>
+<h2>Source index</h2>
+<ul>
+  <li><code>tui/internal/preset/skills/lingtai-dev-guide/SKILL.md</code> — router (edited)</li>
+  <li><code>tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md</code> — new section (edited)</li>
+  <li>Cleanup sweep of 2026-06-12 — policy source (report retained outside the repo)</li>
+</ul>
+</section>
+</main>
+</body>
+</html>

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -6,7 +6,7 @@ description: >
   TUI/portal repo or Python kernel, develop MCP addons, prepare a release,
   troubleshoot a running network, audit security, or govern avatars. This is
   for developers and contributors; for end-user lessons, use tutorial-guide.
-version: 2.1.0
+version: 2.2.0
 ---
 
 # LingTai Developer Guide
@@ -53,7 +53,8 @@ drill-down files, not standalone top-level skills.
   location: reference/contributing/SKILL.md
   description: |
     Contribution workflows for TUI, portal, kernel, addons, bundled utilities,
-    skill changes, tests, PR preparation, and review discipline.
+    skill changes, tests, PR preparation, review discipline, and local
+    worktree hygiene (auditing and cleaning stale git worktrees).
 - name: dev-guide-gotchas
   location: reference/gotchas/SKILL.md
   description: |
@@ -131,6 +132,9 @@ drill-down files, not standalone top-level skills.
 - **"This broad dev task needs triage"** → run the read-only portfolio sweep in
   `reference/contributing/SKILL.md`, then ask for authorization before mutating
   GitHub state.
+- **"Local worktrees are piling up"** → the "Worktree hygiene" section in
+  `reference/contributing/SKILL.md`: audit first, remove only merged + clean
+  secondary worktrees, record what was removed.
 
 ## Skill layout
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: dev-guide-contributing
 description: >
-  Nested lingtai-dev-guide reference for contribution workflow: issue/worktree/PR discipline, daemon decomposition, portfolio sweeps, repo-specific build/test commands, skill changes, and anatomy maintenance.
-version: 1.0.0
+  Nested lingtai-dev-guide reference for contribution workflow: issue/worktree/PR discipline, stale-worktree cleanup, daemon decomposition, portfolio sweeps, repo-specific build/test commands, skill changes, and anatomy maintenance.
+version: 1.1.0
 ---
 
 # Contributing to LingTai
@@ -34,7 +34,7 @@ Non-trivial work flows through this loop. No exceptions for "small" fixes that t
 1. **Issue.** Open or pick a GitHub issue that names the problem. If one does not exist, write one — it is the durable record of the contract.
 2. **Worktree + branch.** Create an isolated `git worktree` off `origin/main` on a topic branch (`fix/...`, `feat/...`, `docs/...`, `chore/...`). Never edit the main checkout, and never share a worktree across two parallel daemons.
 3. **PR.** Push the branch and open a PR against `Lingtai-AI/<repo>`. The PR body cites the issue, summarizes the change, and lists validation steps.
-4. **Merge.** After review, merge via the GitHub UI (or `gh pr merge`). Delete the branch and clean up the worktree.
+4. **Merge.** After review, merge via the GitHub UI (or `gh pr merge`). Delete the branch and clean up the worktree. Worktrees that outlive this step accumulate — see "Worktree hygiene" below for the periodic cleanup procedure.
 
 ### 3. Decompose into daemon-sized tasks
 
@@ -77,6 +77,89 @@ Skipping the sweep is how you end up duplicating in-flight work, stomping on som
 ### 6. Self-operate GitHub via `GH_TOKEN` when the human provides one
 
 For any of the `gh` invocations above — issue triage, PR creation, the portfolio sweep — if the human pastes a GitHub token into the session and you have bash, use it directly: `GH_TOKEN=$TOKEN gh ...`. Don't print commands for the human to copy-paste and don't require `gh auth login`. Read-only probe first (`gh repo view`, `gh issue list`), then ask explicit per-action consent before any mutation (issue creation, PR open/merge, comments). Never echo, log, or persist the token; let it live only in the env of the single command. The full protocol lives in `procedures.md` under "Self-Operating GitHub via GH_TOKEN".
+
+## Worktree hygiene: cleaning stale local worktrees
+
+Every merged PR leaves a worktree behind unless someone removes it, and with
+multiple agents/daemons running in parallel, `.worktrees/` fills up fast. Run
+this cleanup periodically (or when a sweep shows worktrees piling up). The
+discipline is **audit first, remove conservatively, record everything**.
+
+### 1. Audit first — never remove on sight
+
+Fetch with prune so remote-branch existence checks are accurate, then list
+every worktree with its merge/dirt/remote status:
+
+```bash
+cd <repo-primary-checkout>
+git fetch --prune origin
+
+git worktree list --porcelain | awk '/^worktree /{print $2}' | tail -n +2 |
+while read -r wt; do
+  branch=$(git -C "$wt" branch --show-current)        # empty = detached HEAD
+  head=$(git -C "$wt" rev-parse HEAD)
+  if git merge-base --is-ancestor "$head" origin/main; then merged=yes; else merged=no; fi
+  if [ -n "$branch" ] && git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    remote=exists; else remote=gone; fi
+  dirty=$(git -C "$wt" status --porcelain | wc -l | tr -d ' ')
+  echo "$wt | branch=${branch:-DETACHED} | merged=$merged | remote=$remote | dirty_files=$dirty"
+done
+```
+
+(`tail -n +2` skips the first entry, which is the primary checkout.) For any
+dirty worktree, inspect `git -C "$wt" status --porcelain` by hand to see
+*what* is dirty before deciding anything.
+
+### 2. Removal criteria — all must hold
+
+Remove a worktree only when **every** condition is true:
+
+- It is a **secondary** worktree (never the primary checkout).
+- Its HEAD is an **ancestor of `origin/main`** (`git merge-base --is-ancestor`
+  succeeded — the work is fully merged).
+- Its **remote branch is gone** (deleted after merge) or it is on a detached
+  HEAD. A remote branch that still exists may back an in-flight PR.
+- It is **clean**, or dirty only with **generated artifacts** — `logs/`,
+  `artifacts/`, review-tool outputs (Claude/GLM review files), build
+  droppings. Generated-only dirt may be force-removed; anything that looks
+  like source edits may not.
+
+### 3. Keep/skip list — when in doubt, skip
+
+- **Primary checkout** — never a removal candidate.
+- **Live/protected worktrees** — anything currently serving a purpose, e.g. a
+  release worktree that a deployed binary was built from and still resolves to
+  (such as `release-vX.Y.Z-<date>`). Check `which`/symlinks before touching
+  anything release-shaped.
+- **Unmerged branches** — HEAD not an ancestor of `origin/main`. That is
+  in-flight or abandoned-but-undecided work; not yours to delete.
+- **Remote branch still exists** — likely an open PR; skip.
+- **Source-dirty worktrees** — uncommitted edits to tracked source files mean
+  skip, *even if the branch is merged*. Someone may have WIP there.
+- **Other agents' worktrees** — directories under another agent's project or
+  working area are out of scope unless the human explicitly included them.
+
+### 4. Remove
+
+```bash
+git worktree remove .worktrees/<slug>            # clean worktree
+git worktree remove --force .worktrees/<slug>    # ONLY for generated-only dirt (step 2)
+git worktree prune                               # drop metadata for already-deleted dirs
+git branch -d <branch>                           # -d (not -D): refuses unmerged branches
+```
+
+Stick with `git branch -d` — its refusal on an unmerged branch is a safety
+net, not an obstacle. If `-d` refuses, re-check your audit instead of
+escalating to `-D`.
+
+### 5. Record and report
+
+Write down what was removed (worktree path, branch, HEAD SHA) and what was
+skipped with the reason (e.g. `~/path/to/.worktrees/<slug> — skipped:
+source-dirty`), save it as a small report file, and tell the human what was
+cleaned. The SHA list is the recovery path: a merged branch's commits remain
+reachable from `origin/main`, and even unmerged SHAs stay in the reflog for a
+while.
 
 ## Changing the TUI (`tui/`)
 


### PR DESCRIPTION
## Summary
- add a stale local worktree cleanup procedure to `lingtai-dev-guide`
- document audit-first rules, safe removal criteria, prune/branch cleanup, generated-only dirt policy, and reporting expectations
- add a shareable HTML report for the cleanup workflow

## Validation
- `git diff --check origin/main...HEAD`
- frontmatter/code-fence/private-path validation for touched docs/report

## Notes
- This documents the cleanup routine used after the local stale-worktree sweep; no runtime code changes.
