### PR TITLE
Fix /setup keep-current preset policy

### DIFF
--- a/artifacts/community-issue-316-20260612/implementation-summary.md
+++ b/artifacts/community-issue-316-20260612/implementation-summary.md
@@ -1,0 +1,69 @@
+# Issue #316 Implementation Summary
+
+**Date:** 2026-06-12  
+**Branch:** fix/setup-preset-policy-316-20260612
+
+## Problem
+
+`/setup` with "Keep current preset" (cursor == -1) synthesises a placeholder
+`Preset{Name: "keep_current"}` so downstream wizard steps can read the agent's
+existing LLM/capability config. On save, `GenerateInitJSONWithOpts` passed this
+sentinel through `RefFor()`, which computed a non-existent path
+`~/.lingtai-tui/presets/saved/keep_current.json` and wrote it into
+`manifest.preset.default` and `manifest.preset.allowed`.
+
+A second path: `performSetupSaveOnly` would also propagate that synthetic ref to
+all peer agents via `propagatePresetPolicyToNetwork`.
+
+## Fix (3 parts)
+
+### 1. `tui/internal/preset/preset.go` — core writer fix
+
+Added `isSyntheticPreset(p Preset) bool` for the exact keep-current sentinel
+(`SourceUnknown` + `Name == "keep_current"`). The predicate is intentionally
+narrow so hand-built/custom presets that rely on `RefFor`'s saved-preset fallback
+are not misclassified.
+
+In `GenerateInitJSONWithOpts`, inside the `PreserveActivePreset` block that already
+reads `active` and `allowed` from the existing init.json, also read
+`manifest.preset.default`. When `isSyntheticPreset(p)` is true, override `presetRef`
+with the existing default string; if an older init lacks `default`, fall back to the
+real existing `active` ref. The synthetic name never reaches disk.
+
+### 2. `tui/internal/tui/firstrun.go` — propagation fix
+
+In `performSetupSaveOnly()`, the propagation call used `presetCanonicalRef(p)` which
+returns the synthetic path. Now reads the real existing default from
+`m.setupKeepInitJSON["manifest"]["preset"]["default"]` when `m.cursor == -1`.
+
+### 3. `tui/internal/tui/firstrun.go` — UX: auto-check just-created preset
+
+In `enterAgentPresets()`, after setup-mode hydration from the existing init.json,
+auto-check the row for `m.cursor`'s preset if it is not already in `presetAllowed`.
+This ensures a preset created in the editor on the same `/setup` run defaults to
+authorized, without turning all saved presets on.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `tui/internal/preset/preset.go` | Added `isSyntheticPreset`; override `presetRef` with existing default when synthetic |
+| `tui/internal/tui/firstrun.go` | Propagation uses real existing default for keep-current; auto-check just-created preset |
+| `tui/internal/preset/preset_keep_current_test.go` | New regression tests (2 cases) |
+| `reports/issue316-setup-preset-policy-20260612.html` | HTML explainer |
+| `artifacts/community-issue-316-20260612/implementation-summary.md` | This file |
+
+## Tests
+
+```
+go test ./internal/preset/ -run TestSetupModeKeepCurrent -v
+# → PASS (2 tests)
+go test ./... -timeout 120s
+# → all packages pass
+```
+
+## Invariants preserved
+
+- `manifest.preset.allowed` remains a static authorization snapshot
+- Kernel/TUI allowed-gate unchanged
+- No migrations needed (bug only affected newly-written files)

--- a/reports/issue316-setup-preset-policy-20260612.html
+++ b/reports/issue316-setup-preset-policy-20260612.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Issue #316 – /setup Keep Current Preset Writes Synthetic Ref</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 860px; margin: 2rem auto; line-height: 1.6; color: #222; }
+  h1 { border-bottom: 2px solid #e63; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #333; }
+  code, pre { background: #f4f4f4; border-radius: 4px; }
+  code { padding: 0 .3em; font-size: .92em; }
+  pre { padding: 1em; overflow-x: auto; font-size: .88em; }
+  .bad  { color: #c00; }
+  .good { color: #060; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #ccc; padding: .4rem .7rem; text-align: left; }
+  th { background: #f0f0f0; }
+  .label { display: inline-block; padding: .15em .5em; border-radius: 3px; font-size: .8em; font-weight: bold; }
+  .label-bug  { background: #fdd; color: #900; }
+  .label-fix  { background: #dfd; color: #060; }
+  .label-ux   { background: #def; color: #039; }
+</style>
+</head>
+<body>
+
+<h1>Issue #316 &mdash; <code>/setup</code> Keep-Current Preset Writes Synthetic Ref</h1>
+<p><em>2026-06-12 &mdash; worktree fix/setup-preset-policy-316-20260612</em></p>
+
+<h2>Summary</h2>
+<p>
+  When a user runs <code>/setup</code> and selects <strong>Keep current preset</strong>
+  (the default cursor position, <code>cursor&nbsp;==&nbsp;-1</code>), the TUI
+  synthesises a placeholder preset with <code>Name="keep_current"</code> to carry
+  the existing agent's LLM/capability config. On save, <code>GenerateInitJSONWithOpts</code>
+  passes that synthetic preset through <code>RefFor()</code>, which derives
+  <code class="bad">~/.lingtai-tui/presets/saved/keep_current.json</code> — a file that
+  does not exist. That path was written to <code>manifest.preset.default</code> and
+  <code>manifest.preset.allowed</code>, which would cause the kernel to reject the
+  config or fail to load the preset at next agent boot.
+</p>
+
+<h2>Root cause</h2>
+<p>
+  <code>RefFor(p)</code> in <code>tui/internal/preset/preset.go</code> derives a
+  path purely from <code>p.Name</code> and <code>p.Source</code>. It has no way to
+  distinguish real presets from in-memory sentinels. The sentinel is needed so
+  <code>currentPreset()</code> can return the agent's current capabilities to
+  downstream wizard steps, but it should <em>never</em> be serialised to disk.
+</p>
+<pre>
+// Before fix — GenerateInitJSONWithOpts:
+presetRef := RefFor(p)   // "~/.lingtai-tui/presets/saved/keep_current.json" ❌
+manifest["preset"] = map[string]interface{}{
+    "default": presetRef,  // written!
+    "allowed": [..., presetRef],  // written!
+}
+</pre>
+
+<h2>Fix: three-part patch</h2>
+
+<table>
+  <tr><th>Part</th><th>File</th><th>What changed</th></tr>
+  <tr>
+    <td><span class="label label-bug">bug</span> 1</td>
+    <td><code>preset/preset.go</code></td>
+    <td>
+      Added <code>isSyntheticPreset(p)</code> helper. In the
+      <code>PreserveActivePreset</code> block that already reads <code>active</code>
+      and <code>allowed</code> from the existing init.json, also read
+      <code>manifest.preset.default</code>. When the passed preset is synthetic,
+      override <code>presetRef</code> with the existing default so
+      <code>keep_current.json</code> is never written.
+    </td>
+  </tr>
+  <tr>
+    <td><span class="label label-bug">bug</span> 2</td>
+    <td><code>tui/firstrun.go</code></td>
+    <td>
+      In <code>performSetupSaveOnly()</code>, the propagation call
+      <code>propagatePresetPolicyToNetwork(..., presetCanonicalRef(p), ...)</code>
+      would broadcast <code>keep_current.json</code> to all peer agents. Fixed by
+      reading the real existing default from <code>m.setupKeepInitJSON</code> when
+      <code>m.cursor&nbsp;==&nbsp;-1</code>.
+    </td>
+  </tr>
+  <tr>
+    <td><span class="label label-ux">ux</span> 3</td>
+    <td><code>tui/firstrun.go</code></td>
+    <td>
+      In <code>enterAgentPresets()</code>, after the setup-mode hydration block,
+      auto-check the row for the picker cursor's preset if it is not already
+      authorised. This handles the case where the user just created a preset in the
+      editor and it has not yet appeared in the existing <code>allowed</code> list.
+    </td>
+  </tr>
+</table>
+
+<h2>Regression test</h2>
+<p>
+  Added <code>tui/internal/preset/preset_keep_current_test.go</code> with two cases:
+</p>
+<ul>
+  <li>
+    <strong>TestSetupModeKeepCurrentPresetPolicyDoesNotWriteSyntheticPreset</strong> —
+    existing init has codex as active/default/allowed; keep-current chosen; user additionally
+    allows zhipu-2; asserts: default=codex, active=codex, allowed={codex,zhipu-2},
+    no <code>keep_current</code> string anywhere.
+  </li>
+  <li>
+    <strong>TestSetupModeKeepCurrentNoExtraAllowed</strong> —
+    keep-current chosen, no extra presets granted; asserts existing allowed preserved,
+    default remains codex.
+  </li>
+</ul>
+
+<h2>What was NOT changed</h2>
+<ul>
+  <li><code>manifest.preset.allowed</code> remains a static authorization snapshot —
+      this fix does not make it dynamic.</li>
+  <li>The kernel/TUI allowed-gate is unchanged.</li>
+  <li>No new migrations are needed — the corrupt keep_current path would only have
+      appeared in newly-saved init.json files; no migration can retroactively detect
+      and clean it (affected users would simply re-run <code>/setup</code>).</li>
+</ul>
+
+</body>
+</html>

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -513,6 +513,17 @@ func RefFor(p Preset) string {
 	return "~/.lingtai-tui/presets/" + subdir + "/" + p.Name + ".json"
 }
 
+// isSyntheticPreset reports whether p is the in-memory-only "Keep current
+// preset" sentinel that NewSetupModeModel builds from an existing init.json.
+// It has no backing file on disk; RefFor would otherwise derive a non-existent
+// path like ~/.lingtai-tui/presets/saved/keep_current.json.
+//
+// Be deliberately narrow here: SourceUnknown also appears on hand-built presets
+// in tests or callers that intentionally want RefFor's saved/ fallback.
+func isSyntheticPreset(p Preset) bool {
+	return p.Source == SourceUnknown && p.Name == "keep_current"
+}
+
 // ResolvedRef is a single entry in ResolveRefs's output. It captures
 // everything a UI surface (the kanban Presets section in particular)
 // needs to render an at-a-glance health check for a preset path
@@ -1430,6 +1441,28 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 									if s, ok := e.(string); ok && s != "" {
 										existingAllowed = append(existingAllowed, s)
 									}
+								}
+							}
+							// When the caller passed a synthetic preset (e.g. the
+							// "Keep current preset" sentinel Name="keep_current"
+							// built in NewSetupModeModel), RefFor() above produces
+							// a path that doesn't correspond to any real file.
+							// Preserve the existing on-disk default ref so we never
+							// write keep_current.json into manifest.preset.{default,allowed}.
+							// Older init.json files may lack manifest.preset.default; in that
+							// case fall back to the real active ref instead.
+							if isSyntheticPreset(p) {
+								syntheticRef := RefFor(p)
+								if existingDef, ok := pre["default"].(string); ok && existingDef != "" {
+									presetRef = existingDef
+								} else if activeRef != "" && activeRef != syntheticRef {
+									presetRef = activeRef
+								}
+								// activeRef was already set to the existing active above; if it
+								// was still pointing at the synthetic ref, snap it to the real
+								// policy default.
+								if activeRef == syntheticRef {
+									activeRef = presetRef
 								}
 							}
 						}

--- a/tui/internal/preset/preset_keep_current_test.go
+++ b/tui/internal/preset/preset_keep_current_test.go
@@ -1,0 +1,189 @@
+package preset
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSetupModeKeepCurrentPresetPolicyDoesNotWriteSyntheticPreset is the
+// regression test for issue #316.
+//
+// Scenario: agent has codex as active/default/allowed. User runs /setup,
+// picks "Keep current preset" (cursor==-1 → synthetic preset Name="keep_current"),
+// then on the allowed page also authorises zhipu-2. On save, the writer must:
+//   - NOT write keep_current.json anywhere in allowed or default
+//   - preserve codex as the policy default
+//   - preserve codex as active (PreserveActivePreset semantics)
+//   - include both codex and zhipu-2 in allowed
+func TestSetupModeKeepCurrentPresetPolicyDoesNotWriteSyntheticPreset(t *testing.T) {
+	tmp := t.TempDir()
+	globalDir := filepath.Join(tmp, "global")
+	lingtaiDir := filepath.Join(tmp, "project", ".lingtai")
+	agentDir := filepath.Join(lingtaiDir, "codex-agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	codexRef := "~/.lingtai-tui/presets/templates/codex.json"
+	zhipuRef := "~/.lingtai-tui/presets/saved/zhipu-2.json"
+
+	// Seed an existing init.json where active/default/allowed all point at
+	// the codex template preset.
+	seed := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "codex-agent",
+			"preset": map[string]interface{}{
+				"active":  codexRef,
+				"default": codexRef,
+				"allowed": []interface{}{codexRef},
+			},
+		},
+	}
+	seedData, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), seedData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate /setup keep-current: synthetic preset with Name="keep_current",
+	// zero Source (not a real on-disk file).  This is exactly what firstrun.go
+	// builds in NewSetupModeModel when cursor==-1.
+	synthetic := Preset{
+		Name: "keep_current",
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{
+				"provider": "codex",
+				"model":    "gpt-4o",
+			},
+		},
+	}
+
+	// User also allowed zhipu-2 on the preset-policy page.
+	opts := DefaultAgentOpts()
+	opts.AllowedPresets = []string{codexRef, zhipuRef}
+	opts.PreserveActivePreset = true
+
+	if err := GenerateInitJSONWithOpts(synthetic, "codex-agent", "codex-agent", lingtaiDir, globalDir, opts); err != nil {
+		t.Fatalf("GenerateInitJSONWithOpts: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(agentDir, "init.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	pre := got["manifest"].(map[string]interface{})["preset"].(map[string]interface{})
+
+	// default must remain the real codex ref, not keep_current.json
+	if def := pre["default"]; def != codexRef {
+		t.Errorf("default = %q, want %q (synthetic keep_current must never be written as default)", def, codexRef)
+	}
+
+	// active must remain codex (PreserveActivePreset)
+	if active := pre["active"]; active != codexRef {
+		t.Errorf("active = %q, want %q", active, codexRef)
+	}
+
+	// allowed must contain both real presets and must NOT contain keep_current
+	allowed, _ := pre["allowed"].([]interface{})
+	allowedStrs := make([]string, 0, len(allowed))
+	for _, e := range allowed {
+		if s, ok := e.(string); ok {
+			allowedStrs = append(allowedStrs, s)
+		}
+	}
+
+	for _, s := range allowedStrs {
+		if strings.Contains(s, "keep_current") {
+			t.Errorf("allowed contains synthetic keep_current ref %q; full allowed: %v", s, allowedStrs)
+		}
+	}
+
+	hasCodex := false
+	hasZhipu := false
+	for _, s := range allowedStrs {
+		if s == codexRef {
+			hasCodex = true
+		}
+		if s == zhipuRef {
+			hasZhipu = true
+		}
+	}
+	if !hasCodex {
+		t.Errorf("allowed missing codex ref %q; got %v", codexRef, allowedStrs)
+	}
+	if !hasZhipu {
+		t.Errorf("allowed missing zhipu-2 ref %q; got %v", zhipuRef, allowedStrs)
+	}
+	if len(allowedStrs) != 2 {
+		t.Errorf("allowed has %d entries, want 2; got %v", len(allowedStrs), allowedStrs)
+	}
+}
+
+// TestSetupModeKeepCurrentNoExtraAllowed verifies that when "Keep current
+// preset" is chosen and the user does not add any extra presets to the
+// allowed list (opts.AllowedPresets is nil), the result preserves the
+// existing allowed list from init.json unchanged and never writes
+// keep_current.json as the default.
+func TestSetupModeKeepCurrentNoExtraAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	globalDir := filepath.Join(tmp, "global")
+	lingtaiDir := filepath.Join(tmp, "project", ".lingtai")
+	agentDir := filepath.Join(lingtaiDir, "alice")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	codexRef := "~/.lingtai-tui/presets/templates/codex.json"
+	zhipuRef := "~/.lingtai-tui/presets/saved/zhipu-1.json"
+
+	seed := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "alice",
+			"preset": map[string]interface{}{
+				"active":  codexRef,
+				"default": codexRef,
+				"allowed": []interface{}{codexRef, zhipuRef},
+			},
+		},
+	}
+	seedData, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(filepath.Join(agentDir, "init.json"), seedData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	synthetic := Preset{
+		Name: "keep_current",
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{"provider": "codex"},
+		},
+	}
+
+	opts := DefaultAgentOpts()
+	opts.PreserveActivePreset = true
+	// AllowedPresets deliberately not set — user skipped the preset-policy page
+
+	if err := GenerateInitJSONWithOpts(synthetic, "alice", "alice", lingtaiDir, globalDir, opts); err != nil {
+		t.Fatalf("GenerateInitJSONWithOpts: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(agentDir, "init.json"))
+	var got map[string]interface{}
+	json.Unmarshal(data, &got)
+	pre := got["manifest"].(map[string]interface{})["preset"].(map[string]interface{})
+
+	if def := pre["default"].(string); strings.Contains(def, "keep_current") {
+		t.Errorf("default = %q must not reference keep_current", def)
+	}
+	if def := pre["default"]; def != codexRef {
+		t.Errorf("default = %q, want %q", def, codexRef)
+	}
+	if active := pre["active"]; active != codexRef {
+		t.Errorf("active = %q, want %q", active, codexRef)
+	}
+}

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -3290,6 +3290,19 @@ func (m *FirstRunModel) enterAgentPresets() tea.Cmd {
 				}
 			}
 		}
+
+		// If the picker cursor points at a saved preset that was not found
+		// in the existing allowed list (e.g. the user just created it in the
+		// preset editor), auto-check it so a just-added preset doesn't silently
+		// stay unauthorized. The user can still uncheck it with [space].
+		if m.cursor >= 0 {
+			for r, idx := range m.savedPresetIdx {
+				if idx == m.cursor && !m.presetAllowed[r] {
+					m.presetAllowed[r] = true
+					break
+				}
+			}
+		}
 	}
 
 	return nil
@@ -4183,7 +4196,22 @@ func (m FirstRunModel) performSetupSaveOnly() (FirstRunModel, tea.Cmd) {
 		return m, nil
 	}
 	if m.setupMode {
-		propagatePresetPolicyToNetwork(m.baseDir, dirName, presetCanonicalRef(p), m.pendingAgentOpts.AllowedPresets)
+		// Derive the real policy default ref for propagation. When the user
+		// chose "Keep current preset" (cursor == -1), p is the synthetic
+		// keep_current preset whose presetCanonicalRef would produce a
+		// non-existent path. Use the existing init.json's manifest.preset.default
+		// instead so propagation never broadcasts keep_current.json to peers.
+		policyDefaultRef := presetCanonicalRef(p)
+		if m.cursor == -1 && m.setupKeepInitJSON != nil {
+			if mn, ok := m.setupKeepInitJSON["manifest"].(map[string]interface{}); ok {
+				if pre, ok := mn["preset"].(map[string]interface{}); ok {
+					if def, ok := pre["default"].(string); ok && def != "" {
+						policyDefaultRef = def
+					}
+				}
+			}
+		}
+		propagatePresetPolicyToNetwork(m.baseDir, dirName, policyDefaultRef, m.pendingAgentOpts.AllowedPresets)
 	}
 	return m, func() tea.Msg { return SetupSavedMsg{} }
 }


### PR DESCRIPTION
## Summary

Fixes the real `/setup` preset-policy bug behind #316 without weakening the static allowed-preset gate.

- prevents the virtual `keep_current` preset from being written as `manifest.preset.default` or `manifest.preset.allowed`
- makes propagation use the existing real policy default when `/setup` keeps the current preset
- auto-checks a just-created/just-selected preset on the allowed-preset page so it is actually authorized unless the user unchecks it
- adds regression tests for the keep-current writer path

Fixes #316.

## Validation

- `cd tui && go test ./internal/preset -run 'TestSetupModeKeepCurrent' -count=1`
- `cd tui && go test ./internal/preset ./internal/tui -count=1`
- `cd tui && go test ./... -count=1`
- `git diff --check`

## Human report

Standalone explainer: `reports/issue316-setup-preset-policy-20260612.html`
Implementation notes: `artifacts/community-issue-316-20260612/implementation-summary.md`
