### PR TITLE
Add root-owned TUI layout budget

### DIFF
--- a/reports/root-layout-budget-308-20260613.html
+++ b/reports/root-layout-budget-308-20260613.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Issue #308 – Root-Owned TUI Layout Budget</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 860px; margin: 2rem auto; line-height: 1.6; color: #222; padding: 0 1rem; }
+  h1 { border-bottom: 2px solid #e63; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #333; }
+  code, pre { background: #f4f4f4; border-radius: 4px; }
+  code { padding: 0 .3em; font-size: .92em; }
+  pre { padding: 1em; overflow-x: auto; font-size: .88em; }
+  .bad  { color: #c00; }
+  .good { color: #060; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #ccc; padding: .4rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f0f0; }
+  .label { display: inline-block; padding: .15em .5em; border-radius: 3px; font-size: .8em; font-weight: bold; }
+  .label-feat { background: #dfd; color: #060; }
+  .label-test { background: #def; color: #039; }
+  .label-doc  { background: #fef3c7; color: #92600a; }
+  .note { background: #f8f8f8; border-left: 3px solid #e63; padding: .6rem 1rem; margin: 1rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Issue #308 &mdash; Root-Owned TUI Layout Budget</h1>
+<p><em>2026-06-13 &mdash; worktree fix/root-layout-budget-308-20260613</em></p>
+
+<h2>Summary</h2>
+<p>
+  The root <code>App</code> model (<code>tui/internal/tui/app.go</code>) sizes every
+  child screen by forwarding the raw terminal <code>tea.WindowSizeMsg</code> straight
+  through. Child screens therefore size themselves to the <em>full</em> terminal
+  height. Any persistent root-level chrome (a status bar, a warning banner) then has
+  to be <strong>appended after</strong> the child has already rendered at full height
+  &mdash; which pushes content off-screen or corrupts the layout.
+</p>
+<p>
+  Today the only such consumer is the <strong>startup banner</strong> (the Codex-auth
+  warning), which <code>View()</code> prepended to the mail content <em>after</em> the
+  mail view had already sized itself to the full terminal height. This PR builds the
+  small, explicit <strong>layout-ownership contract</strong> the banner &mdash; and any
+  future root chrome / status line &mdash; can consume safely. It is the
+  <em>foundation</em>, not a revival of the full status-line feature from PR #241.
+</p>
+
+<div class="note">
+  <strong>Non-goal:</strong> no new persistent status-bar setting or UI. Bottom chrome is
+  an inert hook reserving zero rows until a real product surface needs it.
+</div>
+
+<h2>The contract</h2>
+<p>New file <code>tui/internal/tui/layout.go</code>:</p>
+<pre>
+type LayoutBudget struct {
+    Width  int
+    Height int // full terminal height
+
+    TopChromeRows    int // rows reserved at top for root chrome
+    BottomChromeRows int // rows reserved at bottom (0 today)
+    ChildHeight      int // height handed to the child (clamped &gt;= 0)
+}
+
+func (b LayoutBudget) ChildWindowSize() tea.WindowSizeMsg  // full width, reduced height
+
+func (a App) layoutBudget() LayoutBudget   // reserve chrome rows, clamp child &gt;= 0
+func (a App) topChromeRows() int           // 1 when startupBanner != "", else 0
+func (a App) bottomChromeRows() int        // always 0 (inert hook)
+func (a App) topChrome() string            // renders the banner row
+func (a App) composeWithChrome(child) string // stacks chrome above child content
+</pre>
+
+<h2>The flow: reserve &rarr; forward &rarr; compose</h2>
+<table>
+  <tr><th>Stage</th><th>Before</th><th>After</th></tr>
+  <tr>
+    <td><strong>Reserve</strong></td>
+    <td>&mdash;</td>
+    <td><code>layoutBudget()</code> reserves <code>topChromeRows()</code> +
+        <code>bottomChromeRows()</code> and computes <code>ChildHeight</code>.</td>
+  </tr>
+  <tr>
+    <td><strong>Forward</strong> (<code>Update</code> &amp; <code>sendSize</code>)</td>
+    <td class="bad">child receives raw terminal <code>Width&times;Height</code></td>
+    <td class="good">child receives <code>ChildWindowSize()</code> &mdash; full width,
+        height reduced by reserved rows</td>
+  </tr>
+  <tr>
+    <td><strong>Compose</strong> (<code>View</code>)</td>
+    <td class="bad">banner prepended to mail content <em>after</em> the child sized to
+        full height (mail-view branch only)</td>
+    <td class="good"><code>composeWithChrome()</code> stacks root chrome above the
+        already-reduced child content, for the whole app</td>
+  </tr>
+</table>
+
+<h2>Changes</h2>
+<table>
+  <tr><th>Part</th><th>File</th><th>What changed</th></tr>
+  <tr>
+    <td><span class="label label-feat">feat</span></td>
+    <td><code>tui/internal/tui/layout.go</code> <em>(new)</em></td>
+    <td>The <code>LayoutBudget</code> contract, <code>layoutBudget()</code>,
+        <code>ChildWindowSize()</code>, top/bottom chrome row helpers, and
+        <code>composeWithChrome()</code>.</td>
+  </tr>
+  <tr>
+    <td><span class="label label-feat">feat</span></td>
+    <td><code>tui/internal/tui/app.go</code></td>
+    <td>
+      <code>Update</code>'s <code>WindowSizeMsg</code> handler records the full terminal
+      size on <code>App</code>, then forwards <code>layoutBudget().ChildWindowSize()</code>
+      to the current view. <code>sendSize()</code> forwards the same reduced child size.
+      <code>View()</code> drops the mail-view banner prepend and wraps <em>all</em> child
+      content with <code>composeWithChrome()</code>. The now-unused <code>lipgloss</code>
+      import moved to <code>layout.go</code>.
+    </td>
+  </tr>
+  <tr>
+    <td><span class="label label-test">test</span></td>
+    <td><code>tui/internal/tui/layout_test.go</code> <em>(new)</em></td>
+    <td>8 focused tests (see below).</td>
+  </tr>
+  <tr>
+    <td><span class="label label-doc">doc</span></td>
+    <td><code>tui/internal/tui/ANATOMY.md</code></td>
+    <td>Updated <code>App.Update</code> / <code>App.View</code> / <code>sendSize</code>
+        descriptions and added a "Root layout budget (layout.go)" section.</td>
+  </tr>
+</table>
+
+<h2>Why this is the status-area foundation</h2>
+<p>
+  Root chrome ownership is now <strong>explicit and declarative</strong>. A future
+  persistent status line plugs in by: (1) declaring its rows in
+  <code>layoutBudget()</code> (e.g. <code>bottomChromeRows()</code> returns 1), and
+  (2) rendering them in a chrome helper composed by <code>View()</code>. The child
+  screen <em>automatically</em> yields the space because every sizing path
+  &mdash; the live resize (<code>Update</code>) and the route-entry seed
+  (<code>sendSize</code>) &mdash; forwards the reduced budget. No screen has to know
+  about the status area; the contract is enforced once, at the root.
+</p>
+
+<h2>Tests run</h2>
+<p>From <code>tui/</code>: <code>go test ./internal/tui</code> &mdash; <span class="good">PASS</span> (full package, no regressions). New cases:</p>
+<table>
+  <tr><th>Test</th><th>Proves</th></tr>
+  <tr><td><code>TestLayoutBudgetNoChrome</code></td><td>no chrome &rarr; child size == terminal size, zero reserved rows.</td></tr>
+  <tr><td><code>TestLayoutBudgetTopChrome</code></td><td>non-empty banner &rarr; exactly 1 top row reserved, child height &minus; 1.</td></tr>
+  <tr><td><code>TestUpdateForwardsReducedHeight</code></td><td><code>Update(WindowSizeMsg)</code> forwards child height 23 (24 &minus; 1) while <code>App.height</code> stays 24.</td></tr>
+  <tr><td><code>TestUpdateNoChromeForwardsFullHeight</code></td><td>no chrome &rarr; <code>Update</code> forwards full height.</td></tr>
+  <tr><td><code>TestSendSizeForwardsReducedHeight</code></td><td><code>sendSize()</code> forwards the reduced child size, matching the <code>Update</code> path.</td></tr>
+  <tr><td><code>TestSendSizeNoChromeForwardsFullHeight</code></td><td>no chrome &rarr; <code>sendSize()</code> forwards full size.</td></tr>
+  <tr><td><code>TestViewComposesBannerOnce</code></td><td><code>View()</code> renders the banner token exactly once, composed outside child content.</td></tr>
+  <tr><td><code>TestLayoutBudgetClampsSmallHeight</code></td><td>terminal too short &rarr; <code>ChildHeight</code> clamps to &gt;= 0, no panic.</td></tr>
+</table>
+<p>
+  The Update/sendSize/View tests run against the <code>/help</code> view (a real
+  constructor that records its forwarded height in <code>help.inner.height</code>),
+  since <code>startupBanner</code> is root chrome independent of which view is current
+  &mdash; a zero-value <code>MailModel</code> has a nil textarea and panics on size.
+</p>
+
+<h2>Limitations &amp; next steps</h2>
+<ul>
+  <li><strong>Bottom chrome is inert.</strong> <code>bottomChromeRows()</code> returns 0;
+      it exists only as a tested hook. A real bottom status line is a follow-up PR.</li>
+  <li><strong>Banner is one row.</strong> The current banner is single-line by
+      construction (<code>firstLine()</code> sanitises embedded newlines elsewhere). A
+      multi-row chrome consumer would set <code>topChromeRows()</code> accordingly and
+      ensure <code>topChrome()</code> renders exactly that many rows.</li>
+  <li><strong>Child re-clamping unchanged.</strong> Screens still re-clamp the height they
+      receive to their own minimums (e.g. mail's viewport floor of 1). The budget only
+      guarantees a non-negative forwarded height; per-screen minimums are out of scope.</li>
+  <li><strong>No new product surface.</strong> Deliberately no status-bar setting/UI
+      &mdash; this is the layout refactor foundation only (distinct from PR #241).</li>
+</ul>
+
+</body>
+</html>

--- a/tui/internal/tui/ANATOMY.md
+++ b/tui/internal/tui/ANATOMY.md
@@ -14,11 +14,16 @@ Screen routing is centralized in the `App` struct (`app.go`), which holds every 
 - **`app.go:46-79`** — `App` struct: holds every screen model plus routing state (`currentView`, `orchDir`, `orchName`, `recoveryMode`).
 - **`app.go:91-177`** — `NewApp`: constructor deciding initial view — mail view (returning user), first-run wizard (new user or rehydration), or recovery mode (global config lost, agents intact).
 - **`app.go:179-187`** — `App.Init()`: delegates to the initial view's `Init()`.
-- **`app.go:191-561`** — `App.Update()`: the central dispatcher. Three layers: (1) `WindowSizeMsg` forwarded to current view, (2) cross-view messages (`ViewChangeMsg`, `FirstRunDoneMsg`, `SetupSavedMsg`, `NirvanaDoneMsg`, `AddonSavedMsg`, etc.), (3) `KeyPressMsg` for `ctrl+c`/`q` quit, (4) fallthrough to current view's `Update()`.
+- **`app.go:191-561`** — `App.Update()`: the central dispatcher. Three layers: (1) `WindowSizeMsg` — records the full terminal size on `App`, then forwards the *reduced* child window size from `layoutBudget().ChildWindowSize()` (NOT the raw terminal height) to the current view so root chrome rows are reserved before the child sizes itself, (2) cross-view messages (`ViewChangeMsg`, `FirstRunDoneMsg`, `SetupSavedMsg`, `NirvanaDoneMsg`, `AddonSavedMsg`, etc.), (3) `KeyPressMsg` for `ctrl+c`/`q` quit, (4) fallthrough to current view's `Update()`.
 - **`app.go:563-1170`** — `handlePaletteCommand`: maps slash-command strings to view transitions (`/doctor` → `appViewDoctor`, `/daemons` → `appViewDaemons`, `/notification` → `appViewNotification`, `/knowledge` → `appViewCodex` (canonical; hidden `/library` and `/codex` aliases), `/skills` → `appViewLibrary`, etc.) and direct actions (`/suspend`, `/cpr`, `/refresh`, `/clear`, `/molt`, `/btw`, `/goal`, `/export`).
 - **`app.go:1211-1302`** — `switchToView(viewName string)`:  the canonical route-to-view dispatcher used by `ViewChangeMsg` and palette commands returning to a view. Reconstructs models fresh on entry.
-- **`app.go:1304-1356`** — `App.View()`:  delegates to current view's `View()`, wraps in `tea.NewView` with alt-screen + mouse mode.
+- **`app.go:1304-1356`** — `App.View()`:  delegates to current view's `View()` for the child content, then wraps it with root-owned chrome via `composeWithChrome` (top banner today) BEFORE building the `tea.NewView` (alt-screen + mouse mode). The startup banner is no longer prepended inside the mail-view branch — it is root chrome composed for the whole app, so it renders in the rows the child yielded rather than being appended past full terminal height.
+- **`app.go:1199-1206`** — `App.sendSize()`: returns a `tea.Cmd` carrying the *child* window size (terminal size minus root chrome rows) from `layoutBudget().ChildWindowSize()`, so a freshly-routed view and a resized view agree on height.
 - **`app.go:1347-1529`** — portal launch, style helpers, `SetTUIVersion`.
+
+### Root layout budget (`layout.go`)
+
+- **`layout.go`** — the root-owned layout-ownership contract (issue #308). `LayoutBudget{Width, Height, TopChromeRows, BottomChromeRows, ChildHeight}` describes how the terminal is split between root chrome and the child screen. `App.layoutBudget()` reserves `topChromeRows()` (one row when `startupBanner` is non-empty, else zero) + `bottomChromeRows()` (always zero — an inert hook for a future status area) and clamps `ChildHeight` to `>= 0`. `LayoutBudget.ChildWindowSize()` is the `tea.WindowSizeMsg` forwarded to the child (full width, reduced height) by both `App.Update`'s incoming-`WindowSizeMsg` handler and `App.sendSize()`. `App.topChrome()` renders the banner row and `App.composeWithChrome()` stacks it above the child content in `View()`. This is the foundation a future persistent status line plugs into: declare rows in `layoutBudget()`, render in the chrome helpers, and the child automatically yields the space. Covered by `layout_test.go`.
 
 ### Screens
 
@@ -72,7 +77,7 @@ Screen routing is centralized in the `App` struct (`app.go`), which holds every 
 - **Parent:** `tui/` (`tui/ANATOMY.md`)
 - **Subfolders:** none — the package is intentionally flat.
 - **Siblings in `tui/internal/`:** `preset/`, `migrate/`, `globalmigrate/`, `fs/`, `config/`, `process/`, `postman/`, `timemachine/`.
-- **File count:** 35 `.go` files (20 screen models + supporting types + helpers).
+- **File count:** ~43 non-test `.go` files (20 screen models + supporting types + helpers, including `layout.go` for the root layout budget).
 
 ## State
 

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/anthropics/lingtai-tui/i18n"
 	"github.com/anthropics/lingtai-tui/internal/config"
 	"github.com/anthropics/lingtai-tui/internal/fs"
@@ -193,6 +192,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.width = msg.Width
 		a.height = msg.Height
+		// Reserve rows for root chrome first, then forward the *reduced*
+		// child window size — never the raw terminal height. See
+		// layout.go (LayoutBudget) for the contract.
+		msg = a.layoutBudget().ChildWindowSize()
 		// Forward to current view so it can resize
 		var cmd tea.Cmd
 		switch a.currentView {
@@ -1196,11 +1199,14 @@ func firstLine(err error) string {
 
 // tryLock is defined in lock_unix.go / lock_windows.go
 
-// sendSize returns a tea.Cmd that sends the current terminal dimensions to the
-// newly created view so it doesn't render with zero width/height.
+// sendSize returns a tea.Cmd that sends the current *child* window size to a
+// newly created view so it doesn't render with zero width/height. The size is
+// the terminal dimensions reduced by any root chrome (see layout.go) — the same
+// budget the incoming-WindowSizeMsg handler forwards, so a freshly-routed view
+// and a resized view agree on their height.
 func (a App) sendSize() tea.Cmd {
-	w, h := a.width, a.height
-	return func() tea.Msg { return tea.WindowSizeMsg{Width: w, Height: h} }
+	cs := a.layoutBudget().ChildWindowSize()
+	return func() tea.Msg { return cs }
 }
 
 // RecipeFreshStartMsg is emitted from stepRecipeSwapConfirm when the user
@@ -1317,11 +1323,7 @@ func (a App) View() tea.View {
 	case appViewFirstRun:
 		content = a.firstRun.View()
 	case appViewMail:
-		banner := ""
-		if a.startupBanner != "" {
-			banner = "  " + lipgloss.NewStyle().Foreground(ColorStuck).Render(a.startupBanner) + "\n"
-		}
-		content = banner + a.mail.View()
+		content = a.mail.View()
 	case appViewSetup:
 		content = a.setup.View()
 	case appViewSettings:
@@ -1355,6 +1357,10 @@ func (a App) View() tea.View {
 	case appViewHelp:
 		content = a.help.View()
 	}
+	// Compose root-owned chrome (top banner today) around the child content.
+	// The child was already sized to the reduced budget, so chrome occupies
+	// the rows the child yielded rather than being appended past full height.
+	content = a.composeWithChrome(content)
 	v := tea.NewView(content)
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion

--- a/tui/internal/tui/layout.go
+++ b/tui/internal/tui/layout.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// LayoutBudget is the root-owned layout contract. The root App reserves rows
+// for persistent chrome (top status banners, and — in the future — a bottom
+// status area) BEFORE the child screen sizes itself, then forwards the reduced
+// height to the child via a WindowSizeMsg. View() composes root chrome around
+// the child content, so chrome never gets appended after a child has already
+// rendered at full terminal height.
+//
+// This is the foundation a future persistent status line / chrome consumer
+// plugs into: declare its rows in layoutBudget(), render them in the chrome
+// helpers, and the child automatically yields the space. Today the only
+// consumer is the startup banner (one top row, shown only when non-empty).
+type LayoutBudget struct {
+	Width  int
+	Height int // full terminal height
+
+	TopChromeRows    int // rows reserved at the top for root chrome
+	BottomChromeRows int // rows reserved at the bottom for root chrome (0 today)
+	ChildHeight      int // height handed to the child screen (clamped >= 0)
+}
+
+// ChildWindowSize is the WindowSizeMsg the child screen should receive: full
+// width, reduced height. Both Update's incoming-WindowSizeMsg handler and
+// sendSize() forward this so the child never sizes to the full terminal height
+// when root chrome is present.
+func (b LayoutBudget) ChildWindowSize() tea.WindowSizeMsg {
+	return tea.WindowSizeMsg{Width: b.Width, Height: b.ChildHeight}
+}
+
+// topChromeRows reports how many rows the root reserves at the top. Today that
+// is one row for the startup banner when it is non-empty, else zero.
+func (a App) topChromeRows() int {
+	if a.startupBanner != "" {
+		return 1
+	}
+	return 0
+}
+
+// bottomChromeRows reports how many rows the root reserves at the bottom. There
+// is no bottom chrome consumer yet, so this is always zero; it exists so a
+// future status area has an explicit, testable hook rather than a hard-coded
+// assumption that the child owns the last row.
+func (a App) bottomChromeRows() int {
+	return 0
+}
+
+// layoutBudget computes the current root layout budget from terminal size and
+// the rows reserved by root chrome. ChildHeight is clamped to >= 0 so a
+// terminal too short to fit the chrome never forwards a negative height
+// (screens re-clamp to their own minimums internally).
+func (a App) layoutBudget() LayoutBudget {
+	top := a.topChromeRows()
+	bottom := a.bottomChromeRows()
+	child := a.height - top - bottom
+	if child < 0 {
+		child = 0
+	}
+	return LayoutBudget{
+		Width:            a.width,
+		Height:           a.height,
+		TopChromeRows:    top,
+		BottomChromeRows: bottom,
+		ChildHeight:      child,
+	}
+}
+
+// topChrome renders the root-owned top chrome (the rows counted by
+// topChromeRows). Returns "" when there is no top chrome. The returned string,
+// when non-empty, is exactly topChromeRows() rows tall and is composed ABOVE
+// the child content in View().
+func (a App) topChrome() string {
+	if a.startupBanner == "" {
+		return ""
+	}
+	return "  " + lipgloss.NewStyle().Foreground(ColorStuck).Render(a.startupBanner)
+}
+
+// composeWithChrome stacks root top chrome above the child content. With no
+// chrome it returns the child content unchanged, so screens with no banner
+// render identically to before this contract existed.
+func (a App) composeWithChrome(child string) string {
+	top := a.topChrome()
+	if top == "" {
+		return child
+	}
+	return top + "\n" + child
+}

--- a/tui/internal/tui/layout_test.go
+++ b/tui/internal/tui/layout_test.go
@@ -1,0 +1,161 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// budgetApp builds an App parked in the /help view with the given startup
+// banner. The help view has a real constructor (unlike a zero-value MailModel,
+// whose textarea is nil) and records the height it is sized to in
+// help.inner.height — which is what these tests inspect to prove the child
+// received the reduced budget. The startupBanner is root-owned chrome,
+// independent of which view is current, so the help view exercises the same
+// layout contract the mail banner uses in production.
+func budgetApp(t *testing.T, banner string) App {
+	t.Helper()
+	return App{
+		currentView:   appViewHelp,
+		help:          NewHelpModel(),
+		startupBanner: banner,
+	}
+}
+
+// TestLayoutBudgetNoChrome: with no root chrome, the child budget equals the
+// terminal size and there are zero reserved rows.
+func TestLayoutBudgetNoChrome(t *testing.T) {
+	a := budgetApp(t, "")
+	a.width = 80
+	a.height = 24
+
+	b := a.layoutBudget()
+
+	if b.TopChromeRows != 0 || b.BottomChromeRows != 0 {
+		t.Fatalf("no banner: chrome rows = (%d, %d), want (0, 0)", b.TopChromeRows, b.BottomChromeRows)
+	}
+	if b.ChildHeight != 24 {
+		t.Fatalf("no banner: ChildHeight = %d, want 24", b.ChildHeight)
+	}
+	if cs := b.ChildWindowSize(); cs.Width != 80 || cs.Height != 24 {
+		t.Fatalf("no banner: ChildWindowSize = %dx%d, want 80x24", cs.Width, cs.Height)
+	}
+}
+
+// TestLayoutBudgetTopChrome: a non-empty startupBanner reserves exactly one top
+// row, reducing the child height by one.
+func TestLayoutBudgetTopChrome(t *testing.T) {
+	a := budgetApp(t, "⚠ something")
+	a.width = 80
+	a.height = 24
+
+	b := a.layoutBudget()
+
+	if b.TopChromeRows != 1 {
+		t.Fatalf("banner: TopChromeRows = %d, want 1", b.TopChromeRows)
+	}
+	if b.BottomChromeRows != 0 {
+		t.Fatalf("banner: BottomChromeRows = %d, want 0", b.BottomChromeRows)
+	}
+	if b.ChildHeight != 23 {
+		t.Fatalf("banner: ChildHeight = %d, want 23 (24 - 1 top chrome)", b.ChildHeight)
+	}
+	if cs := b.ChildWindowSize(); cs.Width != 80 || cs.Height != 23 {
+		t.Fatalf("banner: ChildWindowSize = %dx%d, want 80x23", cs.Width, cs.Height)
+	}
+}
+
+// TestUpdateForwardsReducedHeight: the direct Update(WindowSizeMsg) path must
+// forward the *child* window size (reduced by top chrome), not the raw
+// terminal height.
+func TestUpdateForwardsReducedHeight(t *testing.T) {
+	a := budgetApp(t, "⚠ banner")
+
+	updated, _ := a.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	got := updated.(App)
+
+	if got.help.inner.height != 23 {
+		t.Fatalf("Update forwarded child height = %d, want 23 (reduced by 1 banner row)", got.help.inner.height)
+	}
+	// Root still records the full terminal height.
+	if got.height != 24 {
+		t.Fatalf("Update recorded app height = %d, want 24 (full terminal)", got.height)
+	}
+}
+
+// TestUpdateNoChromeForwardsFullHeight: without root chrome the child receives
+// the full terminal height.
+func TestUpdateNoChromeForwardsFullHeight(t *testing.T) {
+	a := budgetApp(t, "")
+
+	updated, _ := a.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	got := updated.(App)
+
+	if got.help.inner.height != 24 {
+		t.Fatalf("Update forwarded child height = %d, want 24 (no chrome)", got.help.inner.height)
+	}
+}
+
+// TestSendSizeForwardsReducedHeight: the sendSize() cmd path must also forward
+// the reduced child size, matching the direct Update path.
+func TestSendSizeForwardsReducedHeight(t *testing.T) {
+	a := budgetApp(t, "⚠ banner")
+	a.width = 80
+	a.height = 24
+
+	msg := runCmd(a.sendSize())
+	ws, ok := msg.(tea.WindowSizeMsg)
+	if !ok {
+		t.Fatalf("sendSize produced %T, want tea.WindowSizeMsg", msg)
+	}
+	if ws.Width != 80 || ws.Height != 23 {
+		t.Fatalf("sendSize forwarded %dx%d, want 80x23 (reduced by 1 banner row)", ws.Width, ws.Height)
+	}
+}
+
+// TestSendSizeNoChromeForwardsFullHeight: without chrome, sendSize forwards the
+// full terminal size.
+func TestSendSizeNoChromeForwardsFullHeight(t *testing.T) {
+	a := budgetApp(t, "")
+	a.width = 80
+	a.height = 24
+
+	msg := runCmd(a.sendSize())
+	ws := msg.(tea.WindowSizeMsg)
+	if ws.Width != 80 || ws.Height != 24 {
+		t.Fatalf("sendSize forwarded %dx%d, want 80x24 (no chrome)", ws.Width, ws.Height)
+	}
+}
+
+// TestViewComposesBannerOnce: View() must include the banner text exactly once
+// and compose it outside the child content (as root-owned top chrome).
+func TestViewComposesBannerOnce(t *testing.T) {
+	a := budgetApp(t, "UNIQUEBANNERTOKEN")
+	a.width = 80
+	a.height = 24
+	// Size the child so its View() renders.
+	updated, _ := a.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	a = updated.(App)
+
+	out := a.View().Content
+	if n := strings.Count(out, "UNIQUEBANNERTOKEN"); n != 1 {
+		t.Fatalf("banner token appears %d times in View(), want exactly 1", n)
+	}
+}
+
+// TestLayoutBudgetClampsSmallHeight: a terminal too short to fit the reserved
+// chrome must clamp ChildHeight to >= 0 (never negative), without panicking.
+func TestLayoutBudgetClampsSmallHeight(t *testing.T) {
+	a := budgetApp(t, "⚠ banner")
+	a.width = 80
+	a.height = 0
+
+	b := a.layoutBudget()
+	if b.ChildHeight < 0 {
+		t.Fatalf("ChildHeight = %d, want >= 0 (clamped)", b.ChildHeight)
+	}
+	if cs := b.ChildWindowSize(); cs.Height < 0 {
+		t.Fatalf("ChildWindowSize.Height = %d, want >= 0 (clamped)", cs.Height)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce a root-owned `LayoutBudget` contract for TUI chrome rows
- make both `App.Update(WindowSizeMsg)` and `sendSize()` forward the reduced child window size
- move the startup banner into root top chrome composition instead of prepending it after child render
- add focused tests for no-chrome, top-chrome, `sendSize`, view composition, and small-height clamping

Fixes #308.

## Validation
- from `tui/`: `go test ./internal/tui`
- from `tui/`: `git diff --check`

## Report
- `reports/root-layout-budget-308-20260613.html`

## Notes
- this does not revive the old full status-line PR; bottom chrome remains an inert zero-row hook for future work
