### PR TITLE
feat(preset): add NVIDIA NIM template (free OpenAI-compatible catalog)

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -239,6 +239,7 @@
   "setup.provider_minimax": "MiniMax (Recommended)",
   "setup.provider_zhipu": "Zhipu GLM Coding Plan",
   "setup.provider_deepseek": "DeepSeek V4 (1M context, tool calls)",
+  "setup.provider_nvidia": "NVIDIA NIM (free OpenAI-compatible catalog, tool calls)",
   "setup.provider_openrouter": "OpenRouter (gateway to many models)",
   "setup.provider_codex": "OpenAI Codex (ChatGPT OAuth)",
   "setup.provider_custom": "Custom",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -234,6 +234,7 @@
   "setup.provider_minimax": "MiniMax（荐）",
   "setup.provider_zhipu": "智谱 GLM 编程套餐",
   "setup.provider_deepseek": "DeepSeek V4（百万之文，能唤具）",
+  "setup.provider_nvidia": "NVIDIA NIM（免资之库，兼容 OpenAI，能唤具）",
   "setup.provider_openrouter": "OpenRouter（众模型之关）",
   "setup.provider_codex": "OpenAI Codex（ChatGPT 帐登）",
   "setup.provider_custom": "自设",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -234,6 +234,7 @@
   "setup.provider_minimax": "MiniMax（推荐）",
   "setup.provider_zhipu": "智谱 GLM 编程套餐",
   "setup.provider_deepseek": "DeepSeek V4（1M 上下文，支持工具调用）",
+  "setup.provider_nvidia": "NVIDIA NIM（免费 OpenAI 兼容模型库，支持工具调用）",
   "setup.provider_openrouter": "OpenRouter（多模型聚合网关）",
   "setup.provider_codex": "OpenAI Codex（ChatGPT 账号登录）",
   "setup.provider_custom": "自定义",

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -572,6 +572,8 @@ func DeriveLedgerProvider(endpoint, model string) string {
 		return "gemini"
 	case strings.Contains(ep, "openrouter.ai"):
 		return "openrouter"
+	case strings.Contains(ep, "api.nvidia.com"):
+		return "nvidia"
 	case ep != "":
 		// Recognized URL but not in our table — surface the host so the
 		// user can still see the breakdown without a code change.

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -215,7 +215,7 @@ func List() ([]Preset, error) {
 	})
 	templateOrder := map[string]int{
 		"minimax": 0, "zhipu": 1, "mimo": 2, "deepseek": 3,
-		"kimi": 4, "openrouter": 5, "codex": 6, "custom": 7,
+		"kimi": 4, "nvidia": 5, "openrouter": 6, "codex": 7, "custom": 8,
 	}
 	sort.Slice(templates, func(i, j int) bool {
 		return templateOrder[templates[i].Name] < templateOrder[templates[j].Name]
@@ -451,6 +451,7 @@ func BuiltinPresets() []Preset {
 		deepseekPreset(),
 		geminiPreset(),
 		kimiPreset(),
+		nvidiaPreset(),
 		openrouterPreset(),
 		codexPreset(),
 		customPreset(),
@@ -468,6 +469,7 @@ var builtinNames = map[string]bool{
 	"deepseek":    true,
 	"gemini":      true,
 	"kimi":        true,
+	"nvidia":      true,
 	"openrouter":  true,
 	"codex":       true,
 	"codex_oauth": true,
@@ -899,6 +901,36 @@ func kimiPreset() Preset {
 			// Kimi Code is text-only — no media generation. For audio
 			// analysis use the `listen` skill; for media creation register
 			// the MiniMax-Media MCP server via the `mcp-manual` skill.
+			"capabilities": map[string]interface{}{
+				"web_search": map[string]interface{}{"provider": "duckduckgo"},
+				"skills":     skillsDefault(),
+			},
+		},
+	}
+}
+
+func nvidiaPreset() Preset {
+	// NVIDIA NIM / NVIDIA API Catalog (build.nvidia.com) — an
+	// OpenAI-compatible /chat/completions gateway hosting a large catalog
+	// of open-weight models (Llama, Qwen, Kimi, GPT-OSS, Nemotron, ...) at
+	// no per-token cost on the free developer tier. Default model is
+	// Llama 3.3 70B Instruct; users clone this preset to switch to any
+	// other catalog ID (e.g. qwen/qwen3-coder-480b-a35b-instruct,
+	// moonshotai/kimi-k2-thinking, openai/gpt-oss-120b). Provider is the
+	// generic "nvidia" string routed through the kernel's OpenAI-compatible
+	// client via api_compat=openai + the explicit base_url below.
+	return Preset{
+		Name:        "nvidia",
+		Description: PresetDescription{Summary: "NVIDIA NIM — free OpenAI-compatible catalog (Llama, Qwen, Kimi, GPT-OSS, ...), tool calls"},
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{
+				"provider": "nvidia", "model": "meta/llama-3.3-70b-instruct",
+				"api_key": nil, "api_key_env": "NVIDIA_API_KEY",
+				"base_url": "https://integrate.api.nvidia.com/v1", "api_compat": "openai",
+			},
+			// NVIDIA NIM is a text /chat/completions gateway — no media
+			// generation. For audio analysis use the `listen` skill; for
+			// media creation register a provider's MCP server via `mcp-manual`.
 			"capabilities": map[string]interface{}{
 				"web_search": map[string]interface{}{"provider": "duckduckgo"},
 				"skills":     skillsDefault(),

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -54,8 +54,8 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 			t.Fatalf("RefreshTemplates() error: %v", err)
 		}
 		presets, _ := List()
-		if len(presets) != 9 {
-			t.Fatalf("expected 9 presets, got %d", len(presets))
+		if len(presets) != 10 {
+			t.Fatalf("expected 10 presets, got %d", len(presets))
 		}
 		names := map[string]bool{}
 		for _, p := range presets {
@@ -64,7 +64,7 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 				t.Errorf("preset %q: Source = %v, want SourceTemplate", p.Name, p.Source)
 			}
 		}
-		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "kimi", "openrouter", "codex", "custom"} {
+		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "nvidia", "openrouter", "codex", "custom"} {
 			if !names[want] {
 				t.Errorf("missing preset %q", want)
 			}

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -571,7 +571,7 @@ func classifyWire(provider, apiCompat string) wireProtocol {
 	switch provider {
 	case "anthropic", "minimax":
 		return wireAnthropic
-	case "openai", "openrouter", "deepseek", "kimi", "mimo", "zhipu", "codex":
+	case "openai", "openrouter", "deepseek", "kimi", "mimo", "zhipu", "codex", "nvidia":
 		return wireOpenAI
 	case "custom":
 		switch apiCompat {

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -936,7 +936,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feProvider:
 		// Order matches the builtin presets (preset.go BuiltinPresets).
 		// Keep this in sync when adding a new provider/builtin.
-		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "openrouter", "codex", "custom"}
+		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "codex", "custom"}
 		newProvider := cycleString(opts, m.fieldString(f), dir)
 		m.llmMap()["provider"] = newProvider
 		// Reset model to the new provider's first canonical entry when the

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -131,6 +131,19 @@ var providerModels = map[string][]string{
 	"zhipu":    {"GLM-5.2", "GLM-5.1", "GLM-5-Turbo", "GLM-4.7", "GLM-4.5-Air"},
 	"mimo":     {"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-flash"},
 	"deepseek": {"deepseek-v4-flash", "deepseek-v4-pro"},
+	// NVIDIA NIM catalog IDs (build.nvidia.com) served on the free tier.
+	// Default flagship first; the rest are popular open-weight options.
+	// Users can also free-text any other catalog ID on this row.
+	"nvidia": {
+		"meta/llama-3.3-70b-instruct",
+		"meta/llama-3.1-70b-instruct",
+		"qwen/qwen3-coder-480b-a35b-instruct",
+		"moonshotai/kimi-k2-thinking",
+		"openai/gpt-oss-120b",
+		"nvidia/llama-3.1-nemotron-ultra-253b-v1",
+		"mistralai/mistral-nemotron",
+		"microsoft/phi-4-mini-instruct",
+	},
 	// Codex: ChatGPT-OAuth-only models served by chatgpt.com/backend-api/codex.
 	// gpt-5.5 is OAuth-exclusive (not available via API key); see SKILL.md
 	// next to this file for the canonical source list and why each one is

--- a/tui/internal/tui/setup.go
+++ b/tui/internal/tui/setup.go
@@ -34,6 +34,7 @@ var providers = []struct {
 	{"minimax", "setup.provider_minimax", "MINIMAX_API_KEY"},
 	{"zhipu", "setup.provider_zhipu", "ZHIPU_API_KEY"},
 	{"deepseek", "setup.provider_deepseek", "DEEPSEEK_API_KEY"},
+	{"nvidia", "setup.provider_nvidia", "NVIDIA_API_KEY"},
 	{"openrouter", "setup.provider_openrouter", "OPENROUTER_API_KEY"},
 	{"custom", "setup.provider_custom", "LLM_API_KEY"},
 }


### PR DESCRIPTION
## What

Adds an **`nvidia`** built-in preset targeting the [NVIDIA NIM / API Catalog](https://build.nvidia.com) (`https://integrate.api.nvidia.com/v1`), an OpenAI-compatible `/chat/completions` gateway that serves a large catalog of open-weight models (Llama, Qwen, Kimi, GPT-OSS, Nemotron, …) **free on the developer tier**.

## Why

NVIDIA's hosted models are free, so a one-click preset has broad appeal for users who want to drive LingTai without paying per token. The kernel already supports arbitrary OpenAI-compatible providers (mimo, kimi, deepseek, zhipu all do this via `api_compat: "openai"` + explicit `base_url`), so this slots into the existing path with no kernel change.

## Details

- **Default model:** `meta/llama-3.3-70b-instruct`. The preset editor offers a picker of popular catalog IDs (Qwen3-Coder-480B, Kimi-K2-Thinking, GPT-OSS-120B, Nemotron-Ultra-253B, …) and free-text for any other.
- **Key:** read from `NVIDIA_API_KEY`.
- **Wiring (OpenAI-compat path, `provider=nvidia` + `api_compat=openai`):**
  - Registered in `BuiltinPresets` / `builtinNames` / template ordering (`preset.go`)
  - Added to the first-run provider list (`setup.go`) + `setup.provider_nvidia` in all three locales (en/zh/wen)
  - Added to the doctor wire classifier (`doctor.go` → `wireOpenAI`)
  - Added a model picker in the preset editor (`preset_editor.go`)
  - Added an endpoint→provider case in the usage-ledger labeler (`agent.go`)

## Verification

- Live endpoint returns HTTP 200 with a real NVIDIA key (OpenAI-style `/chat/completions`).
- Generated `nvidia.json` matches the verified working config (base_url, model, `api_compat`, env var).
- `go build ./...` clean; `go test ./internal/preset/... ./internal/tui/... ./internal/fs/...` all pass (preset count test bumped 9→10, name list updated to include `nvidia` + the previously-omitted `gemini`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)