### PR TITLE
fix: align migration version 38

### DIFF
--- a/portal/internal/migrate/m038_agent_init_skills_paths.go
+++ b/portal/internal/migrate/m038_agent_init_skills_paths.go
@@ -1,0 +1,118 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var defaultPresetSkillsPaths = []interface{}{
+	"../.library_shared",
+	"~/.lingtai-tui/utilities",
+}
+
+// migrateAgentInitSkillsPaths is the portal copy of TUI m038 (see
+// tui/internal/migrate/m038_agent_init_skills_paths.go — keep the logic
+// identical). Agents materialized while the preset editor model-switch bug
+// (PR #312) was live carry damaged init.json: a manifest.capabilities map
+// whose skills entry lost its paths kwarg (or the skills entry — or the
+// whole capabilities map — outright).
+//
+// This repair touches shared on-disk state, so whichever binary migrates
+// the project first must perform it: a no-op stub here would let a
+// portal-first launch stamp meta.json at 38 and silently skip the TUI's
+// repair forever.
+//
+// Walks every agent directory under the project's .lingtai/ dir and adds
+// the default skills paths where missing:
+//
+//   - existing skills.paths values are preserved exactly
+//   - other skills config and other capability entries are untouched
+//   - a missing manifest.capabilities map is created
+//   - a non-map manifest.capabilities (or manifest) means skip that file
+//
+// Best-effort: malformed init.json is logged to stderr and skipped; a single
+// broken agent must not stall the migration.
+func migrateAgentInitSkillsPaths(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		patchAgentInitSkillsPathsFile(filepath.Join(lingtaiDir, name, "init.json"))
+	}
+	return nil
+}
+
+func patchAgentInitSkillsPathsFile(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // dirs without init.json are not agents
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: skipping %s — unparseable init.json: %v\n", path, err)
+		return
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		if _, exists := manifest["capabilities"]; exists {
+			return // non-map capabilities: not a shape we understand, leave alone
+		}
+		caps = map[string]interface{}{}
+		manifest["capabilities"] = caps
+	}
+	if !patchPresetSkillsPathsMap(caps) {
+		return
+	}
+	updated, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "m038: marshal failed for %s: %v\n", path, err)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, updated, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: write tmp failed for %s: %v\n", path, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: rename failed for %s: %v\n", path, err)
+		_ = os.Remove(tmp)
+	}
+}
+
+// patchPresetSkillsPathsMap mirrors the TUI m037 helper of the same name:
+// ensure caps has a skills entry whose paths kwarg exists, without touching
+// any existing paths value or sibling config. Reports whether caps changed.
+func patchPresetSkillsPathsMap(caps map[string]interface{}) bool {
+	skillsRaw, hasSkills := caps["skills"]
+	if !hasSkills {
+		caps["skills"] = map[string]interface{}{"paths": append([]interface{}{}, defaultPresetSkillsPaths...)}
+		return true
+	}
+	skillsCfg, ok := skillsRaw.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if _, hasPaths := skillsCfg["paths"]; hasPaths {
+		return false
+	}
+	skillsCfg["paths"] = append([]interface{}{}, defaultPresetSkillsPaths...)
+	return true
+}

--- a/portal/internal/migrate/m038_agent_init_skills_paths_test.go
+++ b/portal/internal/migrate/m038_agent_init_skills_paths_test.go
@@ -1,0 +1,152 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeAgentInit(t *testing.T, lingtaiDir, agent, content string) string {
+	t.Helper()
+	agentDir := filepath.Join(lingtaiDir, agent)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(agentDir, "init.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readAgentSkills(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("patched init.json is not valid json: %v\n%s", err, data)
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing or not a map: %s", data)
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("capabilities missing or not a map: %s", data)
+	}
+	skills, ok := caps["skills"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("skills missing or not a map: %s", data)
+	}
+	return skills
+}
+
+// TestRunFrom37PatchesAgentInitAndAdvancesTo38 pins the portal-opened-first
+// scenario: a project the TUI last touched at version 37 must get the agent
+// init.json skills.paths repair from the portal too, not just a version
+// stamp. A no-op stub here would mark the project as migrated and the TUI's
+// m038 would never run.
+func TestRunFrom37PatchesAgentInitAndAdvancesTo38(t *testing.T) {
+	lingtaiDir := filepath.Join(t.TempDir(), ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMeta(t, lingtaiDir, 37)
+
+	// skills entry present but paths lost
+	orch := writeAgentInit(t, lingtaiDir, "orch",
+		`{"manifest":{"capabilities":{"skills":{"library_limit":42},"web_search":{"provider":"zhipu"}}}}`)
+	// whole capabilities map lost
+	scout := writeAgentInit(t, lingtaiDir, "scout", `{"manifest":{"llm":{"provider":"custom"}}}`)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+
+	if meta := readMeta(t, lingtaiDir); meta.Version != 38 {
+		t.Fatalf("expected meta version 38, got %d", meta.Version)
+	}
+
+	orchSkills := readAgentSkills(t, orch)
+	if !reflect.DeepEqual(orchSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("orch skills.paths = %#v, want %#v", orchSkills["paths"], defaultPresetSkillsPaths)
+	}
+	if got := orchSkills["library_limit"]; got != float64(42) {
+		t.Fatalf("orch existing skills config overwritten: %#v", orchSkills)
+	}
+
+	scoutSkills := readAgentSkills(t, scout)
+	if !reflect.DeepEqual(scoutSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("scout skills.paths = %#v, want %#v", scoutSkills["paths"], defaultPresetSkillsPaths)
+	}
+
+	// sibling capability entries survive
+	data, _ := os.ReadFile(orch)
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	caps := doc["manifest"].(map[string]interface{})["capabilities"].(map[string]interface{})
+	ws, ok := caps["web_search"].(map[string]interface{})
+	if !ok || ws["provider"] != "zhipu" {
+		t.Fatalf("web_search entry damaged: %#v", caps["web_search"])
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsPreservesCustomPaths(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	content := `{"manifest":{"capabilities":{"skills":{"paths":["./custom-skills"]}}}}`
+	path := writeAgentInit(t, lingtaiDir, "orch", content)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// File must be byte-identical: nothing to patch means no rewrite.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Fatalf("init.json with custom paths was rewritten: %s", data)
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsSkipsMalformedAndNonMapCases(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	cases := map[string]string{
+		"broken":         `{"manifest":`,
+		"weird-caps":     `{"manifest":{"capabilities":["skills"]}}`,
+		"weird-manifest": `{"manifest":"nope"}`,
+	}
+	paths := map[string]string{}
+	for agent, content := range cases {
+		paths[agent] = writeAgentInit(t, lingtaiDir, agent, content)
+	}
+	// a valid sibling proves the migration continues past the broken ones
+	good := writeAgentInit(t, lingtaiDir, "zz-good", `{"manifest":{"capabilities":{}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	for agent, content := range cases {
+		data, err := os.ReadFile(paths[agent])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != content {
+			t.Fatalf("%s init.json should be unchanged, got: %s", agent, data)
+		}
+	}
+
+	skills := readAgentSkills(t, good)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("valid sibling not patched: %#v", skills["paths"])
+	}
+}

--- a/portal/internal/migrate/migrate.go
+++ b/portal/internal/migrate/migrate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CurrentVersion is the latest migration version compiled into this binary.
-const CurrentVersion = 37
+const CurrentVersion = 38
 
 type metaFile struct {
 	Version int `json:"version"`
@@ -60,6 +60,7 @@ var migrations = []Migration{
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},                                           // shared: strips brief.md + brief_file/brief keys after secretary removal
 	{Version: 36, Name: "sqlite-log-backfill", Fn: func(_ string) error { return nil }},                   // TUI-only: optional command-line SQLite log backfill prompt/progress
 	{Version: 37, Name: "preset-skills-paths", Fn: func(_ string) error { return nil }},                   // TUI-only: patches saved preset skill path overrides
+	{Version: 38, Name: "agent-init-skills-paths", Fn: migrateAgentInitSkillsPaths},                       // shared: restores missing skills.paths in agent init.json — whichever binary migrates first must repair
 }
 
 // StampCurrent writes meta.json at CurrentVersion without running any

--- a/reports/agent-init-skills-paths-migration-20260612-explainer.html
+++ b/reports/agent-init-skills-paths-migration-20260612-explainer.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>m038: restore skills.paths in materialized agent init.json</title>
+  <style>
+    :root { color-scheme: light dark; --accent:#5b6cff; --muted:#667085; --border:#d0d5dd; --bg:#f8fafc; }
+    body { margin:0; font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; color:#101828; background:var(--bg); }
+    main { max-width:920px; margin:40px auto; padding:0 22px 48px; }
+    .card { background:white; border:1px solid var(--border); border-radius:18px; padding:24px; box-shadow:0 10px 28px rgba(16,24,40,.08); }
+    h1 { margin:0 0 10px; font-size:30px; line-height:1.15; }
+    h2 { margin-top:28px; font-size:20px; }
+    .lede { color:var(--muted); margin-top:0; }
+    .pill { display:inline-block; border-radius:999px; padding:4px 10px; background:#eef2ff; color:#3538cd; font-weight:600; font-size:13px; }
+    ul { padding-left:22px; }
+    code { background:#f2f4f7; padding:2px 5px; border-radius:6px; }
+    pre { background:#f2f4f7; padding:14px; border-radius:10px; overflow-x:auto; font-size:14px; }
+    pre code { background:none; padding:0; }
+    .ok { border-left:4px solid #12b76a; padding-left:14px; }
+    @media (prefers-color-scheme: dark) { body { background:#0b1020; color:#e4e7ec; } .card { background:#111827; border-color:#344054; } .lede { color:#98a2b3; } code { background:#1f2937; } pre { background:#1f2937; } .pill { background:#20295f; color:#c7d7fe; } }
+  </style>
+</head>
+<body>
+<main>
+  <div class="card">
+    <span class="pill">PR #312 follow-up · project migration m038</span>
+    <h1>Repair <code>skills.paths</code> in already-materialized agent <code>init.json</code></h1>
+    <p class="lede">PR #312 fixed the preset editor bug that deleted <code>skills.paths</code> on model switch, and m037 repaired the saved presets it damaged. Jason's review pointed out the target that actually matters: agents <em>materialized while the bug was live</em> carry the same damage in their own <code>init.json</code>, and they keep running with it regardless of the repaired preset. m038 is the per-project companion that patches those files directly.</p>
+
+    <h2>What m038 does</h2>
+    <p>On the project's next TUI launch, the migration walks every agent directory under <code>.lingtai/</code> (skipping hidden dirs and <code>human/</code>) and silently ensures <code>manifest.capabilities.skills.paths</code> exists in each <code>init.json</code>, restoring the defaults when missing:</p>
+    <pre><code>"skills": {
+  "paths": ["../.library_shared", "~/.lingtai-tui/utilities"]
+}</code></pre>
+    <p>Same rules as m037, applied per agent via the shared <code>patchPresetSkillsPathsMap</code> helper:</p>
+    <ul>
+      <li>Existing <code>skills.paths</code> values (custom overrides) are preserved exactly — the file isn't even rewritten.</li>
+      <li>Other <code>skills</code> config keys and all sibling capability entries (<code>web_search</code>, <code>bash</code>, …) are untouched.</li>
+      <li>A missing <code>manifest.capabilities</code> map is created; a non-object <code>capabilities</code> (or <code>manifest</code>) means that file is skipped safely.</li>
+      <li>Malformed <code>init.json</code> is skipped with a stderr note only; one broken agent never stalls the migration.</li>
+      <li>Writes are atomic (temp file + rename), matching every other migration in the package.</li>
+    </ul>
+
+    <h2>Migration etiquette</h2>
+    <ul>
+      <li>Both registries bump <code>CurrentVersion</code> 37 → 38 with <code>m038 agent-init-skills-paths</code>.</li>
+      <li>The migration touches shared on-disk state (agent <code>init.json</code>) and both binaries run migrations against the shared <code>meta.json</code> version space, so the repair is implemented with identical logic in <strong>both</strong> <code>tui/internal/migrate</code> and <code>portal/internal/migrate</code> — whichever binary opens the project first performs the one-time repair. A no-op portal stub would have let a portal-first launch stamp the project at version 38 and silently skip the repair forever.</li>
+    </ul>
+
+    <h2>Tests</h2>
+    <ul>
+      <li><code>TestMigrateAgentInitSkillsPathsPatchesMultipleAgents</code> — two agents (paths lost vs. whole skills entry lost) both repaired; sibling <code>web_search</code> config survives.</li>
+      <li><code>TestMigrateAgentInitSkillsPathsCreatesMissingCapabilitiesMap</code> — an init.json with no capabilities map at all gets one with the default skills paths.</li>
+      <li><code>TestMigrateAgentInitSkillsPathsPreservesCustomPaths</code> — custom <code>skills.paths</code> leaves the file byte-identical.</li>
+      <li><code>TestMigrateAgentInitSkillsPathsSkipsMalformedAndNonMapCases</code> — truncated JSON, list-shaped <code>capabilities</code>, and string <code>manifest</code> are all left unchanged while a valid sibling agent is still patched.</li>
+      <li>Portal: <code>TestRunFrom37PatchesAgentInitAndAdvancesTo38</code> pins the portal-opened-first scenario — <code>Run</code> on a version-37 project repairs agent <code>init.json</code> and advances <code>meta.json</code> to 38 — plus portal copies of the preserve-custom-paths and malformed/non-map skip tests.</li>
+    </ul>
+
+    <h2>Files touched</h2>
+    <ul>
+      <li><code>tui/internal/migrate/m038_agent_init_skills_paths.go</code> and <code>portal/internal/migrate/m038_agent_init_skills_paths.go</code> — the migration, identical logic in both packages (+ test files).</li>
+      <li><code>tui/internal/migrate/migrate.go</code> / <code>portal/internal/migrate/migrate.go</code> — version 38 registry entries.</li>
+    </ul>
+
+    <h2>Validation</h2>
+    <p class="ok">gofmt clean on all touched files; focused <code>TestMigrateAgentInitSkillsPaths*</code>, <code>TestPatchPresetSkillsPaths*</code>, and <code>TestRunFrom37*</code> pass; full <code>go test ./internal/migrate</code> passes in both the TUI and portal modules.</p>
+  </div>
+</main>
+</body>
+</html>

--- a/reports/preserve-skills-paths-model-switch-20260612-explainer.html
+++ b/reports/preserve-skills-paths-model-switch-20260612-explainer.html
@@ -66,7 +66,7 @@ for _, capName := range optionalCapabilities {
     <ul>
       <li>Idempotent: existing <code>skills.paths</code> values are preserved exactly.</li>
       <li>Conservative: built-in templates are not patched because they are regenerated and already carry the default paths.</li>
-      <li>Durable: the preset is patched instead of individual agent <code>init.json</code> files, because active presets rematerialize agent capabilities on refresh/boot.</li>
+      <li>Durable: the preset is patched instead of individual agent <code>init.json</code> files, because active presets rematerialize agent capabilities on refresh/boot. (Follow-up: review found that already-materialized agents keep the damaged <code>init.json</code> until an explicit refresh, so project migration m038 patches those files directly — see <code>agent-init-skills-paths-migration-20260612-explainer.html</code>.)</li>
       <li>Migration etiquette: TUI migration version bumps from 36 to 37, and the portal registry receives the matching no-op version entry to keep the shared meta version space aligned.</li>
     </ul>
 

--- a/tui/internal/migrate/m038_agent_init_skills_paths.go
+++ b/tui/internal/migrate/m038_agent_init_skills_paths.go
@@ -1,0 +1,95 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// migrateAgentInitSkillsPaths is the per-project companion to m037. m037
+// repaired global saved presets hit by the preset editor model-switch bug
+// (PR #312), but agents materialized while the bug was live carry the same
+// damage in their own init.json: a manifest.capabilities map whose skills
+// entry lost its paths kwarg (or the skills entry — or the whole
+// capabilities map — outright). Those agents won't pick up the repaired
+// preset until their next explicit preset refresh, so the already-written
+// init.json is the target that actually matters.
+//
+// Walks every agent directory under the project's .lingtai/ dir and adds the
+// default skills paths where missing, using the same rules as m037:
+//
+//   - existing skills.paths values are preserved exactly
+//   - other skills config and other capability entries are untouched
+//   - a missing manifest.capabilities map is created
+//   - a non-map manifest.capabilities (or manifest) means skip that file
+//
+// Best-effort: malformed init.json is logged to stderr and skipped; a single
+// broken agent must not stall the migration.
+//
+// Shared on-disk state: the portal carries an identical copy
+// (portal/internal/migrate/m038_agent_init_skills_paths.go) because whichever
+// binary migrates the project first must perform the repair — keep the two
+// in sync.
+func migrateAgentInitSkillsPaths(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		patchAgentInitSkillsPathsFile(filepath.Join(lingtaiDir, name, "init.json"))
+	}
+	return nil
+}
+
+func patchAgentInitSkillsPathsFile(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // dirs without init.json are not agents
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: skipping %s — unparseable init.json: %v\n", path, err)
+		return
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		if _, exists := manifest["capabilities"]; exists {
+			return // non-map capabilities: not a shape we understand, leave alone
+		}
+		caps = map[string]interface{}{}
+		manifest["capabilities"] = caps
+	}
+	if !patchPresetSkillsPathsMap(caps) {
+		return
+	}
+	updated, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "m038: marshal failed for %s: %v\n", path, err)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, updated, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: write tmp failed for %s: %v\n", path, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: rename failed for %s: %v\n", path, err)
+		_ = os.Remove(tmp)
+	}
+}

--- a/tui/internal/migrate/m038_agent_init_skills_paths_test.go
+++ b/tui/internal/migrate/m038_agent_init_skills_paths_test.go
@@ -1,0 +1,156 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeAgentInit(t *testing.T, lingtaiDir, agent, content string) string {
+	t.Helper()
+	agentDir := filepath.Join(lingtaiDir, agent)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(agentDir, "init.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readAgentSkills(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("patched init.json is not valid json: %v\n%s", err, data)
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing or not a map: %s", data)
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("capabilities missing or not a map: %s", data)
+	}
+	skills, ok := caps["skills"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("skills missing or not a map: %s", data)
+	}
+	return skills
+}
+
+func TestMigrateAgentInitSkillsPathsPatchesMultipleAgents(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	// skills entry present but paths lost
+	orch := writeAgentInit(t, lingtaiDir, "orch",
+		`{"manifest":{"capabilities":{"skills":{"library_limit":42},"web_search":{"provider":"zhipu"}}}}`)
+	// skills entry lost entirely
+	scout := writeAgentInit(t, lingtaiDir, "scout",
+		`{"manifest":{"capabilities":{"bash":{"yolo":true}}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	orchSkills := readAgentSkills(t, orch)
+	if !reflect.DeepEqual(orchSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("orch skills.paths = %#v, want %#v", orchSkills["paths"], defaultPresetSkillsPaths)
+	}
+	if got := orchSkills["library_limit"]; got != float64(42) {
+		t.Fatalf("orch existing skills config overwritten: %#v", orchSkills)
+	}
+
+	scoutSkills := readAgentSkills(t, scout)
+	if !reflect.DeepEqual(scoutSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("scout skills.paths = %#v, want %#v", scoutSkills["paths"], defaultPresetSkillsPaths)
+	}
+
+	// sibling capability entries survive
+	data, _ := os.ReadFile(orch)
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	caps := doc["manifest"].(map[string]interface{})["capabilities"].(map[string]interface{})
+	ws, ok := caps["web_search"].(map[string]interface{})
+	if !ok || ws["provider"] != "zhipu" {
+		t.Fatalf("web_search entry damaged: %#v", caps["web_search"])
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsCreatesMissingCapabilitiesMap(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	path := writeAgentInit(t, lingtaiDir, "orch", `{"manifest":{"llm":{"provider":"custom"}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := readAgentSkills(t, path)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsPreservesCustomPaths(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	content := `{"manifest":{"capabilities":{"skills":{"paths":["./custom-skills"]}}}}`
+	path := writeAgentInit(t, lingtaiDir, "orch", content)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// File must be byte-identical: nothing to patch means no rewrite.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Fatalf("init.json with custom paths was rewritten: %s", data)
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsSkipsMalformedAndNonMapCases(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	malformed := writeAgentInit(t, lingtaiDir, "broken", `{"manifest":`)
+	nonMapCaps := writeAgentInit(t, lingtaiDir, "weird-caps",
+		`{"manifest":{"capabilities":["skills"]}}`)
+	nonMapManifest := writeAgentInit(t, lingtaiDir, "weird-manifest",
+		`{"manifest":"nope"}`)
+	// a valid sibling proves the migration continues past the broken ones
+	good := writeAgentInit(t, lingtaiDir, "zz-good", `{"manifest":{"capabilities":{}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, path := range map[string]string{
+		"malformed": malformed, "non-map capabilities": nonMapCaps, "non-map manifest": nonMapManifest,
+	} {
+		before := map[string]string{
+			"malformed":            `{"manifest":`,
+			"non-map capabilities": `{"manifest":{"capabilities":["skills"]}}`,
+			"non-map manifest":     `{"manifest":"nope"}`,
+		}[name]
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != before {
+			t.Fatalf("%s init.json should be unchanged, got: %s", name, data)
+		}
+	}
+
+	skills := readAgentSkills(t, good)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("valid sibling not patched: %#v", skills["paths"])
+	}
+}

--- a/tui/internal/migrate/migrate.go
+++ b/tui/internal/migrate/migrate.go
@@ -9,7 +9,7 @@ import (
 
 // CurrentVersion is the latest migration version compiled into this binary.
 // IMPORTANT: when bumping, also bump portal/internal/migrate/migrate.go (see CLAUDE.md).
-const CurrentVersion = 37
+const CurrentVersion = 38
 
 type metaFile struct {
 	Version                     int  `json:"version"`
@@ -62,6 +62,7 @@ var migrations = []Migration{
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},
 	{Version: 36, Name: "sqlite-log-backfill", Fn: migrateSQLiteLogBackfill},
 	{Version: 37, Name: "preset-skills-paths", Fn: migratePresetSkillsPaths},
+	{Version: 38, Name: "agent-init-skills-paths", Fn: migrateAgentInitSkillsPaths},
 }
 
 // Run executes all pending migrations on the given .lingtai/ directory.


### PR DESCRIPTION
## What changed

This PR keeps only the TUI/Portal migration-version fix.

- `tui/internal/migrate/migrate.go`: bumps `CurrentVersion` to 38 and registers m037/m038.
- `portal/internal/migrate/migrate.go`: aligns current version to 38.
- Adds m038 agent-init skills-path migration implementations and tests for TUI and Portal.
- Keeps related explainer report files.

The custom saved-preset workflow documentation was removed from this PR after Jason clarified it belongs in `lingtai-kernel` `system-manual`, not in the TUI repo.

## Why

Some local project data had already reached version 37 while `main` compiled `CurrentVersion = 36`, causing startup failures like:

```text
data version 37 is newer than this binary supports (36); upgrade lingtai-tui
```

## Validation

- `(cd tui && go test ./internal/migrate -count=1 -timeout 90s)`
- `(cd portal && go test ./internal/migrate -count=1 -timeout 60s)`

No merge without Jason approval.