### PR TITLE
docs: add anatomy for beginner manual

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -15,10 +15,10 @@ The repo root holds two binary trees plus shared infrastructure. Each binary is 
 - **`install.sh`** — One-command installer (`curl … | bash`). Builds both binaries from source and installs them into Homebrew's `bin` directory. Auto-detects CN-restricted networks and falls back to mirrors for Go modules / `npm` / Go checksum DB.
 - **`scripts/`** — Auxiliary Python utilities (image-to-blocks, Telegram chat dumper, tool description dumper, file-rename helper). NOT the runtime — these are dev-only tools.
 - **`examples/`** — Reference config files (`init.jsonc`, `bash_policy.json`, `imap.jsonc`, `telegram.jsonc`) for users wiring up their own agents.
-- **`docs/`** — User and developer docs (specs, plans, daily change log, screenshots, known limitations).
+- **`docs/`** — User and developer docs (specs, plans, daily change log, screenshots, known limitations). Includes the human-facing capability map / beginner manual; see `docs/ANATOMY.md`.
 - **`prompt/`** — Localised prompt fragments shared across the TUI/portal.
 - **`assets/`** — Static images (logos, screenshots) used by README and docs.
-- **`README.md` / `README.zh.md` / `README.wen.md`** — Tri-lingual project README.
+- **`README.md` / `README.zh.md` / `README.wen.md`** — Tri-lingual project README. These link to the human-facing beginner manual and animated explainer in `docs/`.
 - **`RELEASING.md`** — Release process: tag, GitHub release, Homebrew tap bump.
 - **`CLAUDE.md`** — Repo-specific Claude Code instructions (build commands, gotchas, sibling repos).
 
@@ -102,6 +102,7 @@ This repo depends on `lingtai-kernel` only at runtime (the Python agent it launc
 
 ## Notes
 
+- **Human-facing anatomy:** `docs/beginner-work-manual.zh.md` and `docs/beginner-work-manual-stick-figure.zh.html` are the user-facing capability map. Any change that adds/removes/renames user-visible capabilities, slash commands, setup/install flows, channel/addon surfaces, memory/molt behavior, daemon/avatar behavior, or safety boundaries must check and update those docs alongside README/help assets.
 - **Binary naming.** The TUI binary is `lingtai-tui`, never `lingtai`. `lingtai` is the Python agent CLI inside the runtime venv (`~/.lingtai-tui/runtime/venv/bin/lingtai`). Build to `tui/bin/lingtai-tui`; never `tui/bin/lingtai`.
 - **Bubble Tea v2 paste delivery.** Bubble Tea v2 splits keys (`tea.KeyPressMsg`) from clipboard pastes (`tea.PasteMsg`). Any `Update` dispatcher gating on `case tea.KeyPressMsg:` must also forward `tea.PasteMsg` to whichever text widget is focused — otherwise paste silently drops. For embedded sub-models hosted inside another model (e.g. `PresetEditorModel` inside `FirstRunModel`), the host's outer `default:` branch must forward paste msgs into the sub-model. Trace top-down to find missing layers; the symptom is "typing works, paste does nothing."
 - **`textarea` vs `textinput`.** For any paste-friendly field (API keys, base URLs), use `textarea` even when the content is conceptually one line. `textinput` drops characters on multi-byte / clipboard pastes. Always apply `themedTextareaStyles()` from the `tui` package — bare `textarea.New()` ships dark default cursor/focus colors that render as a black smear against the warm theme.

--- a/docs/ANATOMY.md
+++ b/docs/ANATOMY.md
@@ -1,0 +1,48 @@
+# docs/
+
+Human- and developer-facing documentation for the Go-side LingTai repo.
+
+> **Maintenance:** see the `lingtai-tui-anatomy` skill. This file is part of the repo anatomy tree. Update it in the same PR when documentation entry points move, when a human-facing manual becomes authoritative for a capability surface, or when docs stop matching the product.
+
+## Components
+
+| Path | Role |
+|---|---|
+| `beginner-work-manual.zh.md` | **Human-facing anatomy / capability map** for first-time users. Explains what LingTai is, first-use flow, common slash commands, files/bash/web/vision/skills/knowledge/pad, MCP/addons, daemon/avatar, context pressure and molt, soul flow, safety/privacy, and troubleshooting. |
+| `beginner-work-manual-stick-figure.zh.html` | Standalone browser-friendly animated explainer for the same beginner manual. No remote assets; keep it consistent with the Markdown manual. |
+| `assets/` | Documentation screenshots and visual assets. |
+| `blog/` | Narrative product/dev blog posts. |
+| `daily/` | Daily notes / project logs. |
+| `plans/` and `superpowers/` | Historical design plans/specs. Treat as background unless a current README/ANATOMY cites them. |
+| `stars/` | GitHub stars trend data and rendering helper. |
+| `known-limitations.md`, `status.md`, `design*.md`, `graphify.md`, `i18n-vocab.md`, `tool-descriptions.md` | Topic documents that complement README and the binary anatomies. |
+
+## Connections
+
+- `README.md`, `README.zh.md`, and `README.wen.md` point first-time users to `beginner-work-manual.zh.md` and the animated HTML version.
+- TUI command/help truth lives in the TUI command registry and shipped help assets; the beginner manual summarizes it for humans and must not drift from those sources.
+- Install/upgrade truth lives in README, release notes, and TUI/doctor behavior; the beginner manual gives a friendly route and should defer to those sources for exact commands.
+- Addon/channel truth lives in the TUI `/mcp` surface and curated addon docs; the manual summarizes the concept and common channels.
+
+## Composition
+
+The documentation tree serves three audiences:
+
+1. **First-time humans:** README docs-by-goal → `beginner-work-manual.zh.md` → optional animated HTML.
+2. **Maintainers / coding agents:** repo-root `ANATOMY.md` → `tui/ANATOMY.md` / `portal/ANATOMY.md` / this file → cited code/docs.
+3. **Historical researchers:** plans, specs, blog, daily logs, and design notes.
+
+The beginner manual is intentionally not just a loose article: it is the human-facing counterpart to code anatomy. It maps the product surface into concepts a user can act on.
+
+## State
+
+- `beginner-work-manual.zh.md` and `beginner-work-manual-stick-figure.zh.html` were added by community PR `Lingtai-AI/lingtai#255` and linked from the three READMEs.
+- The animated HTML is checked in deliberately as long-lived documentation, unlike routine PR explainers under `reports/`.
+- The manual uses version-drift disclaimers; do not rely on those disclaimers as a substitute for updating it when the product surface changes.
+
+## Notes
+
+- **Update trigger:** when a PR changes a user-visible slash command, setup flow, install/upgrade path, `/mcp`/addon/channel behavior, daemon/avatar guidance, memory/molt behavior, soul-flow explanation, safety boundary, or troubleshooting path, check whether the beginner manual and animated HTML need edits.
+- **Keep Markdown and HTML aligned:** if one is updated substantively, update the other or leave a clear note explaining why the HTML remains a high-level explainer.
+- **No private paths or secrets:** docs may mention `.secrets/` and placeholders, but must not include real local paths, tokens, chat IDs, or account-specific values.
+- **Do not commit routine reports:** `reports/*.html` is local-only by default. Long-lived docs belong under `docs/` and should be represented here when they become maintenance obligations.


### PR DESCRIPTION
## Summary

- add `docs/ANATOMY.md` to make the beginner manual a maintained human-facing capability map
- update the repo-root `ANATOMY.md` to route `docs/` through that anatomy and call out the beginner manual / animated explainer as user-facing anatomy
- document update triggers so future changes to commands, setup/install flows, addon/channel behavior, daemon/avatar, memory/molt, soul flow, safety, or troubleshooting also check the beginner manual

## Validation

```bash
git diff --check origin/main...HEAD
```

