### PR TITLE
fix: wait for headless agent readiness

### DIFF
--- a/docs/headless-runtime-contract.md
+++ b/docs/headless-runtime-contract.md
@@ -1,0 +1,55 @@
+# Headless Runtime Contract
+
+This document describes the public controller contract for `lingtai-tui spawn`
+and `lingtai-tui list`.
+
+## Spawn Readiness
+
+`lingtai-tui spawn <directory> --preset <name>` creates the project and launches
+the agent, then waits for both conditions:
+
+- an inspectable `lingtai run <agent-dir>` process exists
+- `.agent.heartbeat` exists and is fresh
+
+Success returns JSON with:
+
+- `status: "ready"`
+- `readiness_status: "ready"`
+- `inspectable_process_confirmed: true`
+- `heartbeat_confirmed: true`
+- `pid` from `.status.json.runtime.pid` when available
+
+`spawn` no longer treats `cmd.Start()` as success. Timeout or early exit returns
+typed JSON errors such as `readiness_timeout` or
+`process_exited_before_ready`. On readiness failure, the TUI attempts best-effort
+cleanup of the launched agent processes.
+
+## List JSON
+
+`lingtai-tui list --json [project-dir]` emits structured process data for
+controllers. Each process entry includes agent identity, `agent_dir`,
+heartbeat freshness, and `lock_exists`.
+
+On Windows, process discovery uses WMIC when available and PowerShell CIM as a
+fallback. When a venv parent process and runtime child process both appear for
+the same `agent_dir`, list output deduplicates by `agent_dir` and prefers
+`.status.json.runtime.pid`.
+
+## Mailbox Probe
+
+Use the kernel runtime probe contract documented in `lingtai-kernel`. A
+successful controller probe should observe:
+
+- probe folder moved from `human/mailbox/outbox/<id>/` to
+  `human/mailbox/sent/<id>/`
+- probe copied to `<agent>/mailbox/inbox/<id>/message.json`
+- structured `runtime_probe_ack` written to `human/mailbox/inbox/`
+
+## Cleanup
+
+Stop is verified by writing `.suspend` or using existing lifecycle controls,
+then confirming `lingtai-tui list --json <project-dir>` returns `count: 0`.
+
+Runtime state, `.lingtai/`, mailbox files, logs, temp dirs, env files, secrets,
+prompts, hidden prompts, chain-of-thought, raw reasoning, and daemon raw logs
+must remain untracked.

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -273,6 +273,8 @@ type AgentStatus struct {
 		} `json:"context"`
 	} `json:"tokens"`
 	Runtime struct {
+		PID           int     `json:"pid"`
+		Running       bool    `json:"running"`
 		UptimeSeconds float64 `json:"uptime_seconds"`
 		StaminaLeft   float64 `json:"stamina_left"`
 	} `json:"runtime"`

--- a/tui/internal/fs/heartbeat.go
+++ b/tui/internal/fs/heartbeat.go
@@ -10,17 +10,36 @@ import (
 
 const AgentAliveThresholdSec = 2.0
 
-func IsAlive(dir string, thresholdSec float64) bool {
+type HeartbeatStatus struct {
+	Exists     bool    `json:"exists"`
+	Fresh      bool    `json:"fresh"`
+	Timestamp  float64 `json:"timestamp,omitempty"`
+	AgeSeconds float64 `json:"age_seconds,omitempty"`
+	Error      string  `json:"error,omitempty"`
+}
+
+func ReadHeartbeat(dir string, thresholdSec float64) HeartbeatStatus {
 	data, err := os.ReadFile(filepath.Join(dir, ".agent.heartbeat"))
 	if err != nil {
-		return false
+		return HeartbeatStatus{Exists: false, Fresh: false, Error: err.Error()}
 	}
 	ts, err := strconv.ParseFloat(strings.TrimSpace(string(data)), 64)
 	if err != nil {
-		return false
+		return HeartbeatStatus{Exists: true, Fresh: false, Error: err.Error()}
 	}
-	age := time.Since(time.Unix(int64(ts), 0)).Seconds()
-	return age < thresholdSec
+	sec := int64(ts)
+	nsec := int64((ts - float64(sec)) * 1e9)
+	age := time.Since(time.Unix(sec, nsec)).Seconds()
+	return HeartbeatStatus{
+		Exists:     true,
+		Fresh:      age < thresholdSec,
+		Timestamp:  ts,
+		AgeSeconds: age,
+	}
+}
+
+func IsAlive(dir string, thresholdSec float64) bool {
+	return ReadHeartbeat(dir, thresholdSec).Fresh
 }
 
 func IsAliveHuman() bool {

--- a/tui/internal/headless/headless.go
+++ b/tui/internal/headless/headless.go
@@ -21,6 +21,18 @@ func WriteError(w io.Writer, message, code string) error {
 	})
 }
 
+// WriteErrorDetail writes a JSON error object with machine-readable details.
+func WriteErrorDetail(w io.Writer, message, code string, details map[string]interface{}) error {
+	out := map[string]interface{}{
+		"error": message,
+		"code":  code,
+	}
+	for k, v := range details {
+		out[k] = v
+	}
+	return WriteJSON(w, out)
+}
+
 // ExitError writes a JSON error to stderr and exits with code 1.
 func ExitError(message, code string) {
 	WriteError(os.Stderr, message, code)

--- a/tui/internal/headless/presets_test.go
+++ b/tui/internal/headless/presets_test.go
@@ -9,14 +9,19 @@ import (
 	"github.com/anthropics/lingtai-tui/internal/preset"
 )
 
-// withTempHome redirects HOME to a temp dir for isolated preset tests.
+// withTempHome redirects home env vars to a temp dir for isolated preset tests.
 // Follows the same pattern as preset_test.go:withTempPresets.
 func withTempHome(t *testing.T) {
 	t.Helper()
-	orig := os.Getenv("HOME")
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
 	tmp := t.TempDir()
 	os.Setenv("HOME", tmp)
-	t.Cleanup(func() { os.Setenv("HOME", orig) })
+	os.Setenv("USERPROFILE", tmp)
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		os.Setenv("USERPROFILE", origUserProfile)
+	})
 }
 
 func TestRunPresets_EmptyDir_ReturnsEmptyList(t *testing.T) {

--- a/tui/internal/headless/spawn.go
+++ b/tui/internal/headless/spawn.go
@@ -5,31 +5,51 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/anthropics/lingtai-tui/internal/config"
+	"github.com/anthropics/lingtai-tui/internal/fs"
 	"github.com/anthropics/lingtai-tui/internal/globalmigrate"
 	"github.com/anthropics/lingtai-tui/internal/preset"
 	"github.com/anthropics/lingtai-tui/internal/process"
 )
 
+const defaultReadyTimeout = 10 * time.Second
+
+var (
+	launchAgent             = process.LaunchAgent
+	findAgentProcesses      = process.FindAgentProcesses
+	terminateAgentProcesses = process.TerminateAgentProcesses
+	readHeartbeat           = fs.ReadHeartbeat
+	readySleep              = time.Sleep
+	readyPollInterval       = 200 * time.Millisecond
+	processExitGrace        = 2 * time.Second
+)
+
 // SpawnOpts holds the parsed flags for the spawn subcommand.
 type SpawnOpts struct {
-	Dir        string // target project directory (will be made absolute)
-	Preset     string // preset name
-	AgentName  string // agent name (empty = basename of Dir)
-	Language   string // "en", "zh", or "wen"
-	SkipLaunch bool   // skip agent launch (for testing)
+	Dir          string        // target project directory (will be made absolute)
+	Preset       string        // preset name
+	AgentName    string        // agent name (empty = basename of Dir)
+	Language     string        // "en", "zh", or "wen"
+	SkipLaunch   bool          // skip agent launch (for testing)
+	ReadyTimeout time.Duration // wait-ready timeout after launch
 }
 
 // SpawnOutput is the JSON response on success.
 type SpawnOutput struct {
-	Status     string `json:"status"`
-	ProjectDir string `json:"project_dir"`
-	AgentName  string `json:"agent_name"`
-	AgentDir   string `json:"agent_dir"`
-	Preset     string `json:"preset"`
-	Recipe     string `json:"recipe"`
-	PID        int    `json:"pid"`
+	Status                      string  `json:"status"`
+	ReadinessStatus             string  `json:"readiness_status"`
+	ProjectDir                  string  `json:"project_dir"`
+	AgentName                   string  `json:"agent_name"`
+	AgentDir                    string  `json:"agent_dir"`
+	Preset                      string  `json:"preset"`
+	Recipe                      string  `json:"recipe"`
+	PID                         int     `json:"pid"`
+	InspectableProcessConfirmed bool    `json:"inspectable_process_confirmed"`
+	HeartbeatConfirmed          bool    `json:"heartbeat_confirmed"`
+	HeartbeatAgeSeconds         float64 `json:"heartbeat_age_seconds,omitempty"`
+	ReadyTimeoutSeconds         float64 `json:"ready_timeout_seconds"`
 }
 
 // resolveAgentName returns AgentName if set, otherwise the basename of Dir.
@@ -77,9 +97,11 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 	// Ensure venv exists, then always run the non-blocking upgrade check so
 	// newly-created/repaired runtimes do not stay on a stale lingtai wheel until
 	// the next launch.
-	if _, err := config.EnsureRuntime(globalDir); err != nil {
-		WriteError(stderr, "venv setup failed: "+err.Error(), "bootstrap_failed")
-		return 1
+	if !opts.SkipLaunch {
+		if _, err := config.EnsureRuntimeQuiet(globalDir, nil); err != nil {
+			WriteError(stderr, "venv setup failed: "+err.Error(), "bootstrap_failed")
+			return 1
+		}
 	}
 
 	// Bootstrap presets + assets
@@ -141,25 +163,130 @@ func RunSpawn(stdout, stderr io.Writer, opts SpawnOpts) int {
 
 	// Launch the agent (async — start and return immediately)
 	pid := 0
+	status := "created"
+	readinessStatus := "not_launched"
+	inspectableProcessConfirmed := false
+	heartbeatConfirmed := false
+	heartbeatAgeSeconds := 0.0
+	readyTimeout := readyTimeoutOrDefault(opts.ReadyTimeout)
 	if !opts.SkipLaunch {
 		lingtaiCmd := config.LingtaiCmd(globalDir)
-		cmd, err := process.LaunchAgent(lingtaiCmd, agentDir)
+		cmd, err := launchAgent(lingtaiCmd, agentDir)
 		if err != nil {
 			WriteError(stderr, "agent launch failed: "+err.Error(), "launch_failed")
 			return 1
 		}
 		pid = cmd.Process.Pid
 		cmd.Process.Release()
+
+		ready := waitForAgentReady(agentDir, readyTimeout)
+		if ready.Code != "ready" {
+			details := map[string]interface{}{
+				"agent_dir":                     agentDir,
+				"pid":                           pid,
+				"readiness_status":              ready.Code,
+				"inspectable_process_confirmed": ready.InspectableProcessConfirmed,
+				"heartbeat_confirmed":           ready.HeartbeatConfirmed,
+				"heartbeat":                     ready.Heartbeat,
+				"ready_timeout_seconds":         readyTimeout.Seconds(),
+			}
+			if cleanupErr := terminateAgentProcesses(agentDir); cleanupErr != nil {
+				details["cleanup_error"] = cleanupErr.Error()
+			}
+			WriteErrorDetail(stderr, ready.Message, ready.Code, details)
+			return 1
+		}
+		status = "ready"
+		readinessStatus = ready.Code
+		inspectableProcessConfirmed = ready.InspectableProcessConfirmed
+		heartbeatConfirmed = ready.HeartbeatConfirmed
+		heartbeatAgeSeconds = ready.Heartbeat.AgeSeconds
+		if ready.PID != 0 {
+			pid = ready.PID
+		}
 	}
 
 	WriteJSON(stdout, SpawnOutput{
-		Status:     "launched",
-		ProjectDir: opts.Dir,
-		AgentName:  agentName,
-		AgentDir:   agentDir,
-		Preset:     opts.Preset,
-		Recipe:     "plain",
-		PID:        pid,
+		Status:                      status,
+		ReadinessStatus:             readinessStatus,
+		ProjectDir:                  opts.Dir,
+		AgentName:                   agentName,
+		AgentDir:                    agentDir,
+		Preset:                      opts.Preset,
+		Recipe:                      "plain",
+		PID:                         pid,
+		InspectableProcessConfirmed: inspectableProcessConfirmed,
+		HeartbeatConfirmed:          heartbeatConfirmed,
+		HeartbeatAgeSeconds:         heartbeatAgeSeconds,
+		ReadyTimeoutSeconds:         readyTimeout.Seconds(),
 	})
 	return 0
+}
+
+type readinessResult struct {
+	Code                        string
+	Message                     string
+	PID                         int
+	InspectableProcessConfirmed bool
+	HeartbeatConfirmed          bool
+	Heartbeat                   fs.HeartbeatStatus
+}
+
+func readyTimeoutOrDefault(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return defaultReadyTimeout
+	}
+	return timeout
+}
+
+func waitForAgentReady(agentDir string, timeout time.Duration) readinessResult {
+	timeout = readyTimeoutOrDefault(timeout)
+	started := time.Now()
+	deadline := started.Add(timeout)
+	var lastHeartbeat fs.HeartbeatStatus
+	var lastPID int
+	var inspectable bool
+
+	for {
+		lastHeartbeat = readHeartbeat(agentDir, 3.0)
+		heartbeatConfirmed := lastHeartbeat.Fresh
+		procs := findAgentProcesses(agentDir)
+		inspectable = len(procs) > 0
+		if inspectable {
+			lastPID = procs[0].PID
+		}
+		if heartbeatConfirmed && inspectable {
+			status := fs.ReadStatus(agentDir)
+			if status.Runtime.PID != 0 {
+				lastPID = status.Runtime.PID
+			}
+			return readinessResult{
+				Code:                        "ready",
+				PID:                         lastPID,
+				InspectableProcessConfirmed: true,
+				HeartbeatConfirmed:          true,
+				Heartbeat:                   lastHeartbeat,
+			}
+		}
+		if !inspectable && time.Since(started) > processExitGrace {
+			return readinessResult{
+				Code:                        "process_exited_before_ready",
+				Message:                     fmt.Sprintf("agent process exited before writing an inspectable fresh heartbeat; see %s", filepath.Join(agentDir, "logs", "agent.log")),
+				InspectableProcessConfirmed: false,
+				HeartbeatConfirmed:          heartbeatConfirmed,
+				Heartbeat:                   lastHeartbeat,
+			}
+		}
+		if time.Now().After(deadline) {
+			return readinessResult{
+				Code:                        "readiness_timeout",
+				Message:                     fmt.Sprintf("agent did not become inspectable with a fresh heartbeat within %s; see %s", timeout, filepath.Join(agentDir, "logs", "agent.log")),
+				PID:                         lastPID,
+				InspectableProcessConfirmed: inspectable,
+				HeartbeatConfirmed:          heartbeatConfirmed,
+				Heartbeat:                   lastHeartbeat,
+			}
+		}
+		readySleep(readyPollInterval)
+	}
 }

--- a/tui/internal/headless/spawn_test.go
+++ b/tui/internal/headless/spawn_test.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/anthropics/lingtai-tui/internal/fs"
 	"github.com/anthropics/lingtai-tui/internal/preset"
+	"github.com/anthropics/lingtai-tui/internal/process"
 )
 
 func TestRunSpawn_RejectsExistingLingtaiDir(t *testing.T) {
@@ -149,8 +152,11 @@ func TestRunSpawn_SuccessOutput_HasRequiredFields(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\nbody: %s", err, stdout.String())
 	}
-	if result.Status != "launched" {
-		t.Errorf("status = %q, want %q", result.Status, "launched")
+	if result.Status != "created" {
+		t.Errorf("status = %q, want %q", result.Status, "created")
+	}
+	if result.ReadinessStatus != "not_launched" {
+		t.Errorf("readiness_status = %q, want %q", result.ReadinessStatus, "not_launched")
 	}
 	if result.AgentName != "test-agent" {
 		t.Errorf("agent_name = %q, want %q", result.AgentName, "test-agent")
@@ -160,6 +166,84 @@ func TestRunSpawn_SuccessOutput_HasRequiredFields(t *testing.T) {
 	}
 	if result.Recipe != "plain" {
 		t.Errorf("recipe = %q, want %q", result.Recipe, "plain")
+	}
+	if result.ReadyTimeoutSeconds != defaultReadyTimeout.Seconds() {
+		t.Errorf("ready_timeout_seconds = %v, want %v", result.ReadyTimeoutSeconds, defaultReadyTimeout.Seconds())
+	}
+}
+
+func TestWaitForAgentReadySuccess(t *testing.T) {
+	restore := stubReadyDeps(t)
+	defer restore()
+
+	readHeartbeat = func(string, float64) fs.HeartbeatStatus {
+		return fs.HeartbeatStatus{Exists: true, Fresh: true, Timestamp: 1, AgeSeconds: 0.1}
+	}
+	findAgentProcesses = func(string) []process.AgentProcess {
+		return []process.AgentProcess{{PID: 777, Command: "python -m lingtai run /tmp/a"}}
+	}
+
+	got := waitForAgentReady(t.TempDir(), 50*time.Millisecond)
+	if got.Code != "ready" {
+		t.Fatalf("Code = %q, want ready", got.Code)
+	}
+	if got.PID != 777 || !got.HeartbeatConfirmed || !got.InspectableProcessConfirmed {
+		t.Fatalf("unexpected readiness result: %+v", got)
+	}
+}
+
+func TestWaitForAgentReadyTimeout(t *testing.T) {
+	restore := stubReadyDeps(t)
+	defer restore()
+
+	readHeartbeat = func(string, float64) fs.HeartbeatStatus {
+		return fs.HeartbeatStatus{Exists: false, Fresh: false}
+	}
+	findAgentProcesses = func(string) []process.AgentProcess {
+		return []process.AgentProcess{{PID: 777, Command: "python -m lingtai run /tmp/a"}}
+	}
+
+	got := waitForAgentReady(t.TempDir(), 5*time.Millisecond)
+	if got.Code != "readiness_timeout" {
+		t.Fatalf("Code = %q, want readiness_timeout", got.Code)
+	}
+	if !got.InspectableProcessConfirmed || got.HeartbeatConfirmed {
+		t.Fatalf("unexpected readiness result: %+v", got)
+	}
+}
+
+func TestWaitForAgentReadyProcessExited(t *testing.T) {
+	restore := stubReadyDeps(t)
+	defer restore()
+	processExitGrace = time.Millisecond
+
+	readHeartbeat = func(string, float64) fs.HeartbeatStatus {
+		return fs.HeartbeatStatus{Exists: false, Fresh: false}
+	}
+	findAgentProcesses = func(string) []process.AgentProcess { return nil }
+
+	got := waitForAgentReady(t.TempDir(), 50*time.Millisecond)
+	if got.Code != "process_exited_before_ready" {
+		t.Fatalf("Code = %q, want process_exited_before_ready", got.Code)
+	}
+}
+
+func stubReadyDeps(t *testing.T) func() {
+	t.Helper()
+	origFind := findAgentProcesses
+	origRead := readHeartbeat
+	origSleep := readySleep
+	origPoll := readyPollInterval
+	origGrace := processExitGrace
+	readySleep = func(time.Duration) {}
+	readyPollInterval = time.Millisecond
+	processExitGrace = 500 * time.Millisecond
+	return func() {
+		findAgentProcesses = origFind
+		readHeartbeat = origRead
+		readySleep = origSleep
+		readyPollInterval = origPoll
+		processExitGrace = origGrace
 	}
 }
 

--- a/tui/internal/processscan/check.go
+++ b/tui/internal/processscan/check.go
@@ -3,6 +3,7 @@ package processscan
 import (
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -24,7 +25,6 @@ type AgentProcess struct {
 // line (which itself may contain spaces). We split on the first whitespace
 // run to separate pid from command.
 func ParsePSOutput(out, abs string) []AgentProcess {
-	needle := "lingtai run " + abs
 	var results []AgentProcess
 	for _, line := range strings.Split(out, "\n") {
 		if !strings.Contains(line, "lingtai run") {
@@ -34,11 +34,7 @@ func ParsePSOutput(out, abs string) []AgentProcess {
 		if trimmed == "" {
 			continue
 		}
-		// Match either `... lingtai run <abs> ...` (additional args follow)
-		// or `... lingtai run <abs>` at end-of-line. Without this guard we
-		// would also match `lingtai run <abs>-suffix`, picking up sibling
-		// agent dirs that share a prefix.
-		if !(strings.Contains(trimmed, needle+" ") || strings.HasSuffix(trimmed, needle)) {
+		if !commandMatchesAgentDir(trimmed, abs) {
 			continue
 		}
 		// Split off the leading pid column. ps emits "  1234 python ..." so
@@ -56,19 +52,113 @@ func ParsePSOutput(out, abs string) []AgentProcess {
 	return results
 }
 
+func ParseWMICOutput(out, abs string) []AgentProcess {
+	var results []AgentProcess
+	var cmdline string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "CommandLine=") {
+			cmdline = strings.TrimPrefix(line, "CommandLine=")
+			continue
+		}
+		if !strings.HasPrefix(line, "ProcessId=") {
+			continue
+		}
+		pidText := strings.TrimPrefix(line, "ProcessId=")
+		pid, err := strconv.Atoi(strings.TrimSpace(pidText))
+		if err == nil && commandMatchesProcess(cmdline, abs) {
+			results = append(results, AgentProcess{
+				PID:     pid,
+				Command: strings.TrimSpace(cmdline),
+			})
+		}
+		cmdline = ""
+	}
+	return results
+}
+
+func commandMatchesProcess(command, abs string) bool {
+	if abs == "" {
+		lower := strings.ToLower(command)
+		return strings.Contains(lower, "-m lingtai run ") ||
+			strings.Contains(lower, "lingtai-agent run ")
+	}
+	return commandMatchesAgentDir(command, abs)
+}
+
+func commandMatchesAgentDir(command, abs string) bool {
+	if !strings.Contains(strings.ToLower(command), "lingtai run") {
+		return false
+	}
+	candidates := []string{abs, filepath.ToSlash(abs)}
+	for _, candidate := range candidates {
+		for _, arg := range []string{candidate, `"` + candidate + `"`} {
+			needle := "lingtai run " + arg
+			if commandContainsArg(command, needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func commandContainsArg(command, needle string) bool {
+	cmd := strings.ToLower(command)
+	n := strings.ToLower(needle)
+	return strings.Contains(cmd, n+" ") || strings.Contains(cmd, n+"\t") || strings.HasSuffix(cmd, n)
+}
+
 // FindAgentProcesses returns all running `lingtai run <agentDir>` processes
-// visible to the current user via `ps -eo pid=,command=`. Empty slice on
+// visible to the current user via process listing. Empty slice on
 // error or no match. Use IsAgentRunning if you only need a boolean.
 func FindAgentProcesses(agentDir string) []AgentProcess {
 	abs, err := filepath.Abs(agentDir)
 	if err != nil {
 		abs = agentDir
 	}
+	if runtime.GOOS == "windows" {
+		return findAgentProcessesWindows(abs)
+	}
 	out, err := exec.Command("ps", "-eo", "pid=,command=").Output()
 	if err != nil {
 		return nil
 	}
 	return ParsePSOutput(string(out), abs)
+}
+
+func findAgentProcessesWindows(abs string) []AgentProcess {
+	out, err := windowsAgentProcessOutput()
+	if err != nil {
+		return nil
+	}
+	return ParseWMICOutput(string(out), abs)
+}
+
+func FindWindowsAgentProcesses(abs string) []AgentProcess {
+	return findAgentProcessesWindows(abs)
+}
+
+func windowsAgentProcessOutput() ([]byte, error) {
+	out, err := exec.Command(
+		"wmic",
+		"process",
+		"where",
+		"commandline like '%lingtai run%'",
+		"get",
+		"processid,commandline",
+		"/format:list",
+	).Output()
+	if err == nil {
+		return out, nil
+	}
+	script := `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*lingtai run*' } | ForEach-Object { "CommandLine=$($_.CommandLine)"; "ProcessId=$($_.ProcessId)"; "" }`
+	return exec.Command(
+		"powershell.exe",
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		script,
+	).Output()
 }
 
 // IsAgentRunning returns true if any `python -m lingtai run <agentDir>`

--- a/tui/internal/processscan/check_test.go
+++ b/tui/internal/processscan/check_test.go
@@ -1,0 +1,49 @@
+package processscan
+
+import "testing"
+
+func TestParseWMICOutputMatchesQuotedWindowsPath(t *testing.T) {
+	abs := `C:\Users\rawle\AppData\Local\Temp\project\.lingtai\agent-a`
+	out := `CommandLine=C:\Python\python.exe -m lingtai run "C:\Users\rawle\AppData\Local\Temp\project\.lingtai\agent-a"
+ProcessId=1234
+
+CommandLine=C:\Python\python.exe -m lingtai run "C:\Users\rawle\AppData\Local\Temp\project\.lingtai\agent-a-sibling"
+ProcessId=5678
+`
+	got := ParseWMICOutput(out, abs)
+	if len(got) != 1 {
+		t.Fatalf("got %d procs, want 1: %+v", len(got), got)
+	}
+	if got[0].PID != 1234 {
+		t.Fatalf("PID = %d, want 1234", got[0].PID)
+	}
+}
+
+func TestParseWMICOutputListsAllWhenAbsEmpty(t *testing.T) {
+	out := `CommandLine=C:\Python\python.exe -m lingtai run C:\tmp\a
+ProcessId=1234
+
+CommandLine=C:\Python\python.exe -m other run C:\tmp\a
+ProcessId=5678
+`
+	got := ParseWMICOutput(out, "")
+	if len(got) != 1 {
+		t.Fatalf("got %d procs, want 1: %+v", len(got), got)
+	}
+	if got[0].PID != 1234 {
+		t.Fatalf("PID = %d, want 1234", got[0].PID)
+	}
+}
+
+func TestCommandMatchesAgentDirEOLAndArgBoundary(t *testing.T) {
+	abs := `/work/foo`
+	if !commandMatchesAgentDir(`python -m lingtai run /work/foo`, abs) {
+		t.Fatal("expected exact EOL match")
+	}
+	if !commandMatchesAgentDir(`python -m lingtai run /work/foo --debug`, abs) {
+		t.Fatal("expected arg-boundary match")
+	}
+	if commandMatchesAgentDir(`python -m lingtai run /work/foo-sibling`, abs) {
+		t.Fatal("prefix sibling should not match")
+	}
+}

--- a/tui/list_common.go
+++ b/tui/list_common.go
@@ -17,6 +17,7 @@ type listOptions struct {
 	FilterDir string
 	Detailed  bool
 	Admin     bool
+	JSON      bool
 }
 
 type listProc struct {
@@ -40,6 +41,30 @@ type listAgentInfo struct {
 	ReadError      string
 }
 
+type listJSONOutput struct {
+	Status      string         `json:"status"`
+	Count       int            `json:"count"`
+	FilterDir   string         `json:"filter_dir,omitempty"`
+	Processes   []listJSONProc `json:"processes"`
+	PhantomDirs []string       `json:"phantom_dirs,omitempty"`
+}
+
+type listJSONProc struct {
+	PID        string             `json:"pid"`
+	Uptime     string             `json:"uptime,omitempty"`
+	Role       string             `json:"role"`
+	Agent      string             `json:"agent"`
+	Project    string             `json:"project"`
+	AgentDir   string             `json:"agent_dir"`
+	Address    string             `json:"address"`
+	AgentName  string             `json:"agent_name"`
+	Nickname   string             `json:"nickname,omitempty"`
+	State      string             `json:"state"`
+	ReadError  string             `json:"read_error,omitempty"`
+	Heartbeat  fs.HeartbeatStatus `json:"heartbeat"`
+	LockExists bool               `json:"lock_exists"`
+}
+
 func parseListArgs(args []string) (listOptions, error) {
 	var opts listOptions
 	for _, arg := range args {
@@ -49,14 +74,16 @@ func parseListArgs(args []string) (listOptions, error) {
 		case "--admin":
 			opts.Admin = true
 			opts.Detailed = true
+		case "--json":
+			opts.JSON = true
 		case "--help", "-h":
-			return opts, fmt.Errorf("usage: lingtai-tui list [--detailed|-d] [--admin] [dir]")
+			return opts, fmt.Errorf("usage: lingtai-tui list [--detailed|-d] [--admin] [--json] [dir]")
 		default:
 			if strings.HasPrefix(arg, "-") {
-				return opts, fmt.Errorf("unknown list flag %q\nusage: lingtai-tui list [--detailed|-d] [--admin] [dir]", arg)
+				return opts, fmt.Errorf("unknown list flag %q\nusage: lingtai-tui list [--detailed|-d] [--admin] [--json] [dir]", arg)
 			}
 			if opts.FilterDir != "" {
-				return opts, fmt.Errorf("list accepts at most one directory filter\nusage: lingtai-tui list [--detailed|-d] [--admin] [dir]")
+				return opts, fmt.Errorf("list accepts at most one directory filter\nusage: lingtai-tui list [--detailed|-d] [--admin] [--json] [dir]")
 			}
 			abs, err := filepath.Abs(arg)
 			if err != nil {
@@ -219,6 +246,35 @@ func annotateListProcs(procs []listProc) {
 	}
 }
 
+func collapseListProcsByAgentDir(procs []listProc) []listProc {
+	if len(procs) < 2 {
+		return procs
+	}
+	out := make([]listProc, 0, len(procs))
+	indexByDir := map[string]int{}
+	for _, p := range procs {
+		if p.Dir == "" {
+			out = append(out, p)
+			continue
+		}
+		idx, ok := indexByDir[p.Dir]
+		if !ok {
+			indexByDir[p.Dir] = len(out)
+			out = append(out, p)
+			continue
+		}
+		status := fs.ReadStatus(p.Dir)
+		statusPID := ""
+		if status.Runtime.PID != 0 {
+			statusPID = fmt.Sprint(status.Runtime.PID)
+		}
+		if statusPID != "" && p.PID == statusPID {
+			out[idx] = p
+		}
+	}
+	return out
+}
+
 func printList(w io.Writer, procs []listProc, phantomDirs map[string]bool, opts listOptions, showUptime bool) {
 	if opts.Admin {
 		if showUptime {
@@ -274,6 +330,51 @@ func printList(w io.Writer, procs []listProc, phantomDirs map[string]bool, opts 
 			}
 		}
 	}
+}
+
+func printListJSON(w io.Writer, procs []listProc, phantomDirs map[string]bool, opts listOptions) {
+	phantoms := make([]string, 0, len(phantomDirs))
+	for dir := range phantomDirs {
+		phantoms = append(phantoms, dir)
+	}
+	sort.Strings(phantoms)
+
+	out := listJSONOutput{
+		Status:      "ok",
+		Count:       len(procs),
+		FilterDir:   opts.FilterDir,
+		Processes:   make([]listJSONProc, 0, len(procs)),
+		PhantomDirs: phantoms,
+	}
+	for _, p := range procs {
+		role := roleLabel(p.Info)
+		address := firstNonEmpty(p.Info.Address, p.Agent)
+		name := firstNonEmpty(p.Info.AgentName, p.Agent)
+		state := firstNonEmpty(p.Info.State, "unknown")
+		out.Processes = append(out.Processes, listJSONProc{
+			PID:        p.PID,
+			Uptime:     p.Uptime,
+			Role:       role,
+			Agent:      p.Agent,
+			Project:    p.Project,
+			AgentDir:   p.Dir,
+			Address:    address,
+			AgentName:  name,
+			Nickname:   p.Info.Nickname,
+			State:      state,
+			ReadError:  p.Info.ReadError,
+			Heartbeat:  fs.ReadHeartbeat(p.Dir, fs.AgentAliveThresholdSec),
+			LockExists: fileExists(filepath.Join(p.Dir, ".agent.lock")),
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func printListWarnings(w io.Writer, phantomDirs map[string]bool, filterDir string) {

--- a/tui/list_common_test.go
+++ b/tui/list_common_test.go
@@ -3,22 +3,93 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseListArgsModesAndDir(t *testing.T) {
-	opts, err := parseListArgs([]string{"--detailed", "--admin", "./project"})
+	opts, err := parseListArgs([]string{"--detailed", "--admin", "--json", "./project"})
 	if err != nil {
 		t.Fatalf("parseListArgs returned error: %v", err)
 	}
-	if !opts.Detailed || !opts.Admin {
-		t.Fatalf("expected detailed/admin true, got detailed=%v admin=%v", opts.Detailed, opts.Admin)
+	if !opts.Detailed || !opts.Admin || !opts.JSON {
+		t.Fatalf("expected detailed/admin/json true, got detailed=%v admin=%v json=%v", opts.Detailed, opts.Admin, opts.JSON)
 	}
 	want, _ := filepath.Abs("./project")
 	if opts.FilterDir != want {
 		t.Fatalf("FilterDir=%q, want %q", opts.FilterDir, want)
+	}
+}
+
+func TestPrintListJSONIncludesHeartbeatAndLock(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".lingtai", "agent-a")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	heartbeat := fmt.Sprintf("%.6f", float64(time.Now().UnixNano())/1e9)
+	if err := os.WriteFile(filepath.Join(agentDir, ".agent.heartbeat"), []byte(heartbeat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, ".agent.lock"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	procs := []listProc{{
+		PID:     "123",
+		Uptime:  "1s",
+		Agent:   "agent-a",
+		Project: project,
+		Dir:     agentDir,
+		Info: listAgentInfo{
+			Address:   "agent-a",
+			AgentName: "agent-a",
+			State:     "asleep",
+		},
+	}}
+
+	var buf bytes.Buffer
+	printListJSON(&buf, procs, nil, listOptions{JSON: true})
+	var parsed listJSONOutput
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if parsed.Count != 1 || len(parsed.Processes) != 1 {
+		t.Fatalf("unexpected process count: %+v", parsed)
+	}
+	got := parsed.Processes[0]
+	if !got.Heartbeat.Fresh {
+		t.Fatalf("heartbeat should be fresh: %+v", got.Heartbeat)
+	}
+	if !got.LockExists {
+		t.Fatal("lock_exists should be true")
+	}
+}
+
+func TestCollapseListProcsPrefersRuntimeStatusPID(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".lingtai", "agent-a")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	status := []byte(`{"runtime":{"pid":222,"running":true}}`)
+	if err := os.WriteFile(filepath.Join(agentDir, ".status.json"), status, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := collapseListProcsByAgentDir([]listProc{
+		{PID: "111", Agent: "agent-a", Project: project, Dir: agentDir},
+		{PID: "222", Agent: "agent-a", Project: project, Dir: agentDir},
+	})
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].PID != "222" {
+		t.Fatalf("PID = %q, want status pid 222", got[0].PID)
 	}
 }
 

--- a/tui/list_unix.go
+++ b/tui/list_unix.go
@@ -69,6 +69,10 @@ func listMain() {
 	}
 
 	if len(procs) == 0 {
+		if opts.JSON {
+			printListJSON(os.Stdout, procs, nil, opts)
+			return
+		}
 		if opts.FilterDir != "" {
 			fmt.Printf("No lingtai processes running in %s.\n", opts.FilterDir)
 		} else {
@@ -111,6 +115,11 @@ func listMain() {
 
 	phantomDirs := detectPhantomDirs(procs, opts.FilterDir)
 	annotateListProcs(procs)
+	procs = collapseListProcsByAgentDir(procs)
+	if opts.JSON {
+		printListJSON(os.Stdout, procs, phantomDirs, opts)
+		return
+	}
 	printList(os.Stdout, procs, phantomDirs, opts, true)
 	fmt.Printf("\n%d process(es) running.\n", len(procs))
 	printListWarnings(os.Stdout, phantomDirs, opts.FilterDir)

--- a/tui/list_windows.go
+++ b/tui/list_windows.go
@@ -5,9 +5,10 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/anthropics/lingtai-tui/internal/processscan"
 )
 
 func listMain() {
@@ -16,55 +17,36 @@ func listMain() {
 		listUsageError(err)
 	}
 
-	out, err := exec.Command("wmic", "process", "where",
-		"commandline like '%lingtai run%'",
-		"get", "processid,commandline", "/format:list").Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error listing processes: %v\n", err)
-		os.Exit(1)
-	}
-
 	var procs []listProc
-	var cmdline, pid string
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "CommandLine=") {
-			cmdline = strings.TrimPrefix(line, "CommandLine=")
+	for _, proc := range processscan.FindWindowsAgentProcesses("") {
+		cmdline := proc.Command
+		agentDir := agentDirFromWindowsCommandLine(cmdline)
+		agent := "unknown"
+		if agentDir != "" {
+			agent = filepath.Base(agentDir)
 		}
-		if strings.HasPrefix(line, "ProcessId=") {
-			pid = strings.TrimPrefix(line, "ProcessId=")
-			if cmdline != "" && strings.Contains(cmdline, "lingtai run") {
-				agentDir := ""
-				agent := "unknown"
-				if idx := strings.Index(cmdline, "lingtai run "); idx >= 0 {
-					agentDir = cmdline[idx+len("lingtai run "):]
-					agentDir = strings.Trim(strings.TrimSpace(strings.Split(agentDir, " ")[0]), "\"")
-					agent = filepath.Base(agentDir)
-				}
 
-				// Filter by dir if specified.
-				if opts.FilterDir != "" {
-					lingtaiPrefix := filepath.Join(opts.FilterDir, ".lingtai") + string(filepath.Separator)
-					if !strings.HasPrefix(agentDir, lingtaiPrefix) {
-						cmdline = ""
-						pid = ""
-						continue
-					}
-				}
-
-				project := ""
-				if idx := strings.Index(agentDir, `\.lingtai\`); idx >= 0 {
-					project = agentDir[:idx]
-				}
-
-				procs = append(procs, listProc{PID: pid, Agent: agent, Dir: agentDir, Project: project})
+		// Filter by dir if specified.
+		if opts.FilterDir != "" {
+			lingtaiPrefix := filepath.Join(opts.FilterDir, ".lingtai") + string(filepath.Separator)
+			if !strings.HasPrefix(agentDir, lingtaiPrefix) {
+				continue
 			}
-			cmdline = ""
-			pid = ""
 		}
+
+		project := ""
+		if idx := strings.Index(agentDir, `\.lingtai\`); idx >= 0 {
+			project = agentDir[:idx]
+		}
+
+		procs = append(procs, listProc{PID: fmt.Sprint(proc.PID), Agent: agent, Dir: agentDir, Project: project})
 	}
 
 	if len(procs) == 0 {
+		if opts.JSON {
+			printListJSON(os.Stdout, procs, nil, opts)
+			return
+		}
 		if opts.FilterDir != "" {
 			fmt.Printf("No lingtai processes running in %s.\n", opts.FilterDir)
 		} else {
@@ -75,6 +57,11 @@ func listMain() {
 
 	phantomDirs := detectPhantomDirs(procs, opts.FilterDir)
 	annotateListProcs(procs)
+	procs = collapseListProcsByAgentDir(procs)
+	if opts.JSON {
+		printListJSON(os.Stdout, procs, phantomDirs, opts)
+		return
+	}
 	printList(os.Stdout, procs, phantomDirs, opts, false)
 	fmt.Printf("\n%d process(es) running.\n", len(procs))
 	printListWarnings(os.Stdout, phantomDirs, opts.FilterDir)
@@ -102,4 +89,29 @@ func detectPhantomDirs(procs []listProc, filterDir string) map[string]bool {
 		}
 	}
 	return phantomDirs
+}
+
+func agentDirFromWindowsCommandLine(cmdline string) string {
+	lower := strings.ToLower(cmdline)
+	idx := strings.Index(lower, "lingtai run ")
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(cmdline[idx+len("lingtai run "):])
+	if rest == "" {
+		return ""
+	}
+	if strings.HasPrefix(rest, `"`) {
+		rest = strings.TrimPrefix(rest, `"`)
+		end := strings.Index(rest, `"`)
+		if end < 0 {
+			return strings.TrimSpace(rest)
+		}
+		return strings.TrimSpace(rest[:end])
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.Trim(fields[0], `"`)
 }

--- a/tui/list_windows_test.go
+++ b/tui/list_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestAgentDirFromWindowsCommandLine(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "quoted path with spaces",
+			cmd:  `C:\Python\python.exe -m lingtai run "C:\Users\Raw Lee\project\.lingtai\contract-agent"`,
+			want: `C:\Users\Raw Lee\project\.lingtai\contract-agent`,
+		},
+		{
+			name: "unquoted path",
+			cmd:  `C:\Python\python.exe -m lingtai run C:\Users\rawle\project\.lingtai\contract-agent`,
+			want: `C:\Users\rawle\project\.lingtai\contract-agent`,
+		},
+		{
+			name: "non lingtai command",
+			cmd:  `powershell.exe -NoProfile`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentDirFromWindowsCommandLine(tt.cmd); got != tt.want {
+				t.Fatalf("agentDirFromWindowsCommandLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tui/main.go
+++ b/tui/main.go
@@ -1042,7 +1042,7 @@ func presetsMain() {
 func spawnMain() {
 	if len(os.Args) < 3 {
 		headless.ExitError(
-			"usage: lingtai-tui spawn <directory> --preset <name> [--agent-name <name>] [--language <en|zh|wen>]",
+			"usage: lingtai-tui spawn <directory> --preset <name> [--agent-name <name>] [--language <en|zh|wen>] [--wait-ready-timeout <duration>]",
 			"invalid_args")
 	}
 
@@ -1072,6 +1072,16 @@ func spawnMain() {
 				headless.ExitError("--language must be en, zh, or wen", "invalid_args")
 			}
 			opts.Language = lang
+		case "--wait-ready-timeout":
+			if i+1 >= len(os.Args) {
+				headless.ExitError("--wait-ready-timeout requires a value", "invalid_args")
+			}
+			i++
+			timeout, err := time.ParseDuration(os.Args[i])
+			if err != nil || timeout <= 0 {
+				headless.ExitError("--wait-ready-timeout must be a positive duration like 10s", "invalid_args")
+			}
+			opts.ReadyTimeout = timeout
 		default:
 			headless.ExitError("unknown flag: "+os.Args[i], "invalid_args")
 		}


### PR DESCRIPTION
## Summary

Fixes the TUI/controller side of the headless runtime contract:

- `spawn` waits for an inspectable process plus fresh heartbeat before returning success
- `spawn` returns typed JSON failures such as `readiness_timeout` and `process_exited_before_ready`
- `spawn` uses quiet runtime bootstrap so stdout remains parseable JSON
- `list --json` emits structured process/identity/heartbeat/lock data
- Windows process discovery falls back from WMIC to PowerShell CIM and handles quoted paths with spaces
- list output deduplicates venv parent/runtime child process rows by `agent_dir`
- documents the controller contract under `docs/`

Companion kernel PR: https://github.com/Lingtai-AI/lingtai-kernel/pull/351

## Root Cause

`spawn` returned after `cmd.Start()` and did not prove a durable runtime process, heartbeat, or mailbox roundtrip. On Windows, process discovery could fail when WMIC was unavailable, and first-run runtime bootstrap logs polluted stdout before JSON.

## Runtime Contract

- Success means `status: "ready"`, `inspectable_process_confirmed: true`, and `heartbeat_confirmed: true`.
- Timeout and early-exit paths return typed JSON errors with readiness details.
- `list --json` is controller-friendly and includes heartbeat freshness and lock state.
- Stop/cleanup is verifiable by suspend plus `list --json` returning `count: 0`.

## Validation

- `go test ./internal/processscan ./internal/process ./internal/headless . -count=1` - passed
- `go test ./internal/fs -run 'TestIsAlive|TestReadHeartbeat' -count=1` - passed
- `go build -o %TEMP%/lingtai-tui-contract-smoke.exe .` - passed
- Joint smoke with kernel companion branch: controlled spawn ready, list JSON count 1, lock fresh, heartbeat fresh, runtime probe delivered/copied/acked, suspend stop verified, temp project cleanup verified.

## Safety

- No `.lingtai/`, mailbox state, logs, runtime state, temp dirs, `.env`, API keys, secrets, hidden prompts, raw prompts, chain-of-thought, or daemon raw logs are included.