### PR TITLE
Improve /kanban Ctrl+D detail hint

### DIFF
--- a/reports/kanban-ctrl-d-hint-20260612.html
+++ b/reports/kanban-ctrl-d-hint-20260612.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>/kanban Ctrl+D 提示小改说明</title>
+  <style>
+    :root { color-scheme: light dark; --bg:#0f172a; --card:#111827; --text:#e5e7eb; --muted:#9ca3af; --accent:#38bdf8; --ok:#22c55e; --warn:#f59e0b; }
+    body { margin:0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background:linear-gradient(135deg,#0f172a,#111827); color:var(--text); }
+    main { max-width:960px; margin:0 auto; padding:40px 20px; }
+    h1 { margin:0 0 12px; font-size:32px; }
+    h2 { margin-top:28px; color:#bfdbfe; }
+    .card { background:rgba(17,24,39,.86); border:1px solid rgba(148,163,184,.25); border-radius:16px; padding:20px; margin:16px 0; box-shadow:0 12px 28px rgba(0,0,0,.25); }
+    .lead { color:var(--muted); font-size:17px; line-height:1.6; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    pre { background:#020617; border:1px solid rgba(148,163,184,.22); border-radius:12px; padding:14px; overflow:auto; }
+    ul { line-height:1.7; }
+    .ok { color:var(--ok); font-weight:700; }
+    .warn { color:var(--warn); font-weight:700; }
+    .pill { display:inline-block; border:1px solid rgba(56,189,248,.45); color:#bae6fd; border-radius:999px; padding:4px 10px; margin:2px; font-size:13px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>/kanban 顶部加入 Ctrl+D 详情提示</h1>
+  <p class="lead">本小改采纳 ktwu01 #289 背后的可发现性问题，但不新增顶层 <code>/context</code> 命令：既有入口仍为 <code>/kanban</code>，详情页仍由 <code>Ctrl+D</code> 打开。</p>
+
+  <section class="card">
+    <h2>结论</h2>
+    <p><span class="ok">可合并。</span> 改动范围小，未改变 slash-command 路由、未新增命令，只把 <code>Ctrl+D</code> 提示从右下角弱提示提升为 <code>/kanban</code> 标题分隔线下方的醒目提示。</p>
+    <p><span class="pill">TUI-only</span><span class="pill">i18n en/zh/wen</span><span class="pill">测试覆盖</span><span class="pill">无外部副作用</span></p>
+  </section>
+
+  <section class="card">
+    <h2>为什么不收 /context</h2>
+    <ul>
+      <li><code>/context</code> 只是 <code>/kanban → Ctrl+D</code> 的别名，不提供新能力。</li>
+      <li>新增顶层 slash command 会扩大命令面，降低命令列表清晰度。</li>
+      <li>真正问题是用户不容易发现 <code>Ctrl+D</code>，因此应修提示，而非加别名。</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2>改动内容</h2>
+    <ul>
+      <li><code>tui/internal/tui/props.go</code>：在 <code>/kanban</code> 非详情模式标题下方渲染醒目的 <code>ctrl+d open context detail breakdown</code> callout；详情模式中隐藏该 callout。</li>
+      <li><code>tui/i18n/{en,zh,wen}.json</code>：加入 <code>props.ctrl_d_hint</code>，并将原 footer 中 <code>detail</code> 文案扩成“context detail / 上下文详情 / 语境详”。</li>
+      <li><code>tui/internal/tui/props_test.go</code>：新增测试，确认普通 <code>/kanban</code> 视图显示 callout，详情视图不重复显示，同时 footer 仍保留 <code>ctrl+d</code> 提示。</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2>验证</h2>
+    <pre><code>cd tui && go test ./internal/tui ./i18n -count=1
+cd tui && go test ./... -count=1
+git diff --check</code></pre>
+    <p>三项均已通过。全量 <code>go test ./...</code> 亦通过；测试生成的 <code>tui/internal/tui/logs/</code> 已清除。</p>
+  </section>
+
+  <section class="card">
+    <h2>风险与取舍</h2>
+    <ul>
+      <li>顶部多占 1 行视口高度，以换取可发现性；这是 Jason 明确要求的“上面显眼”提示。</li>
+      <li>不触碰命令 palette，不影响用户已知的 <code>/kanban</code> 与 <code>Ctrl+D</code> 行为。</li>
+      <li>不解决 #237/#299/#302 的较大功能诉求；这些已另行 triage。</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>

--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -312,7 +312,7 @@
   "props.preset_source_template": "template",
   "props.preset_source_saved": "saved",
   "props.detail_title": "Agent Detail",
-  "props.detail_open": "detail",
+  "props.detail_open": "context detail",
   "props.detail_back_to_summary": "back to summary",
   "props.detail_tokens_by_provider": "Token usage by provider",
   "props.detail_no_tokens": "No token usage recorded yet.",
@@ -609,5 +609,6 @@
   "mail.goal_no_agent": "No current agent is selected; cannot send a goal request.",
   "palette.goal": "Guide goal creation",
   "cmd.goal": "Goal guide — send a system notification asking the current agent to read the goal manual, guide the human through objective/criteria/reminder/cancellation semantics, and only create .notification/goal.json after confirmation",
-  "props.detail_context_stats": "Current context statistics"
+  "props.detail_context_stats": "Current context statistics",
+  "props.ctrl_d_hint": "ctrl+d open context detail breakdown"
 }

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -307,7 +307,7 @@
   "props.preset_source_template": "模",
   "props.preset_source_saved": "存",
   "props.detail_title": "器灵之详",
-  "props.detail_open": "详",
+  "props.detail_open": "语境详",
   "props.detail_back_to_summary": "返概",
   "props.detail_tokens_by_provider": "诸厂之 token 用",
   "props.detail_no_tokens": "未尝有 token 之用。",
@@ -609,5 +609,6 @@
   "mail.goal_no_agent": "今无所择器灵，不可遣设愿之讯。",
   "palette.goal": "导立愿",
   "cmd.goal": "导立愿——投 system notification，使当前器灵读 goal manual，导人明 objective / criteria / reminder / 取消之义，待确认后方写 .notification/goal.json",
-  "props.detail_context_stats": "今识之计"
+  "props.detail_context_stats": "今识之计",
+  "props.ctrl_d_hint": "ctrl+d 察语境之详"
 }

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -307,7 +307,7 @@
   "props.preset_source_template": "模板",
   "props.preset_source_saved": "已存",
   "props.detail_title": "智能体详情",
-  "props.detail_open": "详情",
+  "props.detail_open": "上下文详情",
   "props.detail_back_to_summary": "返回概览",
   "props.detail_tokens_by_provider": "按提供商统计的 token 使用",
   "props.detail_no_tokens": "尚未记录 token 使用。",
@@ -609,5 +609,6 @@
   "mail.goal_no_agent": "当前没有选中的 Agent，无法发送 goal 引导通知。",
   "palette.goal": "引导创建 goal",
   "cmd.goal": "Goal 引导——发送 system notification，让当前 Agent 阅读 goal manual，引导人类明确 objective / criteria / reminder / 取消语义，并只在确认后创建 .notification/goal.json",
-  "props.detail_context_stats": "当前上下文统计"
+  "props.detail_context_stats": "当前上下文统计",
+  "props.ctrl_d_hint": "ctrl+d 查看上下文详情"
 }

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -116,8 +116,8 @@ func (m PropsModel) loadData() tea.Msg {
 
 func (m PropsModel) Init() tea.Cmd { return m.loadData }
 
-// propsHeaderLines is the number of lines used by the header (title + separator).
-const propsHeaderLines = 2
+// propsHeaderLines is the number of lines used by the header (title + separator + optional callout).
+const propsHeaderLines = 3
 
 // propsFooterLines is the number of lines used by the footer (separator + hints).
 const propsFooterLines = 2
@@ -345,6 +345,11 @@ func (m PropsModel) View() string {
 		title = i18n.T("props.detail_title")
 	}
 	header := StyleTitle.Render("  "+title) + "\n" + strings.Repeat("\u2500", m.width)
+	if !m.detailOpen {
+		header += "\n" + "  " + StyleAccent.Render("⎔ "+i18n.T("props.ctrl_d_hint"))
+	} else {
+		header += "\n"
+	}
 
 	scrollHint := ""
 	if m.ready && !m.viewport.AtBottom() {

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anthropics/lingtai-tui/i18n"
 	"github.com/anthropics/lingtai-tui/internal/fs"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -104,5 +105,37 @@ func TestPropsLoadDetailKeepsLastFortyLedgerEntries(t *testing.T) {
 	}
 	if got := m.detailRecent[len(m.detailRecent)-1].Model; got != "m5" {
 		t.Fatalf("oldest retained recent model = %q, want m5", got)
+	}
+}
+
+func TestPropsHeaderShowsCtrlDHint(t *testing.T) {
+	// The non-detail header must prominently advertise ctrl+d for context detail.
+	m := PropsModel{
+		width:  80,
+		height: 24,
+		ready:  true,
+	}
+	m.viewport.SetWidth(80)
+	m.viewport.SetHeight(20)
+
+	view := ansi.Strip(m.View())
+
+	// The callout line must mention the i18n key text.
+	hint := i18n.T("props.ctrl_d_hint")
+	if !strings.Contains(view, hint) {
+		t.Fatalf("View() header missing ctrl+d callout hint %q:\n%s", hint, view)
+	}
+
+	// Also verify the standard footer line keeps ctrl+d with the renamed label.
+	label := i18n.T("props.detail_open")
+	if !strings.Contains(view, "ctrl+d "+label) {
+		t.Fatalf("View() footer missing 'ctrl+d %s':\n%s", label, view)
+	}
+
+	// When detailOpen, the callout should NOT appear.
+	m.detailOpen = true
+	viewDetail := ansi.Strip(m.View())
+	if strings.Contains(viewDetail, hint) {
+		t.Fatalf("View() detail mode should NOT show callout:\n%s", viewDetail)
 	}
 }


### PR DESCRIPTION
## Summary

- keep `/context` declined, but make the existing `/kanban` → `Ctrl+D` detail path easier to discover
- add a prominent top-of-view Ctrl+D callout in `/kanban` summary mode
- update en/zh/wen copy and add a regression test for the callout

## Validation

- `cd tui && go test ./internal/tui ./i18n -count=1`
- `cd tui && go test ./... -count=1`
- `git diff --check`

## Report

- `reports/kanban-ctrl-d-hint-20260612.html`

Related to #289: preserves the useful discoverability insight without adding a new top-level `/context` command.