### PR TITLE
Add claude-code provider to the TUI (Claude subscription via the claude CLI)

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -480,6 +480,7 @@
   "preset_editor.field_api_key": "API key",
   "preset_editor.api_key_unset": "(not set — paste here)",
   "preset_editor.api_key_codex_readonly": "OAuth credential — manage on the preset picker page.",
+  "preset_editor.api_key_claude_code_readonly": "No API key — the claude CLI handles auth. Run `claude` or `claude setup-token` to log in.",
   "preset_editor.field_edit": "edit",
   "preset_editor.field_streaming": "streaming",
   "preset_editor.field_karma": "karma",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -475,6 +475,7 @@
   "preset_editor.field_api_key": "API 钥",
   "preset_editor.api_key_unset": "（未设——粘于此）",
   "preset_editor.api_key_codex_readonly": "OAuth 凭据——于择预页管之。",
+  "preset_editor.api_key_claude_code_readonly": "无需密钥——claude 命令自理鉴权。运行 `claude` 或 `claude setup-token` 以登。",
   "preset_editor.field_edit": "编辑",
   "preset_editor.field_streaming": "流式输出",
   "preset_editor.field_karma": "因果",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -475,6 +475,7 @@
   "preset_editor.field_api_key": "API 密钥",
   "preset_editor.api_key_unset": "（未设置——在此粘贴）",
   "preset_editor.api_key_codex_readonly": "OAuth 凭据 — 于预设选择页管理。",
+  "preset_editor.api_key_claude_code_readonly": "无需 API 密钥 — 由 claude CLI 处理鉴权。运行 `claude` 或 `claude setup-token` 登录。",
   "preset_editor.field_edit": "编辑",
   "preset_editor.field_streaming": "流式输出",
   "preset_editor.field_karma": "因果",

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -215,7 +215,7 @@ func List() ([]Preset, error) {
 	})
 	templateOrder := map[string]int{
 		"minimax": 0, "zhipu": 1, "mimo": 2, "deepseek": 3,
-		"kimi": 4, "nvidia": 5, "openrouter": 6, "codex": 7, "custom": 8,
+		"kimi": 4, "nvidia": 5, "openrouter": 6, "codex": 7, "claude-code": 8, "custom": 9,
 	}
 	sort.Slice(templates, func(i, j int) bool {
 		return templateOrder[templates[i].Name] < templateOrder[templates[j].Name]
@@ -478,6 +478,7 @@ func BuiltinPresets() []Preset {
 		nvidiaPreset(),
 		openrouterPreset(),
 		codexPreset(),
+		claudeCodePreset(),
 		customPreset(),
 	}
 }
@@ -497,6 +498,7 @@ var builtinNames = map[string]bool{
 	"openrouter":  true,
 	"codex":       true,
 	"codex_oauth": true,
+	"claude-code": true,
 	"custom":      true,
 }
 
@@ -587,6 +589,13 @@ type AuthState struct {
 	// not import the tui package (import cycle), so this is computed by the
 	// caller and passed in.
 	CodexOAuthConfigured bool
+
+	// ClaudeCodeAvailable is true when the `claude` CLI is installed and on
+	// PATH. The claude-code provider authenticates through the CLI's own
+	// stored credentials, so availability of the binary is the credential
+	// signal we can check without importing the tui package. Computed by the
+	// caller (exec.LookPath) and passed in.
+	ClaudeCodeAvailable bool
 }
 
 // ResolveRefs expands and inspects a list of preset path strings. For
@@ -662,6 +671,12 @@ func resolveOneRef(ref string, existingKeys map[string]string, auth AuthState) R
 			// Codex declares no api_key_env by design — it uses ChatGPT
 			// OAuth (codex-auth.json). Valid only when OAuth is configured.
 			r.HasKey = auth.CodexOAuthConfigured
+		case provider == "claude-code":
+			// claude-code declares no api_key_env — the `claude` CLI owns
+			// auth (its stored subscription/OAuth credentials). Valid when
+			// the CLI is installed; runtime surfaces a login error if the
+			// user has not authenticated yet.
+			r.HasKey = auth.ClaudeCodeAvailable
 		default:
 			// No api_key_env and not codex: no configured credential and no
 			// OAuth, so the preset is not valid. (A preset that genuinely
@@ -1003,6 +1018,31 @@ func codexPreset() Preset {
 			"capabilities": map[string]interface{}{
 				"web_search": cx,
 				"vision":     cx,
+				"skills":     skillsDefault(),
+			},
+		},
+	}
+}
+
+func claudeCodePreset() Preset {
+	return Preset{
+		Name:        "claude-code",
+		Description: PresetDescription{Summary: "Claude subscription (Pro/Max) via the local claude CLI — no API key"},
+		Manifest: map[string]interface{}{
+			"llm": map[string]interface{}{
+				// Drives the local `claude` CLI as the agent's reasoning core
+				// on your Claude subscription. Auth is owned by the CLI itself
+				// (run `claude` or `claude setup-token` to log in) — there is no
+				// api_key_env and no base_url. Model is a claude alias
+				// (sonnet/opus/haiku); the list is curated in preset_editor.go.
+				"provider": "claude-code", "model": "sonnet",
+				"api_key": nil, "api_key_env": "",
+			},
+			// The claude-code brain handles text + tool calls only (no native
+			// vision/media through the CLI). Web search routes through the
+			// provider-agnostic duckduckgo backend, same as the API presets.
+			"capabilities": map[string]interface{}{
+				"web_search": map[string]interface{}{"provider": "duckduckgo"},
 				"skills":     skillsDefault(),
 			},
 		},

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -114,8 +114,8 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 			t.Fatalf("RefreshTemplates() error: %v", err)
 		}
 		presets, _ := List()
-		if len(presets) != 10 {
-			t.Fatalf("expected 10 presets, got %d", len(presets))
+		if len(presets) != 11 {
+			t.Fatalf("expected 11 presets, got %d", len(presets))
 		}
 		names := map[string]bool{}
 		for _, p := range presets {
@@ -124,7 +124,7 @@ func TestRefreshTemplates_CreatesAllTemplates(t *testing.T) {
 				t.Errorf("preset %q: Source = %v, want SourceTemplate", p.Name, p.Source)
 			}
 		}
-		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "nvidia", "openrouter", "codex", "custom"} {
+		for _, want := range []string{"minimax", "zhipu", "mimo", "deepseek", "gemini", "kimi", "nvidia", "openrouter", "codex", "claude-code", "custom"} {
 			if !names[want] {
 				t.Errorf("missing preset %q", want)
 			}
@@ -168,6 +168,7 @@ func writePresetFile(t *testing.T, dir, name, provider, apiKeyEnv string) string
 func TestResolveRefs_ValidityGuard(t *testing.T) {
 	dir := t.TempDir()
 	codexRef := writePresetFile(t, dir, "codex", "codex", "")
+	claudeCodeRef := writePresetFile(t, dir, "claude-code", "claude-code", "")
 	customRef := writePresetFile(t, dir, "custom", "custom", "")
 	keyedRef := writePresetFile(t, dir, "minimax", "minimax", "FOO_API_KEY")
 	missingRef := filepath.Join(dir, "nope.json")
@@ -185,6 +186,8 @@ func TestResolveRefs_ValidityGuard(t *testing.T) {
 	}{
 		{"codex no OAuth", codexRef, keysEmpty, AuthState{}, true, false},
 		{"codex with OAuth", codexRef, keysEmpty, AuthState{CodexOAuthConfigured: true}, true, true},
+		{"claude-code no CLI", claudeCodeRef, keysEmpty, AuthState{}, true, false},
+		{"claude-code with CLI", claudeCodeRef, keysEmpty, AuthState{ClaudeCodeAvailable: true}, true, true},
 		{"keyless non-codex is invalid", customRef, keysEmpty, AuthState{}, true, false},
 		{"keyed with key present", keyedRef, keysWith, AuthState{}, true, true},
 		{"keyed with key absent", keyedRef, keysEmpty, AuthState{}, true, false},

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -1560,6 +1560,16 @@ func codexOAuthConfigured(globalDir string) bool {
 	return json.Unmarshal(data, &tokens) == nil && tokens.RefreshToken != ""
 }
 
+// claudeCodeAvailable reports whether the `claude` CLI is installed and on
+// PATH. The claude-code provider authenticates through the CLI's own stored
+// subscription/OAuth credentials, so the presence of the binary is the
+// credential signal the TUI can check. Actual login state is verified by the
+// CLI at runtime (the kernel adapter surfaces a login error if not authed).
+func claudeCodeAvailable() bool {
+	_, err := exec.LookPath("claude")
+	return err == nil
+}
+
 // validateCodexAuthForAgents scans all agent directories under projectDir
 // for init.json files whose active/default preset is codex. If any exist
 // but ~/.lingtai-tui/codex-auth.json is missing or invalid, returns a

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -3959,6 +3959,10 @@ func (m FirstRunModel) presetNeedsKey(p preset.Preset) bool {
 	if m.getPresetProvider(p) == "codex" {
 		return false
 	}
+	// claude-code authenticates via the local `claude` CLI, not a pasted key.
+	if m.getPresetProvider(p) == "claude-code" {
+		return false
+	}
 	envName, ok := llmStringField(p, "api_key_env")
 	if !ok || envName == "" {
 		return false

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -150,6 +150,9 @@ var providerModels = map[string][]string{
 	// included or excluded (e.g. gpt-5.5-pro is ChatGPT-Pro-only and not
 	// served on the codex endpoint, so we omit it to avoid 4xx breakage).
 	"codex": {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
+	// claude-code: aliases passed to `claude --model` (resolve to the latest
+	// of each tier). Full ids (e.g. claude-sonnet-4-5) also work via free-text.
+	"claude-code": {"sonnet", "opus", "haiku"},
 }
 
 var codexServiceTierOptions = []string{"normal", "fast"}
@@ -598,6 +601,11 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 			m.saveErr = i18n.T("preset_editor.api_key_codex_readonly")
 			return *m, nil
 		}
+		// claude-code authenticates via the local `claude` CLI — no API key.
+		if asString(m.llmMap()["provider"]) == "claude-code" {
+			m.saveErr = i18n.T("preset_editor.api_key_claude_code_readonly")
+			return *m, nil
+		}
 		// Edit the live key buffer, not the env-var-name. We start
 		// blank rather than prefilling the existing value so the user
 		// can paste a new key without first deleting the masked
@@ -936,7 +944,7 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feProvider:
 		// Order matches the builtin presets (preset.go BuiltinPresets).
 		// Keep this in sync when adding a new provider/builtin.
-		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "codex", "custom"}
+		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "codex", "claude-code", "custom"}
 		newProvider := cycleString(opts, m.fieldString(f), dir)
 		m.llmMap()["provider"] = newProvider
 		// Reset model to the new provider's first canonical entry when the

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -535,10 +535,10 @@ func TestPresetEditorProviderSwitchPreservesServiceTier(t *testing.T) {
 	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset("fast"), "en", nil, "", false)
 	m.cursor = editorFieldOrderIndex(t, feProvider)
 
-	m.cycleFocused(+1) // codex -> custom in provider picker order.
+	m.cycleFocused(+1) // codex -> claude-code in provider picker order.
 	llm := m.working.Manifest["llm"].(map[string]interface{})
-	if got := llm["provider"]; got != "custom" {
-		t.Fatalf("provider after cycling from codex = %#v, want custom", got)
+	if got := llm["provider"]; got != "claude-code" {
+		t.Fatalf("provider after cycling from codex = %#v, want claude-code", got)
 	}
 	if got, _ := llm["service_tier"].(string); got != "fast" {
 		t.Fatalf("provider switch should preserve existing service_tier; got %#v", llm["service_tier"])

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -519,7 +519,10 @@ func (m PropsModel) renderLeft(maxW int) string {
 
 			if len(allowedRefs) > 0 {
 				cfg, _ := config.LoadConfig(m.globalDir)
-				auth := preset.AuthState{CodexOAuthConfigured: codexOAuthConfigured(m.globalDir)}
+				auth := preset.AuthState{
+					CodexOAuthConfigured: codexOAuthConfigured(m.globalDir),
+					ClaudeCodeAvailable:  claudeCodeAvailable(),
+				}
 				resolved := preset.ResolveRefsWithAuth(allowedRefs, cfg.Keys, auth)
 				lines = append(lines, "  "+labelStyle.Render(i18n.T("props.preset_allowed")+":"))
 				for _, rr := range resolved {


### PR DESCRIPTION
## Add `claude-code` provider to the TUI (Claude subscription via the `claude` CLI)

Surfaces the kernel's new `claude-code` provider in the TUI so an agent can run
on a Claude Pro/Max subscription through the local `claude` CLI — the Claude
analogue of the existing `codex` provider.

**Requires** the lingtai-kernel `claude-code` adapter PR: Lingtai-AI/lingtai-kernel#299

### Changes
- `internal/preset/preset.go` — `claudeCodePreset()` (provider `claude-code`,
  model `sonnet`, no `api_key_env`/`base_url`) in `BuiltinPresets` + `builtinNames`
  + the template ordering map. `AuthState.ClaudeCodeAvailable` + a resolve case so
  a claude-code preset is valid when the `claude` CLI is on PATH (auth is owned by
  the CLI's own subscription/OAuth credentials).
- `internal/tui/app.go` — `claudeCodeAvailable()` (exec.LookPath "claude"); wired
  into the AuthState built in `props.go`.
- `internal/tui/preset_editor.go` — claude-code in the provider cycle +
  `providerModels` (sonnet/opus/haiku) + api-key field read-only.
- `internal/tui/firstrun.go` — `presetNeedsKey` returns false for claude-code.
- `i18n/{en,zh,wen}.json` — `api_key_claude_code_readonly`.
- Tests: claude-code cases in the validity-guard + template-count tests; provider
  cycle order test updated.

No migration / no schema change — `RefreshTemplates()` ships the new template on
bootstrap. Portal is unaffected (no shared preset code; the frozen m030 mirror is
untouched). Login is just "is `claude` logged in?": the preset summary and editor
hint point users to `claude` / `claude setup-token`.

### Testing
- Full `go test ./...` for the TUI passes.
- `go build ./...` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
