### PR TITLE
Show main and daemon API call split in kanban

### DIFF
--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -429,6 +429,17 @@ type TokenTotals struct {
 	APICalls int64
 }
 
+// TokenSourceSplit groups token usage by the ledger `source` tag. Main is the
+// foreground agent loop (including legacy entries with no source, plus heal and
+// notification_sync recovery/sync calls); Daemon is delegated work; Soul is
+// shown separately so reflection cost does not inflate the main-vs-daemon ratio.
+type TokenSourceSplit struct {
+	Main          TokenTotals
+	Daemon        TokenTotals
+	Soul          TokenTotals
+	RecentDaemons []LedgerEntry
+}
+
 // AggregateTokens sums token usage from logs/token_ledger.jsonl across all given agent directories.
 // Skips agents whose ledger is missing or unreadable.
 func AggregateTokens(dirs []string) TokenTotals {
@@ -442,6 +453,83 @@ func AggregateTokens(dirs []string) TokenTotals {
 		t.APICalls += ledger.APICalls
 	}
 	return t
+}
+
+// AggregateTokenSourceSplit sums source-grouped usage from token ledgers across agents.
+func AggregateTokenSourceSplit(dirs []string, recentDaemonN int) TokenSourceSplit {
+	var split TokenSourceSplit
+	for _, dir := range dirs {
+		part := SumTokenLedgerBySource(filepath.Join(dir, "logs", "token_ledger.jsonl"), recentDaemonN)
+		split.Main = addTokenTotals(split.Main, part.Main)
+		split.Daemon = addTokenTotals(split.Daemon, part.Daemon)
+		split.Soul = addTokenTotals(split.Soul, part.Soul)
+		split.RecentDaemons = append(split.RecentDaemons, part.RecentDaemons...)
+	}
+	sort.Slice(split.RecentDaemons, func(i, j int) bool {
+		return split.RecentDaemons[i].TS > split.RecentDaemons[j].TS
+	})
+	if recentDaemonN > 0 && len(split.RecentDaemons) > recentDaemonN {
+		split.RecentDaemons = split.RecentDaemons[:recentDaemonN]
+	}
+	return split
+}
+
+func addTokenTotals(a, b TokenTotals) TokenTotals {
+	a.Input += b.Input
+	a.Output += b.Output
+	a.Thinking += b.Thinking
+	a.Cached += b.Cached
+	a.APICalls += b.APICalls
+	return a
+}
+
+func tokenTotalsFromEntry(entry LedgerEntry) TokenTotals {
+	return TokenTotals{
+		Input:    entry.Input,
+		Output:   entry.Output,
+		Thinking: entry.Thinking,
+		Cached:   entry.Cached,
+		APICalls: 1,
+	}
+}
+
+// SumTokenLedgerBySource reads a token_ledger.jsonl file and groups calls by
+// execution source. The main-vs-daemon ratio treats daemon entries as delegated
+// work, soul entries as reflection cost, and all other/legacy sources as main.
+func SumTokenLedgerBySource(path string, recentDaemonN int) TokenSourceSplit {
+	var split TokenSourceSplit
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return split
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry LedgerEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		t := tokenTotalsFromEntry(entry)
+		switch strings.ToLower(entry.Source) {
+		case "daemon":
+			split.Daemon = addTokenTotals(split.Daemon, t)
+			split.RecentDaemons = append(split.RecentDaemons, entry)
+		case "soul":
+			split.Soul = addTokenTotals(split.Soul, t)
+		default:
+			split.Main = addTokenTotals(split.Main, t)
+		}
+	}
+	// Keep newest daemon entries first, matching SumTokenLedgerByProvider.
+	if recentDaemonN > 0 && len(split.RecentDaemons) > recentDaemonN {
+		split.RecentDaemons = split.RecentDaemons[len(split.RecentDaemons)-recentDaemonN:]
+	}
+	for i, j := 0, len(split.RecentDaemons)-1; i < j; i, j = i+1, j-1 {
+		split.RecentDaemons[i], split.RecentDaemons[j] = split.RecentDaemons[j], split.RecentDaemons[i]
+	}
+	return split
 }
 
 // SumTokenLedger reads a token_ledger.jsonl file and sums main-agent entries.

--- a/tui/internal/fs/agent_test.go
+++ b/tui/internal/fs/agent_test.go
@@ -485,3 +485,70 @@ func TestSumTokenLedgerByProviderBoundsRecent(t *testing.T) {
 		t.Fatalf("byProvider = %#v, want all provider totals", byProvider)
 	}
 }
+
+func TestSumTokenLedgerBySourceGroupsMainDaemonSoul(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	lines := []string{
+		`{"ts":"2026-06-19T09:00:00Z","input":10,"output":1,"thinking":2,"cached":3,"model":"legacy"}`,
+		``, // blank line should be skipped, not counted
+		`{"ts":"2026-06-19T09:01:00Z","source":"main","input":20,"output":2,"thinking":0,"cached":4,"model":"main"}`,
+		`{not valid json}`, // malformed line should be skipped, not counted
+		`{"ts":"2026-06-19T09:02:00Z","source":"HEAL","input":5,"output":1,"thinking":0,"cached":0,"model":"heal"}`, // mixed-case unknown source -> main
+		`{"ts":"2026-06-19T09:03:00Z","source":"soul","input":7,"output":1,"thinking":1,"cached":0,"model":"soul"}`,
+		`{"ts":"2026-06-19T09:04:00Z","source":"daemon","em_id":"em-1","run_id":"run-1","input":30,"output":3,"thinking":0,"cached":5,"model":"daemon-a"}`,
+		`{"ts":"2026-06-19T09:05:00Z","source":"DAEMON","em_id":"em-2","run_id":"run-2","input":40,"output":4,"thinking":1,"cached":6,"model":"daemon-b"}`, // mixed-case daemon
+	}
+	if err := os.WriteFile(ledgerPath, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	split := SumTokenLedgerBySource(ledgerPath, 1)
+
+	if split.Main.APICalls != 3 || split.Main.Input != 35 || split.Main.Output != 4 || split.Main.Thinking != 2 || split.Main.Cached != 7 {
+		t.Fatalf("main totals = %+v, want calls=3 input=35 output=4 thinking=2 cached=7", split.Main)
+	}
+	if split.Soul.APICalls != 1 || split.Soul.Input != 7 || split.Soul.Output != 1 || split.Soul.Thinking != 1 {
+		t.Fatalf("soul totals = %+v, want calls=1 input=7 output=1 thinking=1", split.Soul)
+	}
+	if split.Daemon.APICalls != 2 || split.Daemon.Input != 70 || split.Daemon.Output != 7 || split.Daemon.Thinking != 1 || split.Daemon.Cached != 11 {
+		t.Fatalf("daemon totals = %+v, want calls=2 input=70 output=7 thinking=1 cached=11", split.Daemon)
+	}
+	if len(split.RecentDaemons) != 1 {
+		t.Fatalf("RecentDaemons len = %d, want 1", len(split.RecentDaemons))
+	}
+	if got := split.RecentDaemons[0].EmID; got != "em-2" {
+		t.Fatalf("newest daemon em_id = %q, want em-2", got)
+	}
+	if got := split.RecentDaemons[0].RunID; got != "run-2" {
+		t.Fatalf("newest daemon run_id = %q, want run-2", got)
+	}
+}
+
+func TestSumTokenLedgerBySourceRecentDaemonsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	lines := []string{
+		`{"ts":"2026-06-19T09:00:00Z","source":"daemon","em_id":"em-1","input":1}`,
+		`{"ts":"2026-06-19T09:01:00Z","source":"daemon","em_id":"em-2","input":1}`,
+		`{"ts":"2026-06-19T09:02:00Z","source":"daemon","em_id":"em-3","input":1}`,
+	}
+	if err := os.WriteFile(ledgerPath, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	split := SumTokenLedgerBySource(ledgerPath, 2)
+	if len(split.RecentDaemons) != 2 {
+		t.Fatalf("RecentDaemons len = %d, want 2 (capped)", len(split.RecentDaemons))
+	}
+	if got := []string{split.RecentDaemons[0].EmID, split.RecentDaemons[1].EmID}; got[0] != "em-3" || got[1] != "em-2" {
+		t.Fatalf("RecentDaemons order = %v, want [em-3 em-2] (newest first)", got)
+	}
+}
+
+func TestSumTokenLedgerBySourceMissingFileIsEmpty(t *testing.T) {
+	split := SumTokenLedgerBySource(filepath.Join(t.TempDir(), "absent.jsonl"), 5)
+	if split.Main.APICalls != 0 || split.Daemon.APICalls != 0 || split.Soul.APICalls != 0 || len(split.RecentDaemons) != 0 {
+		t.Fatalf("missing file should yield empty split, got %+v", split)
+	}
+}

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -27,16 +27,18 @@ type PropsModel struct {
 	height    int
 
 	// Left panel: selected agent
-	selectedDir    string         // working dir of the agent shown on left (defaults to orchDir)
-	selectedTokens fs.TokenTotals // cached token ledger for selected agent
-	selectedStatus fs.AgentStatus // cached .status.json for selected agent
-	agentDirs      []string       // all discovered agent dirs (for picker)
-	agentNodes     []fs.AgentNode // discovered agents (for picker display)
+	selectedDir         string              // working dir of the agent shown on left (defaults to orchDir)
+	selectedTokens      fs.TokenTotals      // cached token ledger for selected agent
+	selectedSourceSplit fs.TokenSourceSplit // cached main/daemon/soul split for selected agent
+	selectedStatus      fs.AgentStatus      // cached .status.json for selected agent
+	agentDirs           []string            // all discovered agent dirs (for picker)
+	agentNodes          []fs.AgentNode      // discovered agents (for picker display)
 
 	// Right panel: dashboard snapshot
-	network    fs.Network
-	tokens     fs.TokenTotals
-	adminStart string // admin agent's started_at timestamp
+	network            fs.Network
+	tokens             fs.TokenTotals
+	networkSourceSplit fs.TokenSourceSplit
+	adminStart         string // admin agent's started_at timestamp
 
 	// AutoRefresh reflects whether the app-level 1s auto-refresh is enabled.
 	// It only drives the footer hint (a "live" badge); the actual reloading is
@@ -60,6 +62,7 @@ type PropsModel struct {
 	detailByProvider   map[string]fs.TokenTotals
 	detailRecent       []fs.LedgerEntry       // selected main agent recent calls (newest first)
 	detailDaemonRecent []fs.DaemonLedgerEntry // all daemon calls, newest first, tagged by run
+	detailSourceSplit  fs.TokenSourceSplit    // main/daemon/soul call+token split for the selected agent
 	detailContextStats fs.ContextStats
 	detailDaemonCounts fs.DaemonCounts
 	detailMCPNames     []string
@@ -79,13 +82,15 @@ func NewPropsModel(baseDir, orchDir, globalDir string) PropsModel {
 }
 
 type propsLoadMsg struct {
-	network        fs.Network
-	tokens         fs.TokenTotals
-	selectedTokens fs.TokenTotals
-	selectedStatus fs.AgentStatus
-	adminStart     string
-	agentDirs      []string
-	agentNodes     []fs.AgentNode
+	network             fs.Network
+	tokens              fs.TokenTotals
+	networkSourceSplit  fs.TokenSourceSplit
+	selectedTokens      fs.TokenTotals
+	selectedSourceSplit fs.TokenSourceSplit
+	selectedStatus      fs.AgentStatus
+	adminStart          string
+	agentDirs           []string
+	agentNodes          []fs.AgentNode
 }
 
 func (m PropsModel) loadData() tea.Msg {
@@ -98,7 +103,10 @@ func (m PropsModel) loadData() tea.Msg {
 		}
 	}
 	totals := fs.AggregateTokens(dirs)
-	selectedTokens := fs.SumTokenLedger(filepath.Join(m.selectedDir, "logs", "token_ledger.jsonl"))
+	networkSourceSplit := fs.AggregateTokenSourceSplit(dirs, 5)
+	selectedLedgerPath := filepath.Join(m.selectedDir, "logs", "token_ledger.jsonl")
+	selectedTokens := fs.SumTokenLedger(selectedLedgerPath)
+	selectedSourceSplit := fs.SumTokenLedgerBySource(selectedLedgerPath, 5)
 	selectedStatus := fs.ReadStatus(m.selectedDir)
 
 	var adminStart string
@@ -116,13 +124,15 @@ func (m PropsModel) loadData() tea.Msg {
 	}
 
 	return propsLoadMsg{
-		network:        net,
-		tokens:         totals,
-		selectedTokens: selectedTokens,
-		selectedStatus: selectedStatus,
-		adminStart:     adminStart,
-		agentDirs:      allDirs,
-		agentNodes:     net.Nodes,
+		network:             net,
+		tokens:              totals,
+		networkSourceSplit:  networkSourceSplit,
+		selectedTokens:      selectedTokens,
+		selectedSourceSplit: selectedSourceSplit,
+		selectedStatus:      selectedStatus,
+		adminStart:          adminStart,
+		agentDirs:           allDirs,
+		agentNodes:          net.Nodes,
 	}
 }
 
@@ -175,7 +185,9 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 	case propsLoadMsg:
 		m.network = msg.network
 		m.tokens = msg.tokens
+		m.networkSourceSplit = msg.networkSourceSplit
 		m.selectedTokens = msg.selectedTokens
+		m.selectedSourceSplit = msg.selectedSourceSplit
 		m.selectedStatus = msg.selectedStatus
 		m.adminStart = msg.adminStart
 		m.agentDirs = msg.agentDirs
@@ -241,6 +253,7 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 func (m *PropsModel) loadDetail() {
 	ledgerPath := filepath.Join(m.selectedDir, "logs", "token_ledger.jsonl")
 	m.detailByProvider, m.detailRecent = fs.SumTokenLedgerByProvider(ledgerPath, detailRecentCalls)
+	m.detailSourceSplit = fs.SumTokenLedgerBySource(ledgerPath, 10)
 	// Daemon calls are scoped to the selected agent's own daemon run dirs
 	// (agentDir/daemons/<run_id>/logs/token_ledger.jsonl), not the whole
 	// network. Missing ledgers render an empty lane.
@@ -295,7 +308,9 @@ func (m PropsModel) updatePicker(msg tea.KeyPressMsg) (PropsModel, tea.Cmd) {
 	case "enter":
 		if m.pickerIdx < len(m.agentNodes) {
 			m.selectedDir = m.agentNodes[m.pickerIdx].WorkingDir
-			m.selectedTokens = fs.SumTokenLedger(filepath.Join(m.selectedDir, "logs", "token_ledger.jsonl"))
+			ledgerPath := filepath.Join(m.selectedDir, "logs", "token_ledger.jsonl")
+			m.selectedTokens = fs.SumTokenLedger(ledgerPath)
+			m.selectedSourceSplit = fs.SumTokenLedgerBySource(ledgerPath, 5)
 			m.selectedStatus = fs.ReadStatus(m.selectedDir)
 		}
 		m.pickerOpen = false
@@ -635,6 +650,9 @@ func (m PropsModel) renderLeft(maxW int) string {
 		}
 		lines = append(lines, "    "+valueStyle.Render(fmt.Sprintf("cached: %s%s", formatComma(m.selectedTokens.Cached), cacheRateStr)))
 		lines = append(lines, "    "+valueStyle.Render(fmt.Sprintf("api_calls: %d", m.selectedTokens.APICalls)))
+		if sourceSplitHasData(m.selectedSourceSplit) {
+			appendSourceSplitSummary(&lines, "    ", m.selectedSourceSplit, valueStyle)
+		}
 	}
 
 	// Admin
@@ -744,6 +762,9 @@ func (m PropsModel) renderRight(maxW int) string {
 	lines = append(lines, "  "+sectionStyle.Render(i18n.T("props.total_api_calls")))
 	lines = append(lines, "")
 	lines = append(lines, "  "+labelStyle.Render("Total: ")+valueStyle.Render(formatComma(m.tokens.APICalls)))
+	if sourceSplitHasData(m.networkSourceSplit) {
+		appendSourceSplitSummary(&lines, "  ", m.networkSourceSplit, valueStyle)
+	}
 
 	// Mail
 	lines = append(lines, "")
@@ -875,6 +896,64 @@ func (m PropsModel) renderDetail() string {
 					valueStyle.Render(tc.Name),
 					formatComma(int64(tc.Calls)),
 					formatComma(int64(tc.Results)),
+				))
+			}
+		}
+		lines = append(lines, "")
+	}
+
+	// Main/daemon source split. Soul is shown separately and excluded from
+	// the main-vs-daemon denominator so reflection cost does not distort
+	// delegation visibility.
+	if calls := sourceSplitCalls(m.detailSourceSplit); calls > 0 || m.detailSourceSplit.Soul.APICalls > 0 {
+		lines = append(lines, "  "+sectionStyle.Render("Main / daemon call split"))
+		lines = append(lines, "")
+		lines = append(lines, "    "+labelStyle.Render("main calls:          ")+
+			valueStyle.Render(formatComma(m.detailSourceSplit.Main.APICalls)))
+		lines = append(lines, "    "+labelStyle.Render("daemon calls:        ")+
+			valueStyle.Render(formatComma(m.detailSourceSplit.Daemon.APICalls)))
+		if calls > 0 {
+			lines = append(lines, "    "+labelStyle.Render("daemon call share:   ")+
+				valueStyle.Render(fmt.Sprintf("%.1f%%", sourceShare(m.detailSourceSplit.Daemon.APICalls, calls))))
+		}
+		mainSpend := sourceTokenSpend(m.detailSourceSplit.Main)
+		daemonSpend := sourceTokenSpend(m.detailSourceSplit.Daemon)
+		spend := mainSpend + daemonSpend
+		lines = append(lines, "    "+labelStyle.Render("main tokens:         ")+
+			valueStyle.Render(formatComma(mainSpend)))
+		lines = append(lines, "    "+labelStyle.Render("daemon tokens:       ")+
+			valueStyle.Render(formatComma(daemonSpend)))
+		if spend > 0 {
+			lines = append(lines, "    "+labelStyle.Render("daemon token share:  ")+
+				valueStyle.Render(fmt.Sprintf("%.1f%%", sourceShare(daemonSpend, spend))))
+		}
+		if m.detailSourceSplit.Soul.APICalls > 0 {
+			lines = append(lines, "    "+labelStyle.Render("soul calls / tokens: ")+
+				valueStyle.Render(fmt.Sprintf("%s / %s",
+					formatComma(m.detailSourceSplit.Soul.APICalls),
+					formatComma(sourceTokenSpend(m.detailSourceSplit.Soul)))))
+		}
+		if len(m.detailSourceSplit.RecentDaemons) > 0 {
+			lines = append(lines, "")
+			lines = append(lines, "    "+labelStyle.Render("recent daemon work:"))
+			for _, e := range m.detailSourceSplit.RecentDaemons {
+				ts := e.TS
+				if len(ts) > 16 {
+					ts = ts[:16]
+				}
+				model := e.Model
+				if model == "" {
+					model = "—"
+				}
+				emID := e.EmID
+				if emID == "" {
+					emID = "daemon"
+				}
+				lines = append(lines, fmt.Sprintf("      %s  %-10s  %-30s  tokens:%s",
+					subtleStyle.Render(ts),
+					labelStyle.Render(emID),
+					valueStyle.Render(truncate(model, 30)),
+					formatComma(e.Input+e.Output+e.Thinking),
 				))
 			}
 		}
@@ -1088,6 +1167,41 @@ func utcOffsetLabel(t time.Time) string {
 // shortTS renders token-ledger timestamps for compact /kanban tables.
 func shortTS(ts string) string {
 	return formatKanbanTimestamp(ts)
+}
+
+func sourceSplitHasData(split fs.TokenSourceSplit) bool {
+	return split.Main.APICalls > 0 || split.Daemon.APICalls > 0 || split.Soul.APICalls > 0
+}
+
+func appendSourceSplitSummary(lines *[]string, prefix string, split fs.TokenSourceSplit, valueStyle lipgloss.Style) {
+	calls := sourceSplitCalls(split)
+	*lines = append(*lines, prefix+valueStyle.Render(fmt.Sprintf("main calls: %s", formatComma(split.Main.APICalls))))
+	*lines = append(*lines, prefix+valueStyle.Render(fmt.Sprintf("daemon calls: %s", formatComma(split.Daemon.APICalls))))
+	if calls > 0 {
+		*lines = append(*lines, prefix+valueStyle.Render(fmt.Sprintf("daemon share: %.1f%% of main+daemon calls", sourceShare(split.Daemon.APICalls, calls))))
+	}
+	*lines = append(*lines, prefix+valueStyle.Render(fmt.Sprintf("main tokens: %s", formatComma(sourceTokenSpend(split.Main)))))
+	*lines = append(*lines, prefix+valueStyle.Render(fmt.Sprintf("daemon tokens: %s", formatComma(sourceTokenSpend(split.Daemon)))))
+	if split.Soul.APICalls > 0 {
+		*lines = append(*lines, prefix+valueStyle.Render(fmt.Sprintf("soul calls / tokens: %s / %s",
+			formatComma(split.Soul.APICalls),
+			formatComma(sourceTokenSpend(split.Soul)))))
+	}
+}
+
+func sourceTokenSpend(t fs.TokenTotals) int64 {
+	return t.Input + t.Output + t.Thinking
+}
+
+func sourceSplitCalls(split fs.TokenSourceSplit) int64 {
+	return split.Main.APICalls + split.Daemon.APICalls
+}
+
+func sourceShare(part, total int64) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return 100.0 * float64(part) / float64(total)
 }
 
 // renderShareBar returns a small unicode bar (filled + empty cells)

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -375,3 +375,122 @@ func TestPropsHeaderShowsCtrlDHint(t *testing.T) {
 		t.Fatalf("View() detail mode should NOT show callout:\n%s", viewDetail)
 	}
 }
+
+func TestPropsRenderSummaryShowsExplicitSourceSplit(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), []byte(`{"agent_name":"alice","address":"alice","state":"ACTIVE","admin":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := PropsModel{
+		selectedDir:    dir,
+		selectedTokens: fs.TokenTotals{Input: 30, Output: 6, Thinking: 4, APICalls: 4},
+		selectedSourceSplit: fs.TokenSourceSplit{
+			Main:   fs.TokenTotals{Input: 10, Output: 2, APICalls: 1},
+			Daemon: fs.TokenTotals{Input: 20, Output: 4, Thinking: 4, APICalls: 2},
+			Soul:   fs.TokenTotals{Input: 3, Output: 1, APICalls: 1},
+		},
+	}
+
+	left := ansi.Strip(m.renderLeft(80))
+	for _, want := range []string{
+		"main calls: 1",
+		"daemon calls: 2",
+		"daemon share: 66.7% of main+daemon calls",
+		"main tokens: 12",
+		"daemon tokens: 28",
+		"soul calls / tokens: 1 / 4",
+	} {
+		if !strings.Contains(left, want) {
+			t.Fatalf("renderLeft missing %q:\n%s", want, left)
+		}
+	}
+
+	m.networkSourceSplit = m.selectedSourceSplit
+	m.tokens = m.selectedTokens
+	right := ansi.Strip(m.renderRight(80))
+	for _, want := range []string{
+		"main calls: 1",
+		"daemon calls: 2",
+		"daemon share: 66.7% of main+daemon calls",
+		"main tokens: 12",
+		"daemon tokens: 28",
+		"soul calls / tokens: 1 / 4",
+	} {
+		if !strings.Contains(right, want) {
+			t.Fatalf("renderRight missing %q:\n%s", want, right)
+		}
+	}
+}
+
+func TestPropsRenderDetailShowsMainDaemonSplit(t *testing.T) {
+	m := PropsModel{
+		detailSourceSplit: fs.TokenSourceSplit{
+			Main: fs.TokenTotals{
+				Input:    100,
+				Output:   20,
+				Thinking: 5,
+				APICalls: 3,
+			},
+			Daemon: fs.TokenTotals{
+				Input:    50,
+				Output:   10,
+				Thinking: 0,
+				APICalls: 2,
+			},
+			Soul: fs.TokenTotals{
+				Input:    7,
+				Output:   1,
+				APICalls: 1,
+			},
+			RecentDaemons: []fs.LedgerEntry{
+				{TS: "2026-06-19T09:05:00Z", Source: "daemon", EmID: "em-2", RunID: "run-2", Model: "daemon-model", Input: 50, Output: 10},
+			},
+		},
+	}
+
+	detail := ansi.Strip(m.renderDetail())
+	for _, want := range []string{
+		"Main / daemon call split",
+		"main calls:",
+		"daemon calls:",
+		"daemon call share:",
+		"main tokens:",
+		"daemon tokens:",
+		"daemon token share:",
+		"soul calls / tokens:",
+		"recent daemon work:",
+		"em-2",
+		"daemon-model",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("renderDetail missing %q:\n%s", want, detail)
+		}
+	}
+
+	// Daemon call share is 2/(3+2) = 40.0%.
+	if !strings.Contains(detail, "40.0%") {
+		t.Fatalf("renderDetail missing daemon call share 40.0%%:\n%s", detail)
+	}
+}
+
+func TestPropsRenderDetailShowsSplitWhenOnlySoul(t *testing.T) {
+	// With no main/daemon calls but non-zero soul, the section still renders
+	// soul, but omits the daemon-only share rows (no division by zero).
+	m := PropsModel{
+		detailSourceSplit: fs.TokenSourceSplit{
+			Soul: fs.TokenTotals{Input: 7, Output: 1, APICalls: 1},
+		},
+	}
+
+	detail := ansi.Strip(m.renderDetail())
+	if !strings.Contains(detail, "Main / daemon call split") {
+		t.Fatalf("renderDetail should show split section for soul-only:\n%s", detail)
+	}
+	if !strings.Contains(detail, "soul calls / tokens:") {
+		t.Fatalf("renderDetail should show soul row:\n%s", detail)
+	}
+	if strings.Contains(detail, "daemon call share:") {
+		t.Fatalf("renderDetail should omit daemon call share when no main/daemon calls:\n%s", detail)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds an observability-only main/daemon token split to `/kanban`.

It reads the existing `logs/token_ledger.jsonl` lines and groups usage by the ledger `source` tag:

- `source=daemon` → delegated daemon work
- `source=soul` → soul/reflection cost, shown separately
- missing/legacy/other sources → main agent work

The `/kanban` summary and detail views now surface:

- main calls
- daemon calls
- daemon share
- main tokens
- daemon tokens
- soul calls/tokens when present
- recent daemon ledger entries in the detail view

## Scope

This is intentionally a small instrumentation PR.

It does **not**:

- change scheduling behavior
- change prompts
- add a new ledger
- claim that main agent API calls have already decreased

It only makes the main-vs-daemon split visible from the ledger the TUI already reads. This gives us a measurable baseline before any later daemon-first task capsule / result contract work.

## Why this shape

The current goal chain is:

1. reduce main-agent API calls by moving more execution work into daemons;
2. use that delegation pattern to improve token efficiency/cache reuse without weakening the main agent's judgment layer.

So this PR is the dashboard step: first make the path visible, then future PRs can change behavior.

Soul calls are kept separate from the main-vs-daemon denominator so reflection cost does not distort the delegation ratio.

## Tests

Run from the `tui` module:

```bash
go test ./internal/fs ./internal/tui
go test ./...
```

Both pass locally.
