### PR TITLE
docs: deduplicate dev guide release docs

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -163,7 +163,7 @@ drill-down files, not standalone top-level skills.
   `lingtai-kernel-anatomy` → relevant kernel anatomy/code → kernel tests.
 - **"An agent is quiet or unreachable"** → `reference/debug-troubleshoot/SKILL.md`
   → `lingtai-doctor` if local health surfaces disagree.
-- **"I am preparing a release"** → `reference/releasing/SKILL.md` for the overview and authorization boundary, then `reference/release-workflow/SKILL.md` for the full publishing checklist, the required HTML release log, and (for website release blogs) its `assets/release-blog-template.md`.
+- **"I am preparing a release"** → `reference/releasing/SKILL.md` for the overview and authorization boundary, then `reference/release-workflow/SKILL.md` for the full publishing checklist, the required HTML release log, and (for website release blogs) its `reference/release-workflow/assets/release-blog-template.md`.
 - **"This broad dev task needs triage"** → run the read-only portfolio sweep in
   `reference/contributing/SKILL.md`, then ask for authorization before mutating
   GitHub state.

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -65,15 +65,16 @@ drill-down files, not standalone top-level skills.
 - name: dev-guide-releasing
   location: reference/releasing/SKILL.md
   description: |
-    Compact release procedures for TUI/portal and kernel changes, including
-    readiness checks, release artifact guidance, and basic publication steps.
+    Compact release overview: when a release applies, the maintainer-authorization
+    boundary, and the version scheme. Routes to release-workflow for the full
+    command-level checklist. Start here, then go to release-workflow.
 - name: dev-guide-release-workflow
   location: reference/release-workflow/SKILL.md
   description: |
-    Full consequential release workflow for paired TUI/Portal + kernel release
-    planning, clean worktrees, validation gates, GitHub/PyPI/Homebrew publishing
-    boundaries, website release-log/blog drafting, and the reusable release blog
-    template.
+    Full command-level release checklist for paired TUI/Portal + kernel releases:
+    scope/candidate heads, clean worktrees, validation gates, GitHub/PyPI/Homebrew
+    publishing, the required self-contained HTML release log, and website
+    release-log/blog drafting with the reusable release blog template.
 - name: dev-guide-debug-troubleshoot
   location: reference/debug-troubleshoot/SKILL.md
   description: |
@@ -123,7 +124,7 @@ drill-down files, not standalone top-level skills.
 | Set up a local development environment | `reference/setup/SKILL.md` |
 | Make a contribution in TUI, portal, kernel, addons, or skills | `reference/contributing/SKILL.md` |
 | Avoid common footguns while coding | `reference/gotchas/SKILL.md` |
-| Ship a TUI/portal or kernel release | `reference/releasing/SKILL.md`; for consequential paired releases or release blogs, also read `reference/release-workflow/SKILL.md` |
+| Ship a TUI/portal or kernel release | Start at `reference/releasing/SKILL.md` for the overview and authorization boundary, then `reference/release-workflow/SKILL.md` for the full checklist (publishing, HTML release log, release blog) |
 | Diagnose a stuck, errored, or misbehaving LingTai network | `reference/debug-troubleshoot/SKILL.md` |
 | Audit secrets, permissions, MCP config, channels, or data exposure | `reference/security-audit/SKILL.md` |
 | Operate an avatar network over time | `reference/network-governance/SKILL.md` |
@@ -162,7 +163,7 @@ drill-down files, not standalone top-level skills.
   `lingtai-kernel-anatomy` → relevant kernel anatomy/code → kernel tests.
 - **"An agent is quiet or unreachable"** → `reference/debug-troubleshoot/SKILL.md`
   → `lingtai-doctor` if local health surfaces disagree.
-- **"I am preparing a release"** → `reference/releasing/SKILL.md`; for paired TUI/kernel releases, website release blogs, or publication-bound checklists, continue to `reference/release-workflow/SKILL.md` and its `assets/release-blog-template.md`.
+- **"I am preparing a release"** → `reference/releasing/SKILL.md` for the overview and authorization boundary, then `reference/release-workflow/SKILL.md` for the full publishing checklist, the required HTML release log, and (for website release blogs) its `assets/release-blog-template.md`.
 - **"This broad dev task needs triage"** → run the read-only portfolio sweep in
   `reference/contributing/SKILL.md`, then ask for authorization before mutating
   GitHub state.

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
@@ -3,15 +3,20 @@ name: dev-guide-release-workflow
 description: >
   Nested lingtai-dev-guide reference for consequential LingTai releases: paired
   TUI/Portal + kernel release planning, clean worktrees, validation gates,
-  GitHub/PyPI/Homebrew publishing boundaries, website release-log/blog drafting,
-  and the reusable release blog template.
-version: 1.0.0
+  GitHub/PyPI/Homebrew publishing boundaries, the required self-contained HTML
+  release log, website release-log/blog drafting, and the reusable release blog
+  template.
+version: 1.1.0
 ---
 
 # Release Workflow
 
 Nested lingtai-dev-guide reference. Read this after the top-level router sends
 you here for release preparation, release publication, or release blog work.
+
+> For a compact orientation — when a release applies, the maintainer-authorization
+> boundary, and the version scheme — see `../releasing/SKILL.md`. This page owns
+> the full command-level checklist.
 
 Use this workflow for releases spanning:
 
@@ -80,7 +85,7 @@ changes.
 Recommended shape:
 
 ```bash
-REPO=/Users/.../lingtai
+REPO=<your-lingtai-checkout>
 BR=release-vX.Y.Z-YYYYMMDD
 WT="$REPO/.worktrees/$BR"
 git -C "$REPO" fetch origin main --tags --prune
@@ -225,6 +230,67 @@ Report to the maintainer with:
 - tests/builds run;
 - known caveats/flaky tests and reruns;
 - website blog status (drafted / previewed / published / intentionally deferred).
+
+## 6.5 Shareable HTML release log (required for every public release)
+
+Distinct from the website blog (§7): every public LingTai release must also
+produce a polished, self-contained **HTML release log** before the final human
+report. This applies to all public release surfaces — the TUI/Portal Homebrew
+release from the `lingtai` repo, the kernel `lingtai` package on PyPI, and
+first-party MCP/addon packages. Treat the HTML file as the canonical
+external-facing changelog artifact for the release: ready for a maintainer to
+send to users, investors, or collaborators without extra context from the agent
+transcript.
+
+At minimum, the HTML release log must include:
+
+- **Executive summary:** one concise paragraph saying what shipped and why it
+  matters.
+- **Release metadata:** repo, package/binary name, version, tag, release branch
+  or PR, main/release commit, release date/time, and publisher/operator.
+- **What changed:** grouped bullets for user-visible, developer-facing, and
+  docs/process changes.
+- **Validation:** tests, linters, build checks, clean-install checks,
+  Homebrew/PyPI/GitHub verification, and any intentionally skipped noisy suites.
+- **Artifacts:** links plus hashes/sizes when applicable (PyPI wheel/sdist,
+  GitHub release tarball checksum, Homebrew formula commit, downloadable assets).
+- **Operator notes and risks:** known caveats, propagation delays, rollback/retry
+  notes, compatibility warnings, or non-blocking follow-up work.
+- **Next steps:** the exact remaining user/maintainer actions, or an explicit
+  “none” if the release is complete.
+
+Format rules:
+
+- **Self-contained:** inline CSS, no remote fonts/scripts/assets, no dependency
+  on local paths.
+- **Shareable:** write for an external reader, not an agent; no secrets, no raw
+  private paths (public repo paths are fine), no internal message IDs.
+- **Verifiable:** every version/tag/hash/test count must come from commands run
+  during the release.
+- Save under the releasing repo's `reports/` directory with a descriptive name,
+  e.g. `reports/lingtai-0.10.8-release-log.html`.
+- Use `../release-html-log-template.html` as the starter skeleton when you do not
+  already have a stronger release-specific design.
+
+Before announcing completion, validate the log itself:
+
+```bash
+python - <<'PY'
+from html.parser import HTMLParser
+from pathlib import Path
+path = Path('reports/<release-log>.html')
+data = path.read_text(encoding='utf-8')
+data.encode('utf-8')
+class Parser(HTMLParser):
+    pass
+Parser().feed(data)
+print('bytes:', path.stat().st_size)
+print('control chars:', sum(1 for c in data if ord(c) < 32 and c not in '\n\r\t'))
+PY
+```
+
+Send the HTML release log to the maintainer on the same channel as the release
+request, then include its path and validation result in the final release report.
 
 ## 7. Website release log / blog
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
@@ -50,6 +50,6 @@ blog must land first.
 - final public-surface verification and the maintainer report;
 - the **required shareable HTML release log** (per-release, self-contained) and
   its validation, plus `../release-html-log-template.html`;
-- the **website release blog** and its reusable `assets/release-blog-template.md`.
+- the **website release blog** and its reusable `../release-workflow/assets/release-blog-template.md`.
 
 Start there for any real publish operation.

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
@@ -1,374 +1,55 @@
 ---
 name: dev-guide-releasing
 description: >
-  Nested lingtai-dev-guide reference for release work: required HTML release logs, TUI/portal tagging and Homebrew tap updates, kernel clean-worktree releases, PyPI upload, verification, and post-release hygiene.
-version: 1.0.0
+  Compact lingtai-dev-guide release overview: when you are doing a release, the maintainer-authorization boundary, the version scheme, and a pointer to release-workflow for the full TUI/Portal + kernel publishing checklist, GitHub/PyPI/Homebrew steps, the required HTML release log, and the website release blog.
+version: 2.0.0
 ---
 
-# Release Process
+# Releasing — Overview
 
+Nested lingtai-dev-guide reference. Read this after the top-level router sends you
+here. This page is the compact entry point; the full procedure lives in
+`../release-workflow/SKILL.md`.
 
-Nested lingtai-dev-guide reference. Read this after the top-level router sends you here.
+## When this applies
 
-> For consequential paired TUI/Portal + kernel releases, website release-log/blog work, or any release train involving GitHub/PyPI/Homebrew plus public website copy, read `reference/release-workflow/SKILL.md` after this compact procedure. It owns the full checklist and reusable release blog template.
+You are cutting or publishing a LingTai release across one or more of:
 
-## Shareable HTML release log (required for every public release)
+- TUI/Portal repo: `Lingtai-AI/lingtai` (tags, GitHub release, Homebrew tap)
+- Kernel repo: `Lingtai-AI/lingtai-kernel` (PyPI package `lingtai`)
+- Optional first-party addon repos (e.g. `Lingtai-AI/lingtai-telegram`)
+- Website/release-log repo: `lingtai-web`
 
-Every public LingTai release must produce a polished, self-contained HTML release log before the final human report. This applies to all public release surfaces: the TUI/portal Homebrew release from the `lingtai` repo, the kernel `lingtai` package on PyPI, and first-party MCP/addon packages. Treat the HTML file as the canonical external-facing changelog artifact for the release: it should be ready for Jason or another maintainer to send to users, investors, or collaborators without needing extra context from the agent transcript.
+## Boundary: a checklist is not permission
 
-Use the recent `lingtai 0.10.8` PyPI log as the model. At minimum, the HTML release log must include:
-
-- **Executive summary:** one concise paragraph saying what shipped and why it matters.
-- **Release metadata:** repo, package/binary name, version, tag, release branch or PR, main/release commit, release date/time, and publisher/operator.
-- **What changed:** grouped bullets for the user-visible changes, developer-facing changes, and docs/process changes included in the release.
-- **Validation:** tests, linters, build checks, clean-install checks, Homebrew/PyPI/GitHub verification, and any intentionally skipped noisy suites.
-- **Artifacts:** links plus hashes/sizes when applicable (PyPI wheel/sdist, GitHub release tarball checksum, Homebrew formula commit, downloadable assets).
-- **Operator notes and risks:** known caveats, propagation delays, rollback/retry notes, compatibility warnings, or follow-up work that should not block the release.
-- **Next steps:** the exact user/maintainer actions that remain, or an explicit “none” if the release is complete.
-
-Format rules:
-
-- Keep it **self-contained**: inline CSS, no remote fonts, scripts, or assets, and no dependency on local paths.
-- Keep it **shareable**: write for an external reader, not for an agent; do not include secrets, raw private paths unless they are public repo paths, or internal message IDs.
-- Keep it **verifiable**: every version/tag/hash/test count in the report must come from commands run during the release.
-- Save the file under the releasing repo's `reports/` directory with a descriptive name, for example `reports/lingtai-0.10.8-release-log.html`.
-- Use `../release-html-log-template.html` as the starter skeleton when you do not already have a stronger release-specific design.
-
-Before announcing completion, validate the log itself:
-
-```bash
-python - <<'PY'
-from html.parser import HTMLParser
-from pathlib import Path
-path = Path('reports/<release-log>.html')
-data = path.read_text(encoding='utf-8')
-data.encode('utf-8')
-class Parser(HTMLParser):
-    pass
-Parser().feed(data)
-print('bytes:', path.stat().st_size)
-print('control chars:', sum(1 for c in data if ord(c) < 32 and c not in '\n\r\t'))
-PY
-```
-
-Attach or send the HTML release log to Jason on the same channel as the release request, then include its path and validation result in the final release report.
-
-## Releasing the TUI and Portal (`lingtai` repo)
-
-### 1. Commit and push all changes
-
-```bash
-cd ~/Documents/GitHub/lingtai
-git push origin main
-```
-
-### 2. Tag the release
-
-```bash
-git tag v0.X.Y
-git push origin v0.X.Y
-```
-
-### 3. Create the GitHub release
-
-```bash
-gh release create v0.X.Y --title "v0.X.Y" --notes "release notes here..."
-```
-
-No binary assets needed — Homebrew builds from source, Linux users build locally.
-
-### 4. Write release notes and the human-facing release log
-
-Every TUI/portal release should have two written artifacts:
-
-1. **GitHub Release notes** — short, public, and user-facing. These are pasted into `gh release create` with `--notes-file` or edited on the GitHub Release page. Use this structure:
-
-   ```markdown
-   ## Highlights
-
-   - User-visible feature or fix, phrased as an outcome.
-   - Another high-impact change.
-
-   ## Skills, docs, and packaged guidance
-
-   - Shipped skill/procedure/doc updates that change how agents or developers work.
-
-   ## Validation
-
-   Release candidate: `<full commit>` (`upstream/main`).
-
-   Checks run from a clean detached release worktree:
-
-   - `cd tui && go test ./...` ✅
-   - `cd tui && make clean && make build && ./bin/lingtai-tui version` ✅
-   - `cd portal/web && npm ci && npm run build` ✅
-   - `cd portal && go test ./...` ✅ after building `web/dist` for embedded assets
-   - `cd portal && make clean && make build` ✅
-
-   Known note: `<anything users/maintainers should know, or “none.”>`
-   ```
-
-2. **Human-facing HTML release log** — longer, reviewable, and shareable with the maintainer before publishing. Generate it under the agent/report workspace (for example `reports/lingtai-tui-v0.X.Y-release.html`) and send the absolute path to the human. Do **not** attach it to GitHub Release or commit it unless the human explicitly asks. Use one self-contained HTML file (inline CSS, no remote assets) with these sections:
-
-   - **Summary / 摘要** — whether the release is worth upgrading to, the scope boundary (TUI/portal vs kernel/PyPI), the tag/commit, and any caveats.
-   - **Features and fixes / 新功能与修复** — cards grouped by user-visible outcome, with PR/issue links and contributor attribution.
-   - **Contributors / 贡献者** — distinguish external/community contributors, maintainer/release work, automation (`github-actions[bot]`), and AI co-author trailers. Do not count bots or AI trailers as human contributors.
-   - **Validation / 发布验证** — exact commands run, success/failure, workflow/tap links if already published, and known caveats such as `npm audit` findings.
-   - **Commits / 提交明细** — compare range (`v0.X.(Y-1)..v0.X.Y` or `last-release..main`) with commit hash, author, and subject.
-
-Recommended data-gathering commands before writing either artifact:
-
-```bash
-gh release view v0.X.(Y-1) --repo Lingtai-AI/lingtai
-gh api repos/Lingtai-AI/lingtai/compare/v0.X.(Y-1)...main \
-  --jq '{ahead_by,total_commits,commits:[.commits[]|{sha:(.sha[0:7]),message:.commit.message,author:.commit.author.name,date:.commit.author.date}],files:[.files[]|{filename,status,additions,deletions}]}'
-gh pr view <PR> --repo Lingtai-AI/lingtai --json number,title,author,mergedAt,mergeCommit,url,body,files
-```
-
-### 5. Update the Homebrew tap
-
-```bash
-# Get the source tarball checksum
-curl -sL "https://github.com/Lingtai-AI/lingtai/archive/refs/tags/v0.X.Y.tar.gz" | shasum -a 256
-
-# Edit the formula
-cd $(brew --repository)/Library/Taps/lingtai-ai/homebrew-lingtai
-# In lingtai-tui.rb: update the url tag and sha256
-git add lingtai-tui.rb
-git commit -m "bump lingtai-tui to v0.X.Y"
-git push
-```
-
-### 6. Verify
-
-```bash
-brew update && brew upgrade lingtai-ai/lingtai/lingtai-tui
-lingtai-tui version  # should show v0.X.Y
-```
-
-### 7. Rebuild dev mode symlinks (if applicable)
-
-After a release, your dev-mode symlinks still point at the old binary. Rebuild both:
-
-```bash
-cd ~/Documents/GitHub/lingtai/tui && make build
-cd ~/Documents/GitHub/lingtai/portal && make build
-```
-
-## Releasing the kernel (`lingtai-kernel` repo)
-
-The kernel is published to PyPI as package `lingtai`. Do not reuse a version that already exists on PyPI; PyPI uploads are immutable. If the current `pyproject.toml` version is already published and there are new commits on `main`, bump to the next patch version first.
-
-### 1. Inspect current state
-
-```bash
-cd ~/Documents/GitHub/lingtai-kernel
-git status --short --branch
-git tag --sort=-v:refname | head
-python - <<'PY'
-import tomllib, pathlib
-obj = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
-print(obj['project']['name'], obj['project']['version'])
-PY
-python -m pip index versions lingtai
-```
-
-If `pip index` lags behind immediately after an upload, query PyPI JSON directly:
-
-```bash
-python - <<'PY'
-import json, urllib.request
-obj = json.load(urllib.request.urlopen('https://pypi.org/pypi/lingtai/json'))
-print('latest:', obj['info']['version'])
-print('files for 0.X.Y:', len(obj['releases'].get('0.X.Y', [])))
-PY
-```
-
-### 2. Use a clean release worktree
-
-Prefer a clean worktree so unrelated local files do not leak into the release. Avoid `git fetch --tags` if this checkout has historical tag divergence; fetching `origin main` is enough for a patch release from current main.
-
-```bash
-cd ~/Documents/GitHub/lingtai-kernel
-git fetch origin main
-rm -rf .worktrees/release-0.X.Y
-git worktree add -b release/0.X.Y .worktrees/release-0.X.Y origin/main
-cd .worktrees/release-0.X.Y
-```
-
-Bump `pyproject.toml`:
-
-```bash
-python - <<'PY'
-from pathlib import Path
-p = Path('pyproject.toml')
-s = p.read_text()
-p.write_text(s.replace('version = "0.X.(Y-1)"', 'version = "0.X.Y"', 1))
-PY
-git diff -- pyproject.toml
-```
-
-### 3. Run focused release checks
-
-At minimum, rerun the tests that cover the changes in the release plus metadata/build checks. For notification/manifest releases this looked like:
-
-```bash
-python -m ruff check \
-  src/lingtai_kernel/intrinsics/soul/inquiry.py \
-  tests/test_notification_sync.py \
-  tests/test_agent_preset_manifest.py
-pytest -q \
-  tests/test_agent_preset_manifest.py \
-  tests/test_notification_sync.py \
-  tests/test_layers_email.py::test_email_receive_notification \
-  tests/test_agent.py::test_mail_inbox_wiring -q
-```
-
-If you know the full suite is currently noisy/crashy, state that in the release report and use the focused suite that covers the release's touched behavior.
-
-### 4. Build clean artifacts
-
-Remove ignored build byproducts and `__pycache__` before the final build. Otherwise setuptools may warn about `__pycache__` and, in bad cases, include stale `.pyc` files as package data.
-
-```bash
-find src -type d -name __pycache__ -prune -exec rm -rf {} +
-rm -rf dist build *.egg-info src/*.egg-info
-python -m build
-python -m twine check dist/*
-```
-
-Confirm artifact metadata and that no pycache entries are packaged:
-
-```bash
-python - <<'PY'
-import pathlib, tarfile, zipfile
-for p in sorted(pathlib.Path('dist').iterdir()):
-    print('artifact', p.name, p.stat().st_size)
-    if p.suffix == '.whl':
-        with zipfile.ZipFile(p) as z:
-            names = z.namelist()
-            print('pycache_count', sum('__pycache__' in n for n in names))
-            meta = [n for n in names if n.endswith('METADATA')][0]
-            text = z.read(meta).decode()
-            print('\n'.join(line for line in text.splitlines() if line.startswith(('Name:', 'Version:'))))
-    elif p.name.endswith('.tar.gz'):
-        with tarfile.open(p) as t:
-            names = t.getnames()
-            print('pycache_count', sum('__pycache__' in n for n in names))
-            member = [m for m in t.getmembers() if m.name.endswith('PKG-INFO')][0]
-            text = t.extractfile(member).read().decode()
-            print('\n'.join(line for line in text.splitlines() if line.startswith(('Name:', 'Version:'))))
-PY
-```
-
-### 5. Commit, tag, and push
-
-Commit the version bump, push a release branch and tag, then fast-forward `main`. If `main` is checked out in another worktree, do the `main` fast-forward from that main worktree.
-
-```bash
-git add pyproject.toml
-git commit -m 'chore: bump version to 0.X.Y'
-git push -u origin release/0.X.Y
-git tag v0.X.Y
-git push origin v0.X.Y
-```
-
-Then, from the main worktree if needed:
-
-```bash
-cd ~/Documents/GitHub/lingtai-kernel
-git fetch origin main release/0.X.Y
-git checkout main
-git merge --ff-only release/0.X.Y
-git push origin main
-git ls-remote origin refs/heads/main refs/tags/v0.X.Y
-```
-
-### 6. Upload to PyPI
-
-Use the configured Twine credentials (usually `~/.pypirc`, never print secrets). Check the version is still absent, then upload:
-
-```bash
-python - <<'PY'
-import json, urllib.request
-obj = json.load(urllib.request.urlopen('https://pypi.org/pypi/lingtai/json'))
-print('latest:', obj['info']['version'])
-print('0.X.Y files:', len(obj['releases'].get('0.X.Y', [])))
-PY
-python -m twine upload dist/*
-```
-
-### 7. Verify the published package
-
-PyPI JSON usually updates before `pip index`, which can lag. Verify with JSON, then install from PyPI in a clean venv:
-
-```bash
-python - <<'PY'
-import json, time, urllib.request
-for i in range(12):
-    obj = json.load(urllib.request.urlopen('https://pypi.org/pypi/lingtai/json'))
-    files = obj['releases'].get('0.X.Y', [])
-    print('attempt', i + 1, 'latest', obj['info']['version'], 'files', len(files))
-    if files:
-        for f in files:
-            print(f['filename'], f['packagetype'], f['size'], f['upload_time_iso_8601'])
-        break
-    time.sleep(5)
-PY
-
-TMPVENV=$(mktemp -d)
-python -m venv "$TMPVENV/venv"
-"$TMPVENV/venv/bin/python" -m pip install --upgrade pip
-"$TMPVENV/venv/bin/python" -m pip install --no-cache-dir --no-deps lingtai==0.X.Y
-"$TMPVENV/venv/bin/python" - <<'PY'
-import importlib.metadata as md
-import lingtai, lingtai_kernel
-print('dist version:', md.version('lingtai'))
-print('lingtai:', lingtai.__file__)
-print('lingtai_kernel:', lingtai_kernel.__file__)
-PY
-rm -rf "$TMPVENV"
-```
-
-### 8. Report and local hygiene
-
-Report: version, PyPI URL, tag/main commit, tests/checks, artifact sizes, clean-venv install result, and any known caveats. Pull/update any local runtime checkout as needed so auto-upgraders do not clobber an editable install.
-
-```bash
-cd ~/Documents/GitHub/lingtai-kernel
-git pull --ff-only origin main
-```
-
-Or use the project's CI/CD pipeline if configured.
-
-## Installing without Homebrew
-
-```bash
-git clone https://github.com/Lingtai-AI/lingtai.git
-cd lingtai/tui && make build
-# Binary at tui/bin/lingtai-tui
-
-cd ../portal && make build
-# Binary at portal/bin/lingtai-portal
-```
-
-Requires Go toolchain and Node.js (for portal web frontend).
+Pushing tags, creating GitHub releases, uploading to PyPI, committing to the
+Homebrew tap, and deploying website copy are external side effects. **Proceed
+only after explicit maintainer authorization.** If Jason says “直接 release / 先发 /
+publish it” (or equivalent), do the release and send short progress updates
+during long gates. Never print or share secrets/credentials. Do not let the
+website release log block an authorized software release unless Jason says the
+blog must land first.
 
 ## Version scheme
 
-- **TUI/portal:** Semantic versioning (`v0.X.Y`). Tags on the `lingtai` repo.
-- **Kernel:** Semantic versioning. Published to PyPI. Version in `pyproject.toml`.
-- **Migration versions:** Integer counter in `meta.json`. Separate for per-project (TUI+portal shared) and per-machine (global migrations).
+- **TUI/Portal:** semantic versioning (`vX.Y.Z`); tags on the `lingtai` repo.
+  Homebrew builds from source — no binary assets needed.
+- **Kernel:** semantic versioning; published to PyPI as `lingtai`; version in
+  `pyproject.toml`. PyPI uploads are immutable — never reuse a published version.
+- **Migration versions:** integer counter in `meta.json`, tracked separately for
+  per-project (TUI+portal shared) and per-machine (global) migrations.
 
-## Post-release checklist
+## Go to the full checklist
 
-- [ ] Tag pushed to `lingtai` repo
-- [ ] GitHub release created
-- [ ] Homebrew tap updated
-- [ ] `brew upgrade` verified
-- [ ] Kernel version bumped, tag pushed, and main fast-forwarded
-- [ ] Kernel artifacts built cleanly and `twine check` passed
-- [ ] Kernel published to PyPI (if kernel changed)
-- [ ] Clean venv can install the new PyPI version
-- [ ] Dev-mode symlinks rebuilt
-- [ ] Kernel repo pulled on dev machine
+`../release-workflow/SKILL.md` owns the complete, command-level procedure:
+
+- establishing scope and candidate heads;
+- clean release worktrees;
+- TUI/Portal and kernel validation gates;
+- GitHub releases, PyPI (`twine`) upload, and Homebrew tap update;
+- final public-surface verification and the maintainer report;
+- the **required shareable HTML release log** (per-release, self-contained) and
+  its validation, plus `../release-html-log-template.html`;
+- the **website release blog** and its reusable `assets/release-blog-template.md`.
+
+Start there for any real publish operation.


### PR DESCRIPTION
## Summary

- trim `dev-guide-releasing` into a compact release overview and authorization/version boundary
- keep the full command-level publishing checklist in `dev-guide-release-workflow`, with a back-link to the overview
- move the unique shareable HTML release-log requirement into the full release workflow and refresh the dev-guide router wording

## Why

This is the TUI-side part of Jason's requested systematic skill-file cleanup. The audit found the skill system is generally healthy, but `releasing` and `release-workflow` duplicated large parts of the same publishing procedure. This PR keeps progressive disclosure cleaner: start with the overview, then drill into the full workflow for real publish operations.

## Validation

- `git diff --check`
- `(cd tui && go test ./internal/preset/... ./internal/tui/...)`
- privacy/path scan across the changed dev-guide files for private paths/contact IDs → empty
