### PR TITLE
Verify agent heartbeat after refresh launch

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -270,7 +270,30 @@ func loadFromPath(path string) (Preset, error) {
 	if err := json.Unmarshal(data, &p); err != nil {
 		return Preset{}, fmt.Errorf("parse preset %s: %w", path, err)
 	}
+	p.NormalizeLegacyContextLimit()
 	return p, nil
+}
+
+// NormalizeLegacyContextLimit accepts the old saved-preset shape where
+// context_limit lived at manifest.context_limit. The canonical location is
+// manifest.llm.context_limit; if both locations are present, keep the
+// canonical llm value and drop the legacy root key.
+func (p *Preset) NormalizeLegacyContextLimit() {
+	if p == nil || p.Manifest == nil {
+		return
+	}
+	rootCtx, ok := p.Manifest["context_limit"]
+	if !ok {
+		return
+	}
+	delete(p.Manifest, "context_limit")
+	llm, _ := p.Manifest["llm"].(map[string]interface{})
+	if llm == nil {
+		return
+	}
+	if _, hasCanonical := llm["context_limit"]; !hasCanonical {
+		llm["context_limit"] = rootCtx
+	}
 }
 
 // validTiers mirrors the kernel-side TIER_VALUES in lingtai/presets.py.
@@ -280,6 +303,7 @@ var validTiers = map[string]bool{"1": true, "2": true, "3": true, "4": true, "5"
 // kernel's load_preset validation gauntlet so the editor refuses to save
 // anything the kernel will refuse to load. Empty slice = passes.
 func (p Preset) Validate() []error {
+	p.NormalizeLegacyContextLimit()
 	var errs []error
 	if p.Description.Summary == "" {
 		errs = append(errs, fmt.Errorf("description.summary must be non-empty"))

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -48,6 +48,66 @@ func TestSaveAndLoad_Roundtrip(t *testing.T) {
 	})
 }
 
+func TestLoadFromPath_NormalizesLegacyRootContextLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy.json")
+	data := map[string]interface{}{
+		"name":        "legacy",
+		"description": map[string]interface{}{"summary": "legacy"},
+		"manifest": map[string]interface{}{
+			"llm":           map[string]interface{}{"provider": "x", "model": "y"},
+			"capabilities":  map[string]interface{}{},
+			"context_limit": float64(300000),
+		},
+	}
+	raw, _ := json.Marshal(data)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write preset: %v", err)
+	}
+
+	p, err := loadFromPath(path)
+	if err != nil {
+		t.Fatalf("loadFromPath() error: %v", err)
+	}
+	if _, ok := p.Manifest["context_limit"]; ok {
+		t.Fatalf("legacy root context_limit still present: %#v", p.Manifest)
+	}
+	llm := p.Manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("manifest.llm.context_limit = %#v, want 300000", got)
+	}
+	if errs := p.Validate(); len(errs) != 0 {
+		t.Fatalf("Validate() errors after normalization: %v", errs)
+	}
+}
+
+func TestValidate_ConflictingLegacyRootContextLimitPreservesLLM(t *testing.T) {
+	p := Preset{
+		Name:        "conflict",
+		Description: PresetDescription{Summary: "conflict"},
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{
+				"provider":      "x",
+				"model":         "y",
+				"context_limit": float64(1000000),
+			},
+			"capabilities":  map[string]interface{}{},
+			"context_limit": float64(300000),
+		},
+	}
+
+	if errs := p.Validate(); len(errs) != 0 {
+		t.Fatalf("Validate() errors: %v", errs)
+	}
+	if _, ok := p.Manifest["context_limit"]; ok {
+		t.Fatalf("legacy root context_limit still present: %#v", p.Manifest)
+	}
+	llm := p.Manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(1000000) {
+		t.Fatalf("manifest.llm.context_limit = %#v, want canonical 1000000", got)
+	}
+}
+
 func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 	withTempPresets(t, func() {
 		if err := RefreshTemplates(); err != nil {

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1154,9 +1154,12 @@ func hardRefreshDirWithPreset(lingtaiCmd, dir, presetPath string) error {
 		// Don't refuse the relaunch — the user asked to refresh.
 		// Falling back to whatever active currently is.
 	}
-	_, err := process.ForceLaunchAgent(lingtaiCmd, dir)
+	cmd, err := process.ForceLaunchAgent(lingtaiCmd, dir)
 	os.Remove(suspendFile)
-	return err
+	if err != nil {
+		return err
+	}
+	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
 // reviveDir waits for .agent.lock to free (force-removing it if the holder
@@ -1176,8 +1179,25 @@ func reviveDir(lingtaiCmd, dir string) error {
 		// Process likely died without releasing lock — clean up
 		os.Remove(lockFile)
 	}
-	_, err := process.LaunchAgent(lingtaiCmd, dir)
-	return err
+	cmd, err := process.LaunchAgent(lingtaiCmd, dir)
+	if err != nil {
+		return err
+	}
+	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
+}
+
+func waitForLaunchHeartbeat(cmd *exec.Cmd, dir string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fs.IsAlive(dir, 3.0) {
+			return nil
+		}
+		if cmd != nil && !process.IsAgentRunning(dir) {
+			return fmt.Errorf("agent launch exited before writing a fresh heartbeat; see %s", filepath.Join(dir, "logs", "agent.log"))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("agent launch did not write a fresh heartbeat within %s; see %s", timeout, filepath.Join(dir, "logs", "agent.log"))
 }
 
 // firstLine returns the first line of err.Error(), trimmed of trailing

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -921,13 +921,16 @@ func hardRefreshDir(lingtaiCmd, dir string) error {
 	os.Remove(filepath.Join(dir, ".refresh.taken"))
 	os.Remove(suspendFile)
 	resetActivePresetToDefault(dir)
-	_, err := process.ForceLaunchAgent(lingtaiCmd, dir)
+	cmd, err := process.ForceLaunchAgent(lingtaiCmd, dir)
 	// Defensive: ForceLaunchAgent → launchAgentUnsafe calls fs.CleanSignals
 	// internally, but a fresh .suspend written by another path between our
 	// remove() above and the relaunch would put the new process to sleep.
 	// Removing again here is cheap and idempotent.
 	os.Remove(suspendFile)
-	return err
+	if err != nil {
+		return err
+	}
+	return waitForLaunchHeartbeat(cmd, dir, 10*time.Second)
 }
 
 // waitForLockClear polls for .agent.lock to free (force-removing it after


### PR DESCRIPTION
## Summary
- normalize legacy saved-preset `manifest.context_limit` into `manifest.llm.context_limit` when the TUI loads or validates presets
- keep canonical `manifest.llm.context_limit` when both locations are present and disagree
- make `/refresh` and `/cpr` wait for a fresh heartbeat after relaunch before reporting success; early exit or timeout now surfaces an error pointing at `logs/agent.log`

## Why
This addresses the TUI side of #348. The TUI should not reject/load old saved presets in a way that leaves an agent dead, and refresh/CPR should not appear successful until the relaunched process is actually heartbeating.

Companion kernel PR: https://github.com/Lingtai-AI/lingtai-kernel/pull/282

## Tests
- `go test ./internal/preset ./internal/tui`
- `go test ./...`