### PR TITLE
fix: migrate legacy agent init preset fields

### DIFF
--- a/portal/internal/migrate/ANATOMY.md
+++ b/portal/internal/migrate/ANATOMY.md
@@ -9,10 +9,10 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 ## Components
 
 ### Registry (`migrate.go`)
-- `CurrentVersion` (`migrate.go:11`) — `36`. Must match the TUI's `CurrentVersion` exactly; the cross-binary contract requires lockstep bumps.
+- `CurrentVersion` (`migrate.go:11`) — `38`. Must match the TUI's `CurrentVersion` exactly; the cross-binary contract requires lockstep bumps.
 - `metaFile` struct (`migrate.go:13-15`) — `{"version": N}` shape of `.lingtai/meta.json`.
 - `Migration` type (`migrate.go:18-22`) — version + name + function.
-- `migrations` slice (`migrate.go:25-61`) — the append-only ordered list of all 36 migrations. **Real** entries have a named migration function; **no-op stubs** use `func(_ string) error { return nil }`.
+- `migrations` slice (`migrate.go:25-61`) — the append-only ordered list of all 38 migrations. **Real** entries have a named migration function; **no-op stubs** use `func(_ string) error { return nil }`.
 
 ### Real migrations (touch shared on-disk state)
 - **m001** — `topology-to-portal` (`m001_topology.go:9-31`). Portal-only: moves `topology.jsonl` from `.tui-asset/` to `.portal/`.
@@ -28,9 +28,10 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 - **m030** — `preset-dir-split` — rewrites flat `presets/` paths to `templates/` or `saved/` subdirs (shared).
 - **m031** — `drop-legacy-intrinsic-capabilities` — drops `psyche`/`email` from `init.json` (shared).
 - **m035** — `remove-brief` (`m035_remove_brief.go:13`). Portal mirror of the TUI's brief-cleanup migration: deletes `system/brief.md` for each agent, drops `brief`/`brief_file` from `init.json`, and drops `brief` from `human/settings.json`. Touches shared on-disk state — either binary may be the first to open a post-secretary-removal project, so identical logic lives in both packages.
+- **m038** — `agent-init-context-preset-repair` (`m038_agent_init_context_preset_repair.go:43`). Shared repair for existing agent `init.json`: copies legacy root `manifest.context_limit` into `manifest.llm.context_limit` and rewrites stale/missing codex saved-preset refs to `codex-gpt5.5.json` when that replacement exists.
 
 ### No-op stubs (preserve version slots)
-m005 (`soul-inquiry-source`), m007 (`normalize-ledger`), m008 (`recipe-state`), m009 (`procedures`), m010 (`legacy-addons-warn`), m011 (`session-backfill`), m012 (`session-resort`), m013 (`agora-rename`), m014 (`skills-groups`), m016 (`rename-pad-codex-library`), m017 (`rename-preset-caps`), m018 (`library-split`), m019 (`procedures-english-only`), m020 (`pseudo-agent-subscriptions`), m021 (`library-paths`), m022 (`recipe-lang-suffix`), m023 (`recipe-state-rename`), m024 (`add-active-preset`), m025 (`preset-description-object`), m032 (`cleanup-codex-oauth`), m033 (`strip-codex-api-key-env`), m034 (`library-skills-caps`). m036 (`sqlite-log-backfill`). (m035 is real — listed above.)
+m005 (`soul-inquiry-source`), m007 (`normalize-ledger`), m008 (`recipe-state`), m009 (`procedures`), m010 (`legacy-addons-warn`), m011 (`session-backfill`), m012 (`session-resort`), m013 (`agora-rename`), m014 (`skills-groups`), m016 (`rename-pad-codex-library`), m017 (`rename-preset-caps`), m018 (`library-split`), m019 (`procedures-english-only`), m020 (`pseudo-agent-subscriptions`), m021 (`library-paths`), m022 (`recipe-lang-suffix`), m023 (`recipe-state-rename`), m024 (`add-active-preset`), m025 (`preset-description-object`), m032 (`cleanup-codex-oauth`), m033 (`strip-codex-api-key-env`), m034 (`library-skills-caps`). m036 (`sqlite-log-backfill`) and m037 (`preset-skills-paths`). (m035 and m038 are real — listed above.)
 
 All are `TUI-only` — they touch `.tui-asset/`, global preset files, the TUI's saved-preset directory, or TUI-side capability aliases. The portal doesn't care about these but must hold the version slot so `meta.json` version numbers match.
 

--- a/portal/internal/migrate/m038_agent_init_context_preset_repair.go
+++ b/portal/internal/migrate/m038_agent_init_context_preset_repair.go
@@ -1,0 +1,211 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// staleCodexRef is the legacy saved-preset ref that no longer resolves on
+// machines whose codex preset was renamed. legacyCodexReplacement is the file
+// that supersedes it when present.
+const (
+	staleCodexRef          = "~/.lingtai-tui/presets/saved/codex.json"
+	legacyCodexReplacement = "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+)
+
+// migrateAgentInitContextPresetRepair repairs already-created agent init.json
+// files so legacy agents stop dying in refresh/relaunch loops.
+//
+// Two independent defects are healed, both observed in the same incident:
+//
+//  1. Legacy root context limit. Older init.json carried the context window
+//     as manifest.context_limit at the manifest root, before the canonical
+//     home moved to manifest.llm.context_limit. An agent with the root value
+//     but no llm value refreshes into a relaunch-dead loop. When the root
+//     value is present and llm.context_limit is absent, copy it down. The
+//     root key is preserved for backward compatibility — this migration does
+//     not introduce a hard failure and does not strip it. When both exist and
+//     conflict, the canonical manifest.llm.context_limit wins and is never
+//     overwritten.
+//
+//  2. Stale saved-preset pointer. The incident agent's preset active/default/
+//     allowed pointed at ~/.lingtai-tui/presets/saved/codex.json, which had
+//     been renamed to codex-gpt5.5.json. When the stale ref is present, or
+//     active/default point at another missing preset, and the replacement file
+//     exists on disk, active/default are rewritten and the allowed list gains
+//     the replacement while dropping the stale entry.
+//     Unrelated allowed entries that resolve to existing files are preserved.
+//
+// Best-effort and idempotent: a single broken init.json logs to stderr and the
+// migration continues. Files are only rewritten when something actually
+// changed. Atomic temp+rename writes match the surrounding migration style.
+func migrateAgentInitContextPresetRepair(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		agentDir := filepath.Join(lingtaiDir, name)
+		initPath := filepath.Join(agentDir, "init.json")
+		data, err := os.ReadFile(initPath)
+		if err != nil {
+			continue // non-agent dir (library/asset) or unreadable — skip
+		}
+		var init map[string]interface{}
+		if err := json.Unmarshal(data, &init); err != nil {
+			fmt.Fprintf(os.Stderr, "m038: skipping %s — unparseable init.json: %v\n",
+				agentDir, err)
+			continue
+		}
+		manifest, ok := init["manifest"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		changed := repairManifestContextLimit(manifest)
+		if repairManifestPreset(manifest) {
+			changed = true
+		}
+		if !changed {
+			continue
+		}
+
+		if err := writePresetInit(initPath, init); err != nil {
+			fmt.Fprintf(os.Stderr, "m038: write %s: %v\n", agentDir, err)
+		}
+	}
+	return nil
+}
+
+// repairManifestContextLimit copies a legacy root manifest.context_limit into
+// manifest.llm.context_limit when the llm value is absent. The canonical llm
+// value is never overwritten. Returns true if the manifest was modified.
+func repairManifestContextLimit(manifest map[string]interface{}) bool {
+	root, hasRoot := manifest["context_limit"]
+	if !hasRoot {
+		return false
+	}
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		llm = map[string]interface{}{}
+		manifest["llm"] = llm
+	}
+	if _, hasLLM := llm["context_limit"]; hasLLM {
+		// Both present: canonical llm value wins, leave it untouched. Equal or
+		// conflicting, the result is the same — never overwrite llm.
+		return false
+	}
+	llm["context_limit"] = root
+	return true
+}
+
+// repairManifestPreset rewrites stale codex.json preset pointers to the
+// codex-gpt5.5.json replacement when that file exists. Returns true if the
+// manifest was modified.
+func repairManifestPreset(manifest map[string]interface{}) bool {
+	preset, ok := manifest["preset"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Only act when the replacement actually exists on disk; otherwise leave
+	// the pointers alone rather than fabricating a dead ref.
+	if !presetRefExists(legacyCodexReplacement) {
+		return false
+	}
+
+	changed := false
+	needsReplacementAllowed := false
+	for _, key := range []string{"active", "default"} {
+		if s, ok := preset[key].(string); ok && presetRefNeedsRepair(s) {
+			preset[key] = legacyCodexReplacement
+			changed = true
+			needsReplacementAllowed = true
+		}
+	}
+
+	if rawAllowed, ok := preset["allowed"].([]interface{}); ok {
+		var rebuilt []interface{}
+		seen := map[string]struct{}{}
+		appendUnique := func(s string) {
+			if _, dup := seen[s]; dup {
+				return
+			}
+			seen[s] = struct{}{}
+			rebuilt = append(rebuilt, s)
+		}
+		droppedStale := false
+		for _, e := range rawAllowed {
+			s, ok := e.(string)
+			if !ok {
+				rebuilt = append(rebuilt, e) // preserve non-string entries verbatim
+				continue
+			}
+			if refIsStaleCodex(s) {
+				droppedStale = true
+				continue // drop the stale codex.json pointer
+			}
+			appendUnique(s)
+		}
+		if droppedStale || needsReplacementAllowed {
+			// Ensure the existing replacement is authorized. Prepend it so it
+			// sits where the stale entry used to be (entry ordering is not
+			// semantically significant, but keeping the replacement visible is
+			// friendlier).
+			if _, present := seen[legacyCodexReplacement]; !present {
+				rebuilt = append([]interface{}{legacyCodexReplacement}, rebuilt...)
+			}
+			preset["allowed"] = rebuilt
+			changed = true
+		}
+	} else if needsReplacementAllowed {
+		preset["allowed"] = []interface{}{legacyCodexReplacement}
+		changed = true
+	}
+
+	return changed
+}
+
+// presetRefNeedsRepair reports whether a required active/default preset ref
+// should be rewritten to the known-good codex-gpt5.5 replacement. The explicit
+// stale codex ref is always repaired; other refs are repaired only when they do
+// not resolve to a file.
+func presetRefNeedsRepair(ref string) bool {
+	if refIsStaleCodex(ref) {
+		return true
+	}
+	return !presetRefExists(ref)
+}
+
+// refIsStaleCodex reports whether a preset ref points at the renamed
+// codex.json, comparing tilde and absolute forms equal.
+func refIsStaleCodex(ref string) bool {
+	return presetRefsEqual(ref, staleCodexRef)
+}
+
+// presetRefsEqual compares two preset refs for equality after tilde expansion,
+// so ~/-prefixed and absolute forms of the same path compare equal.
+func presetRefsEqual(a, b string) bool {
+	return expandTilde(a) == expandTilde(b)
+}
+
+// presetRefExists reports whether a preset ref resolves to an existing file.
+func presetRefExists(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	info, err := os.Stat(expandTilde(ref))
+	return err == nil && !info.IsDir()
+}

--- a/portal/internal/migrate/m038_agent_init_context_preset_repair_test.go
+++ b/portal/internal/migrate/m038_agent_init_context_preset_repair_test.go
@@ -1,0 +1,369 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeAgentInit writes an agent init.json under .lingtai/<name>/init.json.
+func writeAgentInit(t *testing.T, lingtaiDir, name, body string) string {
+	t.Helper()
+	dir := filepath.Join(lingtaiDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	p := filepath.Join(dir, "init.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func readManifest(t *testing.T, initPath string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", initPath, err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", initPath, err, data)
+	}
+	manifest, ok := m["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing in %s", initPath)
+	}
+	return manifest
+}
+
+func toStringSlice(t *testing.T, raw interface{}) []string {
+	t.Helper()
+	items, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("allowed is %T, want []interface{}", raw)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("allowed entry is %T, want string", item)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestM038_LegacyRootContextCopiedToLLM verifies the incident's core repair:
+// a legacy root manifest.context_limit with no manifest.llm.context_limit gets
+// the value copied into manifest.llm.context_limit.
+func TestM038_LegacyRootContextCopiedToLLM(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	// Root context_limit preserved for backward compatibility.
+	if got := manifest["context_limit"]; got != float64(300000) {
+		t.Fatalf("root context_limit = %#v, want preserved 300000", got)
+	}
+}
+
+// TestM038_ExistingLLMContextWinsOnConflict verifies that when both root and
+// llm context_limit exist but conflict, the canonical llm value is preserved
+// and never overwritten by the root value.
+
+func TestM038_LegacyRootContextCreatesMissingLLMBlock(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("llm block not created: %#v", manifest)
+	}
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+}
+
+func TestM038_ExistingLLMContextWinsOnConflict(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "bob", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y", "context_limit": 128000}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(128000) {
+		t.Fatalf("llm.context_limit = %#v, want canonical 128000 preserved", got)
+	}
+}
+
+// TestM038_StalePresetMigratedWhenReplacementExists verifies that stale
+// codex.json active/default/allowed pointers are rewritten to the existing
+// codex-gpt5.5.json replacement.
+func TestM038_StalePresetMigratedWhenReplacementExists(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp // pretend HOME for tilde resolution
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	// The replacement exists; the stale codex.json does NOT.
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "carol", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("active = %#v, want %q", got, want)
+	}
+	if got := preset["default"]; got != want {
+		t.Fatalf("default = %#v, want %q", got, want)
+	}
+	allowed := preset["allowed"].([]interface{})
+	if !reflect.DeepEqual(allowed, []interface{}{want}) {
+		t.Fatalf("allowed = %#v, want [%q]", allowed, want)
+	}
+}
+
+// TestM038_PreservesUnrelatedExistingAllowedEntries verifies the migration
+// keeps unrelated allowed entries that resolve to existing files, only
+// dropping the stale codex.json pointer.
+func TestM038_PreservesUnrelatedExistingAllowedEntries(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	templatesDir := filepath.Join(home, ".lingtai-tui", "presets", "templates")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(savedDir, "codex-gpt5.5.json"),
+		filepath.Join(templatesDir, "minimax.json"),
+	} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "dave", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/templates/minimax.json",
+      "allowed": [
+        "~/.lingtai-tui/presets/saved/codex.json",
+        "~/.lingtai-tui/presets/templates/minimax.json"
+      ]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	// active was stale -> rewritten to replacement
+	if got := preset["active"]; got != "~/.lingtai-tui/presets/saved/codex-gpt5.5.json" {
+		t.Fatalf("active = %#v, want replacement", got)
+	}
+	// default already pointed at an existing file -> untouched
+	if got := preset["default"]; got != "~/.lingtai-tui/presets/templates/minimax.json" {
+		t.Fatalf("default = %#v, want unchanged minimax", got)
+	}
+	allowed := preset["allowed"].([]interface{})
+	want := []interface{}{
+		"~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+		"~/.lingtai-tui/presets/templates/minimax.json",
+	}
+	if !reflect.DeepEqual(allowed, want) {
+		t.Fatalf("allowed = %#v, want %#v", allowed, want)
+	}
+}
+
+// TestM038_SkipsNonAgentDirs verifies that dotfile dirs, the human mailbox,
+// and dirs without init.json are not touched.
+func TestM038_SkipsNonAgentDirs(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+
+	// human dir with an init.json-shaped file should still be skipped by name.
+	humanInit := writeAgentInit(t, lingtaiDir, "human", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	// dotfile-prefixed dir
+	dotInit := writeAgentInit(t, lingtaiDir, ".portal", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	// library dir without init.json — nothing to do, must not error
+	libDir := filepath.Join(lingtaiDir, "library")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "note.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+
+	humanBefore, _ := os.ReadFile(humanInit)
+	dotBefore, _ := os.ReadFile(dotInit)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	humanAfter, _ := os.ReadFile(humanInit)
+	dotAfter, _ := os.ReadFile(dotInit)
+	if string(humanBefore) != string(humanAfter) {
+		t.Fatalf("human init.json mutated: %s", humanAfter)
+	}
+	if string(dotBefore) != string(dotAfter) {
+		t.Fatalf(".portal init.json mutated: %s", dotAfter)
+	}
+}
+
+// TestM038_Idempotent verifies a second run makes no further changes.
+func TestM038_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "erin", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 1: %v", err)
+	}
+	after1, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 1: %v", err)
+	}
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 2: %v", err)
+	}
+	after2, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 2: %v", err)
+	}
+	if string(after1) != string(after2) {
+		t.Fatalf("second run changed file:\n--- 1 ---\n%s\n--- 2 ---\n%s", after1, after2)
+	}
+}
+
+func TestM038_MissingActiveDefaultPresetGetsReplacementAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	replacement := filepath.Join(tmp, ".lingtai-tui", "presets", "saved", "codex-gpt5.5.json")
+	if err := os.MkdirAll(filepath.Dir(replacement), 0o755); err != nil {
+		t.Fatalf("mkdir replacement dir: %v", err)
+	}
+	if err := os.WriteFile(replacement, []byte(`{"name":"codex-gpt5.5"}`), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	other := filepath.Join(tmp, "other-existing.json")
+	if err := os.WriteFile(other, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write other preset: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/missing-active.json",
+      "default": "~/missing-default.json",
+      "allowed": ["`+other+`"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	if preset["active"] != legacyCodexReplacement || preset["default"] != legacyCodexReplacement {
+		t.Fatalf("active/default not repaired: %#v", preset)
+	}
+	allowed := toStringSlice(t, preset["allowed"])
+	expected := []string{legacyCodexReplacement, other}
+	if !reflect.DeepEqual(allowed, expected) {
+		t.Fatalf("allowed = %#v, want %#v", allowed, expected)
+	}
+}

--- a/portal/internal/migrate/migrate.go
+++ b/portal/internal/migrate/migrate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CurrentVersion is the latest migration version compiled into this binary.
-const CurrentVersion = 37
+const CurrentVersion = 38
 
 type metaFile struct {
 	Version int `json:"version"`
@@ -60,6 +60,7 @@ var migrations = []Migration{
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},                                           // shared: strips brief.md + brief_file/brief keys after secretary removal
 	{Version: 36, Name: "sqlite-log-backfill", Fn: func(_ string) error { return nil }},                   // TUI-only: optional command-line SQLite log backfill prompt/progress
 	{Version: 37, Name: "preset-skills-paths", Fn: func(_ string) error { return nil }},                   // TUI-only: patches saved preset skill path overrides
+	{Version: 38, Name: "agent-init-context-preset-repair", Fn: migrateAgentInitContextPresetRepair},      // shared: copies legacy root context_limit into llm + rewrites stale codex preset pointers in init.json
 }
 
 // StampCurrent writes meta.json at CurrentVersion without running any

--- a/tui/internal/migrate/ANATOMY.md
+++ b/tui/internal/migrate/ANATOMY.md
@@ -10,9 +10,9 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 
 | Symbol | Citation | Purpose |
 |--------|----------|---------|
-| `CurrentVersion` | `tui/internal/migrate/migrate.go:12` | latest version compiled into this binary (currently 36) |
+| `CurrentVersion` | `tui/internal/migrate/migrate.go:12` | latest version compiled into this binary (currently 38) |
 | `Migration` struct | `tui/internal/migrate/migrate.go:20` | `{Version int, Name string, Fn func(string) error}` |
-| `migrations` slice | `tui/internal/migrate/migrate.go:27` | ordered list of all m001..m036, append-only |
+| `migrations` slice | `tui/internal/migrate/migrate.go:27` | ordered list of all m001..m038, append-only |
 | `Run(lingtaiDir)` | `tui/internal/migrate/migrate.go:68` | reads `meta.json` → runs pending migrations → persists atomically |
 | `StampCurrent(lingtaiDir)` | `tui/internal/migrate/migrate.go:116` | stamps `CurrentVersion` without running migrations (fresh projects) |
 | `metaFile` struct | `tui/internal/migrate/migrate.go:14` | `{Version int, AddonCommentCleanupNotified bool}` |
@@ -26,6 +26,8 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 | m034 | `tui/internal/migrate/m034_library_skills_caps.go:23` | rename capability keys `codex`→`library` and `library`→`skills` |
 | m035 | `tui/internal/migrate/m035_remove_brief.go:13` | strip secretary-era brief plumbing: delete `system/brief.md`, drop `brief`/`brief_file` keys from each agent `init.json`, drop `brief` from `human/settings.json` |
 | m036 | `tui/internal/migrate/m036_sqlite_log_backfill.go:34` | optional command-line prompt/progress to backfill stopped agents' historical `events.jsonl` into derived `logs/log.sqlite`; safe to skip |
+| m037 | `tui/internal/migrate/m037_preset_skills_paths.go` | patch saved preset skill path overrides for the shared-library split |
+| m038 | `tui/internal/migrate/m038_agent_init_context_preset_repair.go` | repair existing agent `init.json`: copy legacy root `manifest.context_limit` into `manifest.llm.context_limit` and rewrite stale/missing codex preset refs to `codex-gpt5.5.json` when available |
 
 Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002 is a no-op `func(_ string) error { return nil }` — it preserves the version slot.
 
@@ -45,7 +47,7 @@ Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002
 ## State
 
 - **`<project>/.lingtai/meta.json`** — `{"version": <N>, "addon_comment_cleanup_notified": <bool>}`. Written atomically (temp+rename) on every migration run.
-- **Per-agent `init.json`** — mutated by several migrations (m017 rename caps, m024 add active preset, m026 path form, m027 strip media, m028 addons→MCP, m029 allowed list, m034 library/skills capability keys).
+- **Per-agent `init.json`** — mutated by several migrations (m017 rename caps, m024 add active preset, m026 path form, m027 strip media, m028 addons→MCP, m029 allowed list, m034 library/skills capability keys, m038 context/preset repair).
 
 ## Notes
 

--- a/tui/internal/migrate/m038_agent_init_context_preset_repair.go
+++ b/tui/internal/migrate/m038_agent_init_context_preset_repair.go
@@ -1,0 +1,211 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// staleCodexRef is the legacy saved-preset ref that no longer resolves on
+// machines whose codex preset was renamed. legacyCodexReplacement is the file
+// that supersedes it when present.
+const (
+	staleCodexRef          = "~/.lingtai-tui/presets/saved/codex.json"
+	legacyCodexReplacement = "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+)
+
+// migrateAgentInitContextPresetRepair repairs already-created agent init.json
+// files so legacy agents stop dying in refresh/relaunch loops.
+//
+// Two independent defects are healed, both observed in the same incident:
+//
+//  1. Legacy root context limit. Older init.json carried the context window
+//     as manifest.context_limit at the manifest root, before the canonical
+//     home moved to manifest.llm.context_limit. An agent with the root value
+//     but no llm value refreshes into a relaunch-dead loop. When the root
+//     value is present and llm.context_limit is absent, copy it down. The
+//     root key is preserved for backward compatibility — this migration does
+//     not introduce a hard failure and does not strip it. When both exist and
+//     conflict, the canonical manifest.llm.context_limit wins and is never
+//     overwritten.
+//
+//  2. Stale saved-preset pointer. The incident agent's preset active/default/
+//     allowed pointed at ~/.lingtai-tui/presets/saved/codex.json, which had
+//     been renamed to codex-gpt5.5.json. When the stale ref is present, or
+//     active/default point at another missing preset, and the replacement file
+//     exists on disk, active/default are rewritten and the allowed list gains
+//     the replacement while dropping the stale entry.
+//     Unrelated allowed entries that resolve to existing files are preserved.
+//
+// Best-effort and idempotent: a single broken init.json logs to stderr and the
+// migration continues. Files are only rewritten when something actually
+// changed. Atomic temp+rename writes match the surrounding migration style.
+func migrateAgentInitContextPresetRepair(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		agentDir := filepath.Join(lingtaiDir, name)
+		initPath := filepath.Join(agentDir, "init.json")
+		data, err := os.ReadFile(initPath)
+		if err != nil {
+			continue // non-agent dir (library/asset) or unreadable — skip
+		}
+		var init map[string]interface{}
+		if err := json.Unmarshal(data, &init); err != nil {
+			fmt.Fprintf(os.Stderr, "m038: skipping %s — unparseable init.json: %v\n",
+				agentDir, err)
+			continue
+		}
+		manifest, ok := init["manifest"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		changed := repairManifestContextLimit(manifest)
+		if repairManifestPreset(manifest) {
+			changed = true
+		}
+		if !changed {
+			continue
+		}
+
+		if err := writePresetInit(initPath, init); err != nil {
+			fmt.Fprintf(os.Stderr, "m038: write %s: %v\n", agentDir, err)
+		}
+	}
+	return nil
+}
+
+// repairManifestContextLimit copies a legacy root manifest.context_limit into
+// manifest.llm.context_limit when the llm value is absent. The canonical llm
+// value is never overwritten. Returns true if the manifest was modified.
+func repairManifestContextLimit(manifest map[string]interface{}) bool {
+	root, hasRoot := manifest["context_limit"]
+	if !hasRoot {
+		return false
+	}
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		llm = map[string]interface{}{}
+		manifest["llm"] = llm
+	}
+	if _, hasLLM := llm["context_limit"]; hasLLM {
+		// Both present: canonical llm value wins, leave it untouched. Equal or
+		// conflicting, the result is the same — never overwrite llm.
+		return false
+	}
+	llm["context_limit"] = root
+	return true
+}
+
+// repairManifestPreset rewrites stale codex.json preset pointers to the
+// codex-gpt5.5.json replacement when that file exists. Returns true if the
+// manifest was modified.
+func repairManifestPreset(manifest map[string]interface{}) bool {
+	preset, ok := manifest["preset"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Only act when the replacement actually exists on disk; otherwise leave
+	// the pointers alone rather than fabricating a dead ref.
+	if !presetRefExists(legacyCodexReplacement) {
+		return false
+	}
+
+	changed := false
+	needsReplacementAllowed := false
+	for _, key := range []string{"active", "default"} {
+		if s, ok := preset[key].(string); ok && presetRefNeedsRepair(s) {
+			preset[key] = legacyCodexReplacement
+			changed = true
+			needsReplacementAllowed = true
+		}
+	}
+
+	if rawAllowed, ok := preset["allowed"].([]interface{}); ok {
+		var rebuilt []interface{}
+		seen := map[string]struct{}{}
+		appendUnique := func(s string) {
+			if _, dup := seen[s]; dup {
+				return
+			}
+			seen[s] = struct{}{}
+			rebuilt = append(rebuilt, s)
+		}
+		droppedStale := false
+		for _, e := range rawAllowed {
+			s, ok := e.(string)
+			if !ok {
+				rebuilt = append(rebuilt, e) // preserve non-string entries verbatim
+				continue
+			}
+			if refIsStaleCodex(s) {
+				droppedStale = true
+				continue // drop the stale codex.json pointer
+			}
+			appendUnique(s)
+		}
+		if droppedStale || needsReplacementAllowed {
+			// Ensure the existing replacement is authorized. Prepend it so it
+			// sits where the stale entry used to be (entry ordering is not
+			// semantically significant, but keeping the replacement visible is
+			// friendlier).
+			if _, present := seen[legacyCodexReplacement]; !present {
+				rebuilt = append([]interface{}{legacyCodexReplacement}, rebuilt...)
+			}
+			preset["allowed"] = rebuilt
+			changed = true
+		}
+	} else if needsReplacementAllowed {
+		preset["allowed"] = []interface{}{legacyCodexReplacement}
+		changed = true
+	}
+
+	return changed
+}
+
+// presetRefNeedsRepair reports whether a required active/default preset ref
+// should be rewritten to the known-good codex-gpt5.5 replacement. The explicit
+// stale codex ref is always repaired; other refs are repaired only when they do
+// not resolve to a file.
+func presetRefNeedsRepair(ref string) bool {
+	if refIsStaleCodex(ref) {
+		return true
+	}
+	return !presetRefExists(ref)
+}
+
+// refIsStaleCodex reports whether a preset ref points at the renamed
+// codex.json, comparing tilde and absolute forms equal.
+func refIsStaleCodex(ref string) bool {
+	return presetRefsEqual(ref, staleCodexRef)
+}
+
+// presetRefsEqual compares two preset refs for equality after tilde expansion,
+// so ~/-prefixed and absolute forms of the same path compare equal.
+func presetRefsEqual(a, b string) bool {
+	return expandTilde(a) == expandTilde(b)
+}
+
+// presetRefExists reports whether a preset ref resolves to an existing file.
+func presetRefExists(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	info, err := os.Stat(expandTilde(ref))
+	return err == nil && !info.IsDir()
+}

--- a/tui/internal/migrate/m038_agent_init_context_preset_repair_test.go
+++ b/tui/internal/migrate/m038_agent_init_context_preset_repair_test.go
@@ -1,0 +1,369 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeAgentInit writes an agent init.json under .lingtai/<name>/init.json.
+func writeAgentInit(t *testing.T, lingtaiDir, name, body string) string {
+	t.Helper()
+	dir := filepath.Join(lingtaiDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	p := filepath.Join(dir, "init.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func readManifest(t *testing.T, initPath string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", initPath, err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", initPath, err, data)
+	}
+	manifest, ok := m["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing in %s", initPath)
+	}
+	return manifest
+}
+
+func toStringSlice(t *testing.T, raw interface{}) []string {
+	t.Helper()
+	items, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("allowed is %T, want []interface{}", raw)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("allowed entry is %T, want string", item)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestM038_LegacyRootContextCopiedToLLM verifies the incident's core repair:
+// a legacy root manifest.context_limit with no manifest.llm.context_limit gets
+// the value copied into manifest.llm.context_limit.
+func TestM038_LegacyRootContextCopiedToLLM(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	// Root context_limit preserved for backward compatibility.
+	if got := manifest["context_limit"]; got != float64(300000) {
+		t.Fatalf("root context_limit = %#v, want preserved 300000", got)
+	}
+}
+
+// TestM038_ExistingLLMContextWinsOnConflict verifies that when both root and
+// llm context_limit exist but conflict, the canonical llm value is preserved
+// and never overwritten by the root value.
+
+func TestM038_LegacyRootContextCreatesMissingLLMBlock(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("llm block not created: %#v", manifest)
+	}
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+}
+
+func TestM038_ExistingLLMContextWinsOnConflict(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "bob", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y", "context_limit": 128000}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(128000) {
+		t.Fatalf("llm.context_limit = %#v, want canonical 128000 preserved", got)
+	}
+}
+
+// TestM038_StalePresetMigratedWhenReplacementExists verifies that stale
+// codex.json active/default/allowed pointers are rewritten to the existing
+// codex-gpt5.5.json replacement.
+func TestM038_StalePresetMigratedWhenReplacementExists(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp // pretend HOME for tilde resolution
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	// The replacement exists; the stale codex.json does NOT.
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "carol", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("active = %#v, want %q", got, want)
+	}
+	if got := preset["default"]; got != want {
+		t.Fatalf("default = %#v, want %q", got, want)
+	}
+	allowed := preset["allowed"].([]interface{})
+	if !reflect.DeepEqual(allowed, []interface{}{want}) {
+		t.Fatalf("allowed = %#v, want [%q]", allowed, want)
+	}
+}
+
+// TestM038_PreservesUnrelatedExistingAllowedEntries verifies the migration
+// keeps unrelated allowed entries that resolve to existing files, only
+// dropping the stale codex.json pointer.
+func TestM038_PreservesUnrelatedExistingAllowedEntries(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	templatesDir := filepath.Join(home, ".lingtai-tui", "presets", "templates")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(savedDir, "codex-gpt5.5.json"),
+		filepath.Join(templatesDir, "minimax.json"),
+	} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "dave", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/templates/minimax.json",
+      "allowed": [
+        "~/.lingtai-tui/presets/saved/codex.json",
+        "~/.lingtai-tui/presets/templates/minimax.json"
+      ]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	// active was stale -> rewritten to replacement
+	if got := preset["active"]; got != "~/.lingtai-tui/presets/saved/codex-gpt5.5.json" {
+		t.Fatalf("active = %#v, want replacement", got)
+	}
+	// default already pointed at an existing file -> untouched
+	if got := preset["default"]; got != "~/.lingtai-tui/presets/templates/minimax.json" {
+		t.Fatalf("default = %#v, want unchanged minimax", got)
+	}
+	allowed := preset["allowed"].([]interface{})
+	want := []interface{}{
+		"~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+		"~/.lingtai-tui/presets/templates/minimax.json",
+	}
+	if !reflect.DeepEqual(allowed, want) {
+		t.Fatalf("allowed = %#v, want %#v", allowed, want)
+	}
+}
+
+// TestM038_SkipsNonAgentDirs verifies that dotfile dirs, the human mailbox,
+// and dirs without init.json are not touched.
+func TestM038_SkipsNonAgentDirs(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+
+	// human dir with an init.json-shaped file should still be skipped by name.
+	humanInit := writeAgentInit(t, lingtaiDir, "human", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	// dotfile-prefixed dir
+	dotInit := writeAgentInit(t, lingtaiDir, ".portal", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	// library dir without init.json — nothing to do, must not error
+	libDir := filepath.Join(lingtaiDir, "library")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "note.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+
+	humanBefore, _ := os.ReadFile(humanInit)
+	dotBefore, _ := os.ReadFile(dotInit)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	humanAfter, _ := os.ReadFile(humanInit)
+	dotAfter, _ := os.ReadFile(dotInit)
+	if string(humanBefore) != string(humanAfter) {
+		t.Fatalf("human init.json mutated: %s", humanAfter)
+	}
+	if string(dotBefore) != string(dotAfter) {
+		t.Fatalf(".portal init.json mutated: %s", dotAfter)
+	}
+}
+
+// TestM038_Idempotent verifies a second run makes no further changes.
+func TestM038_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "erin", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 1: %v", err)
+	}
+	after1, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 1: %v", err)
+	}
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 2: %v", err)
+	}
+	after2, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 2: %v", err)
+	}
+	if string(after1) != string(after2) {
+		t.Fatalf("second run changed file:\n--- 1 ---\n%s\n--- 2 ---\n%s", after1, after2)
+	}
+}
+
+func TestM038_MissingActiveDefaultPresetGetsReplacementAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	replacement := filepath.Join(tmp, ".lingtai-tui", "presets", "saved", "codex-gpt5.5.json")
+	if err := os.MkdirAll(filepath.Dir(replacement), 0o755); err != nil {
+		t.Fatalf("mkdir replacement dir: %v", err)
+	}
+	if err := os.WriteFile(replacement, []byte(`{"name":"codex-gpt5.5"}`), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	other := filepath.Join(tmp, "other-existing.json")
+	if err := os.WriteFile(other, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write other preset: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/missing-active.json",
+      "default": "~/missing-default.json",
+      "allowed": ["`+other+`"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	if preset["active"] != legacyCodexReplacement || preset["default"] != legacyCodexReplacement {
+		t.Fatalf("active/default not repaired: %#v", preset)
+	}
+	allowed := toStringSlice(t, preset["allowed"])
+	expected := []string{legacyCodexReplacement, other}
+	if !reflect.DeepEqual(allowed, expected) {
+		t.Fatalf("allowed = %#v, want %#v", allowed, expected)
+	}
+}

--- a/tui/internal/migrate/migrate.go
+++ b/tui/internal/migrate/migrate.go
@@ -9,7 +9,7 @@ import (
 
 // CurrentVersion is the latest migration version compiled into this binary.
 // IMPORTANT: when bumping, also bump portal/internal/migrate/migrate.go (see CLAUDE.md).
-const CurrentVersion = 37
+const CurrentVersion = 38
 
 type metaFile struct {
 	Version                     int  `json:"version"`
@@ -62,6 +62,7 @@ var migrations = []Migration{
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},
 	{Version: 36, Name: "sqlite-log-backfill", Fn: migrateSQLiteLogBackfill},
 	{Version: 37, Name: "preset-skills-paths", Fn: migratePresetSkillsPaths},
+	{Version: 38, Name: "agent-init-context-preset-repair", Fn: migrateAgentInitContextPresetRepair},
 }
 
 // Run executes all pending migrations on the given .lingtai/ directory.


### PR DESCRIPTION
## Summary
- add paired TUI/portal migration m038 to repair existing agent `init.json` files
- copy legacy root `manifest.context_limit` into canonical `manifest.llm.context_limit` without overwriting an existing llm value
- rewrite stale/missing active/default codex saved-preset refs to `~/.lingtai-tui/presets/saved/codex-gpt5.5.json` when that replacement exists, and keep `allowed` usable
- update migration anatomies for `CurrentVersion = 38`

## Why
A legacy Telegram bot agent (`marco-heliophysics` / `Marcovelliheliobot`) entered a refresh/relaunch-dead loop after refresh. Its existing `init.json` still had root `manifest.context_limit` and pointed active/default/allowed at the now-missing `~/.lingtai-tui/presets/saved/codex.json`. Manual repair was to add `manifest.llm.context_limit=300000`, migrate the preset refs to `codex-gpt5.5.json`, then CPR.

Earlier fixes made saved-preset loading tolerant and made CPR/refresh wait for heartbeat, but they do not migrate already-created agent `init.json` files. This migration prevents old agents from hitting the same loop on their next refresh.

## Validation
- `(cd tui && go test ./internal/migrate -count=1)`
- `(cd portal && go test ./internal/migrate -count=1)`
- `git diff --check`

## Notes
- This uses migration version 38 on current `origin/main`.
- Open PR #340 also touches migration version 38 and will need rebase/renumbering if this lands first.
- No secrets or bot tokens are included.
