### PR TITLE
docs: clarify repo hygiene for reports and artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ plot_example.py
 scatter_plot.*
 test/
 playground
+artifacts/
+
+# Do not ignore reports/ globally: this repo intentionally tracks selected
+# human-facing PR/release explainers under reports/. Use artifacts/ or tmp/ for
+# local-only generated output, and force-add reports only when they are durable
+# review artifacts.
 
 # App runtime configs (may contain secrets)
 app/email/config.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,15 @@ git branch -d <branch-slug>
 
 **Hard rule:** if a change touches more than ~10 lines or spans more than one file, move it to a worktree before editing. Single-line fixes and doc tweaks can stay in the main checkout. The 30 seconds to spin up a worktree are recouped the first time a parallel session resets the branch out from under you.
 
+## Repository hygiene: reports, discussions, and scratch output
+
+Treat repo cleanup as a small, evidence-backed change, not a bulk deletion pass. This repo intentionally keeps some human-facing artifacts in git history:
+
+- `reports/` contains selected PR/release explainers and review artifacts that are handed to humans. Do not bulk-delete or globally ignore `reports/`; use `artifacts/` or `tmp/` for local-only generated output, and only add a report when it is meant to survive with the PR/release record.
+- `discussions/` contains agent-filed patch specs and design notes. Do not remove or rewrite them during generic cleanup; close or archive them only through an owner-approved, issue-specific decision.
+- `prompt/archive/` contains historical prompt material. Treat it as manual-review territory unless a reference check and owner approval say otherwise.
+- Local scratch directories (`tmp/`, `artifacts/`, `.worktrees/`, build bins, caches) should be ignored rather than committed. If a cleanup proposal touches durable docs/reports/discussions, split that into a separate owner-gated PR.
+
 ## What is 灵台
 
 灵台 (Língtái) is a generic agent framework — an "agent operating system" providing the minimal kernel for AI agents: thinking (LLM), perceiving (vision, search), acting (file I/O), and communicating (inter-agent email). Domain tools, coordination, and orchestration are plugged in from outside via MCP-compatible interfaces.

--- a/reports/repo-hygiene-20260613.html
+++ b/reports/repo-hygiene-20260613.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LingTai repo hygiene clarification</title>
+  <style>
+    :root { color-scheme: light dark; --bg:#fbf7ef; --card:#fffaf2; --ink:#241b16; --muted:#6d625b; --accent:#9b5c19; --line:#e6d8c6; --ok:#207245; --warn:#a45b00; }
+    @media (prefers-color-scheme: dark) { :root { --bg:#181411; --card:#221c18; --ink:#f3e8dc; --muted:#c6b6a7; --accent:#e0a15c; --line:#40352e; --ok:#7bd88f; --warn:#ffbd66; } }
+    body { margin:0; background:var(--bg); color:var(--ink); font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    main { max-width:920px; margin:0 auto; padding:40px 22px 56px; }
+    h1 { margin:0 0 8px; font-size:30px; }
+    h2 { margin-top:28px; padding-bottom:6px; border-bottom:1px solid var(--line); }
+    .subtitle { color:var(--muted); margin-bottom:24px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:14px; padding:18px 20px; margin:16px 0; }
+    code { background:rgba(127,90,40,.14); padding:1px 5px; border-radius:5px; }
+    ul { padding-left:22px; }
+    .ok { color:var(--ok); font-weight:700; }
+    .warn { color:var(--warn); font-weight:700; }
+    table { width:100%; border-collapse:collapse; margin-top:10px; }
+    th,td { border:1px solid var(--line); padding:8px 10px; vertical-align:top; text-align:left; }
+    th { background:rgba(127,90,40,.10); }
+  </style>
+</head>
+<body>
+<main>
+  <h1>LingTai main repo hygiene clarification</h1>
+  <p class="subtitle">Scope: conservative cleanup PR for <code>Lingtai-AI/lingtai</code>; generated after Claude proposal and conservative synthesis.</p>
+
+  <section class="card">
+    <h2>TL;DR</h2>
+    <p><span class="ok">This PR intentionally does not delete historical reports, discussions, or prompt archives.</span> It makes the repository hygiene contract explicit and adds <code>artifacts/</code> as the local-only output directory for throwaway generated files.</p>
+  </section>
+
+  <section class="card">
+    <h2>Baseline</h2>
+    <ul>
+      <li>Claude Code proposed removing several generated-looking <code>reports/*.html</code> files and adding broad ignore patterns.</li>
+      <li>Local evidence showed <code>reports/</code> is part of the current PR/release explainer workflow: the dev guide requires human-facing HTML explainers under <code>reports/</code>.</li>
+      <li><code>discussions/</code> holds agent-filed patch/design specs and should not be bulk-deleted during generic cleanup.</li>
+      <li><code>prompt/archive/</code> has historical prompt material and references from older planning docs; it remains manual-review territory.</li>
+      <li><code>tui/bin/</code> and <code>portal/bin/</code> are already ignored by their package-level <code>.gitignore</code> files, so no root change is needed for them.</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2>What changed</h2>
+    <table>
+      <tr><th>File</th><th>Change</th></tr>
+      <tr><td><code>.gitignore</code></td><td>Adds <code>artifacts/</code> for local-only generated output and documents why <code>reports/</code> is not globally ignored.</td></tr>
+      <tr><td><code>CLAUDE.md</code></td><td>Adds a repository hygiene section: keep cleanup small and evidence-backed; do not bulk-delete <code>reports/</code>, <code>discussions/</code>, or <code>prompt/archive/</code>; use <code>tmp/</code>/<code>artifacts/</code> for scratch output.</td></tr>
+      <tr><td><code>reports/repo-hygiene-20260613.html</code></td><td>This self-contained explainer.</td></tr>
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Validation</h2>
+    <ul>
+      <li><span class="ok">PASS</span> <code>git diff --check</code></li>
+      <li><span class="ok">PASS</span> <code>git check-ignore -v artifacts/example tmp/example .worktrees/example</code></li>
+      <li><span class="ok">PASS</span> Verified <code>reports/example.html</code> is not globally ignored.</li>
+      <li><span class="ok">PASS</span> Verified <code>tui/bin/lingtai-tui</code> and <code>portal/bin/lingtai-portal</code> are already ignored by package-level <code>.gitignore</code> files.</li>
+      <li><span class="warn">Note</span> GLM/Zhipu review was attempted per Jason's requested flow, but all configured Zhipu keys returned insufficient-balance/resource-package errors. This PR therefore keeps scope minimal and non-destructive.</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2>Risks / decisions</h2>
+    <ul>
+      <li>No source, build, runtime, or release behavior changes.</li>
+      <li>No deletion of tracked historical artifacts in this PR.</li>
+      <li>Future cleanup of individual reports, discussions, or prompt archive files should be owner-approved and issue-specific.</li>
+      <li>Addon repo cleanup should be handled in separate per-repo PRs after the same conservative review.</li>
+    </ul>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary\n- clarify that tracked reports/discussions/prompt archives are durable artifacts, not generic cleanup targets\n- add artifacts/ as the local-only generated-output home while keeping reports/ available for selected PR/release explainers\n- document the conservative cleanup rule in CLAUDE.md\n\n## Cleanup process\n- Claude Code produced a read-only cleanup proposal: tmp/repo-cleanup-20260613/claude-cleanup-proposal.md\n- GLM/Zhipu review was attempted, but every configured Zhipu key/model returned insufficient-balance/resource-package 429; I therefore kept this PR deliberately small and non-destructive\n- Cross-checked dev-3/kernel cleanup principle: do not bulk-delete historical reports/discussions/design artifacts during generic repo cleanup\n\n## Validation\n- git diff --check\n- git check-ignore -v artifacts/example tmp/example .worktrees/example\n- verified reports/example.html is not ignored\n- verified tui/bin/lingtai-tui and portal/bin/lingtai-portal are already ignored by package-level .gitignore files\n\n## Report\n- reports/repo-hygiene-20260613.html