### PR TITLE
feat(tui): support Ctrl+R refresh across views

### DIFF
--- a/tui/internal/tui/addon.go
+++ b/tui/internal/tui/addon.go
@@ -58,6 +58,9 @@ func (m AddonModel) Update(msg tea.Msg) (AddonModel, tea.Cmd) {
 		switch msg.String() {
 		case "esc":
 			return m, func() tea.Msg { return AddonSavedMsg{} }
+		case "ctrl+r":
+			m.addonConfigs, m.addonErrors = readAddonConfigs(m.lingtaiDir)
+			return m, nil
 		}
 	}
 	return m, nil

--- a/tui/internal/tui/codex.go
+++ b/tui/internal/tui/codex.go
@@ -70,6 +70,20 @@ func codexTitleFor(agentDir string) string {
 	return fmt.Sprintf("%s — %s", base, name)
 }
 
+// reloadInner rebuilds the knowledge catalog for the selected agent from disk,
+// resetting the inner markdown viewer to the top. Invoked by ctrl+r.
+func (m CodexModel) reloadInner() (CodexModel, tea.Cmd) {
+	entries := buildAgentCodexEntries(m.selectedDir)
+	m.inner = NewMarkdownViewer(entries, codexTitleFor(m.selectedDir))
+	m.inner.FooterHint = i18n.T("hints.props_select")
+	if m.width > 0 && m.height > 0 {
+		var cmd tea.Cmd
+		m.inner, cmd = m.inner.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+		return m, cmd
+	}
+	return m, nil
+}
+
 func (m CodexModel) loadAgents() tea.Msg {
 	net, _ := fs.BuildNetwork(m.baseDir)
 	var nodes []fs.AgentNode
@@ -185,6 +199,8 @@ func (m CodexModel) Update(msg tea.Msg) (CodexModel, tea.Cmd) {
 			return m, cmd
 		}
 		switch msg.String() {
+		case "ctrl+r":
+			return m.reloadInner()
 		case "ctrl+t":
 			if len(m.agentNodes) == 0 {
 				return m, nil

--- a/tui/internal/tui/ctrl_r_refresh_test.go
+++ b/tui/internal/tui/ctrl_r_refresh_test.go
@@ -1,0 +1,163 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// These tests assert the Ctrl+R refresh contract across TUI views:
+//
+//   - Views with reloadable data refresh on Ctrl+R.
+//   - Views that already had a bare-`r` reload on origin/main keep it AND gain
+//     a Ctrl+R alias (no bare-`r` handler is removed or newly introduced).
+//   - Text-editing views keep typing `r` normally and grow no bare-`r` refresh
+//     interception.
+//
+// Ctrl+R is constructed as tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}; its
+// .String() is "ctrl+r" (verified against charm.land/bubbletea/v2). A bare `r`
+// keypress is tea.KeyPressMsg{Code: 'r', Text: "r"} whose .String() is "r".
+
+func ctrlR() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl} }
+func bareR() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 'r', Text: "r"} }
+
+// --- Cmd-returning views: Ctrl+R must trigger a (re)load command. ---
+
+func TestPropsCtrlRTriggersReload(t *testing.T) {
+	m := NewPropsModel(t.TempDir(), t.TempDir(), t.TempDir())
+	_, cmd := m.Update(ctrlR())
+	if cmd == nil {
+		t.Fatal("PropsModel ctrl+r returned nil cmd; expected a reload command")
+	}
+}
+
+func TestMailCtrlRTriggersRefresh(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMailModel(dir, "human@local", dir, dir, "orch", 20, dir, "en", false, 0)
+	_, cmd := m.Update(ctrlR())
+	if cmd == nil {
+		t.Fatal("MailModel ctrl+r returned nil cmd; expected a refresh command")
+	}
+}
+
+func TestDoctorCtrlRRerunsDiagnostic(t *testing.T) {
+	m := NewDoctorModel(t.TempDir(), t.TempDir())
+	// Simulate the diagnostic having finished so loading is false.
+	m.loading = false
+	updated, cmd := m.Update(ctrlR())
+	if cmd == nil {
+		t.Fatal("DoctorModel ctrl+r returned nil cmd; expected a re-run command")
+	}
+	if !updated.loading {
+		t.Fatal("DoctorModel ctrl+r should set loading=true while the diagnostic re-runs")
+	}
+}
+
+// --- Views with an existing bare-`r` reload on origin/main: keep bare `r`,
+//     add ctrl+r alias. No bare-`r` handler is removed. ---
+
+func TestProjectsCtrlRAndBareRBothReload(t *testing.T) {
+	m := NewProjectsModel(t.TempDir(), t.TempDir())
+	if _, cmd := m.Update(ctrlR()); cmd == nil {
+		t.Fatal("ProjectsModel ctrl+r returned nil cmd; expected reload")
+	}
+	if _, cmd := m.Update(bareR()); cmd == nil {
+		t.Fatal("ProjectsModel bare r regressed; the pre-existing bare-r reload must be preserved")
+	}
+}
+
+func TestPresetLibraryCtrlRAndBareRBothReload(t *testing.T) {
+	m := NewPresetLibraryModel("en", t.TempDir())
+	// Both keypresses must be accepted by the list-focus handler without
+	// panicking; bare `r` is the pre-existing reload and ctrl+r is its alias.
+	if _, _ = m.Update(ctrlR()); true {
+	}
+	if _, _ = m.Update(bareR()); true {
+	}
+}
+
+// --- Viewer-wrapping views: Ctrl+R rebuilds the inner viewer from disk. ---
+
+func TestNotificationCtrlRAndBareRReload(t *testing.T) {
+	agentDir := t.TempDir()
+	m := NewNotificationModel(agentDir)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	// Ctrl+R reloads (new alias).
+	if _, _ = m.Update(ctrlR()); true {
+	}
+	// Bare r still reloads (pre-existing handler preserved).
+	if _, _ = m.Update(bareR()); true {
+	}
+	// Both must observe new files written after construction.
+	notifDir := filepath.Join(agentDir, ".notification")
+	if err := os.MkdirAll(notifDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(notifDir, "system.json"), []byte(`{"hello":"world"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, _ := m.Update(ctrlR())
+	if !strings.Contains(reloaded.View(), "system") {
+		t.Fatalf("NotificationModel ctrl+r did not pick up the new notification file; view:\n%s", reloaded.View())
+	}
+}
+
+func TestViewerViewsHandleCtrlRWithoutPanic(t *testing.T) {
+	base := t.TempDir()
+	agent := filepath.Join(base, "agent")
+	if err := os.MkdirAll(agent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("codex", func(t *testing.T) {
+		m := NewCodexModel(base, agent)
+		if _, _ = m.Update(ctrlR()); true {
+		}
+	})
+	t.Run("system", func(t *testing.T) {
+		m := NewSystemModel(base, agent)
+		if _, _ = m.Update(ctrlR()); true {
+		}
+	})
+	t.Run("mailbox", func(t *testing.T) {
+		m := NewMailboxModel(base)
+		if _, _ = m.Update(ctrlR()); true {
+		}
+	})
+	t.Run("library", func(t *testing.T) {
+		m := NewLibraryModel(base, agent, "en")
+		if _, _ = m.Update(ctrlR()); true {
+		}
+	})
+	t.Run("addon", func(t *testing.T) {
+		m := NewAddonModel(base)
+		if _, _ = m.Update(ctrlR()); true {
+		}
+	})
+}
+
+// --- Text-editing views: bare `r` must keep typing; no bare-`r` refresh. ---
+
+// TestPresetEditorBareRTypesNormally drives the editor into inline edit mode and
+// confirms a bare `r` is appended to the field value rather than swallowed by a
+// refresh handler. This guards the requirement that text-editing screens keep
+// `r` typing intact and grow no bare-`r` interception.
+func TestPresetEditorBareRTypesNormally(t *testing.T) {
+	m := NewPresetEditorModel(testPresetEditorPreset(), "en", nil, "")
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	// Open the inline editor on the focused field (feName at cursor 0).
+	updated, _ := m.openInline()
+	m = updated
+	if m.mode != emInline {
+		t.Fatalf("expected inline edit mode after openInline, got %v", m.mode)
+	}
+	before := m.input.Value()
+	m, _ = m.Update(bareR())
+	after := m.input.Value()
+	if after != before+"r" {
+		t.Fatalf("bare r not typed into preset editor field: before=%q after=%q", before, after)
+	}
+}

--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -61,6 +61,12 @@ func NewDoctorModel(orchDir, globalDir string) DoctorModel {
 }
 
 func (m DoctorModel) Init() tea.Cmd {
+	return m.runDoctorCmd()
+}
+
+// runDoctorCmd returns the command that runs the diagnostic. Shared by Init()
+// (initial load) and the ctrl+r refresh handler.
+func (m DoctorModel) runDoctorCmd() tea.Cmd {
 	orchDir := m.orchDir
 	globalDir := m.globalDir
 	return func() tea.Msg {
@@ -77,8 +83,13 @@ func (m DoctorModel) Update(msg tea.Msg) (DoctorModel, tea.Cmd) {
 		m.lines = msg.Lines
 		m.loading = false
 	case tea.KeyPressMsg:
-		if msg.String() == "esc" {
+		switch msg.String() {
+		case "esc":
 			return m, func() tea.Msg { return ViewChangeMsg{View: "mail"} }
+		case "ctrl+r":
+			// Re-run the full diagnostic from scratch.
+			m.loading = true
+			return m, m.runDoctorCmd()
 		}
 	}
 	return m, nil

--- a/tui/internal/tui/help.go
+++ b/tui/internal/tui/help.go
@@ -71,6 +71,16 @@ func NewHelpModel() HelpModel {
 func (m HelpModel) Init() tea.Cmd { return m.inner.Init() }
 
 func (m HelpModel) Update(msg tea.Msg) (HelpModel, tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok && key.String() == "ctrl+r" {
+		width, height := m.inner.width, m.inner.height
+		m.inner = NewMarkdownViewer(buildHelpEntries(), i18n.T("help.title"))
+		if width > 0 && height > 0 {
+			var cmd tea.Cmd
+			m.inner, cmd = m.inner.Update(tea.WindowSizeMsg{Width: width, Height: height})
+			return m, cmd
+		}
+		return m, nil
+	}
 	var cmd tea.Cmd
 	m.inner, cmd = m.inner.Update(msg)
 	return m, cmd

--- a/tui/internal/tui/library.go
+++ b/tui/internal/tui/library.go
@@ -722,6 +722,19 @@ func (m LibraryModel) Init() tea.Cmd {
 	return tea.Batch(m.inner.Init(), m.loadAgents)
 }
 
+func (m LibraryModel) reloadCatalog() (LibraryModel, tea.Cmd) {
+	entries := buildAgentLibraryCatalog(m.selectedDir, m.lang)
+	m.inner = NewMarkdownViewer(entries, libraryTitleFor(m.selectedDir))
+	m.inner.FooterHint = i18n.T("hints.skills_catalog")
+	m.drillIn = nil
+	if m.width > 0 && m.height > 0 {
+		var cmd tea.Cmd
+		m.inner, cmd = m.inner.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+		return m, cmd
+	}
+	return m, nil
+}
+
 const (
 	libraryHeaderLines = 2
 	libraryFooterLines = 2
@@ -827,6 +840,8 @@ func (m LibraryModel) Update(msg tea.Msg) (LibraryModel, tea.Cmd) {
 			return m, cmd
 		}
 		switch msg.String() {
+		case "ctrl+r":
+			return m.reloadCatalog()
 		case "ctrl+t":
 			if len(m.agentNodes) == 0 {
 				// Picker opens even if empty so the user gets a visual cue;

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -778,6 +778,11 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		}
 
 		switch msg.String() {
+		case "ctrl+r":
+			// Refresh the mail thread and agent state from disk. ctrl+r is a
+			// control key, so it does not interfere with typing `r` into the
+			// compose textarea (which falls through to the default branch).
+			return m, m.refreshMail
 		case "ctrl+o":
 			// Cycle: normal → thinking → extended → normal
 			switch m.verbose {

--- a/tui/internal/tui/mailbox.go
+++ b/tui/internal/tui/mailbox.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/anthropics/lingtai-tui/i18n"
@@ -81,6 +81,18 @@ func mailboxOwnerName(agentDir string) string {
 	return name
 }
 
+func (m MailboxModel) reloadInner() (MailboxModel, tea.Cmd) {
+	entries := buildMailboxEntries(m.selectedDir)
+	m.inner = NewMarkdownViewer(entries, mailboxTitleFor(m.selectedDir))
+	m.inner.FooterHint = i18n.T("hints.props_select")
+	if m.width > 0 && m.height > 0 {
+		var cmd tea.Cmd
+		m.inner, cmd = m.inner.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+		return m, cmd
+	}
+	return m, nil
+}
+
 func (m MailboxModel) loadAgents() tea.Msg {
 	net, _ := fs.BuildNetwork(m.baseDir)
 	var nodes []fs.AgentNode
@@ -135,6 +147,8 @@ func (m MailboxModel) Update(msg tea.Msg) (MailboxModel, tea.Cmd) {
 			return m.updatePicker(msg)
 		}
 		switch msg.String() {
+		case "ctrl+r":
+			return m.reloadInner()
 		case "ctrl+t":
 			if len(m.agentNodes) == 0 {
 				return m, nil

--- a/tui/internal/tui/notification.go
+++ b/tui/internal/tui/notification.go
@@ -180,14 +180,14 @@ func NewNotificationModel(agentDir string) NotificationModel {
 
 func newNotificationViewer(agentDir string) MarkdownViewerModel {
 	viewer := NewMarkdownViewer(buildNotificationEntries(agentDir), notificationTitleFor(agentDir))
-	viewer.FooterHint = "r reload"
+	viewer.FooterHint = "ctrl+r reload"
 	return viewer
 }
 
 func (m NotificationModel) Init() tea.Cmd { return m.inner.Init() }
 
 func (m NotificationModel) Update(msg tea.Msg) (NotificationModel, tea.Cmd) {
-	if key, ok := msg.(tea.KeyPressMsg); ok && key.String() == "r" {
+	if key, ok := msg.(tea.KeyPressMsg); ok && (key.String() == "ctrl+r" || key.String() == "r") {
 		width, height := m.inner.width, m.inner.height
 		m.inner = newNotificationViewer(m.agentDir)
 		if width > 0 && height > 0 {

--- a/tui/internal/tui/preset_library.go
+++ b/tui/internal/tui/preset_library.go
@@ -99,9 +99,9 @@ const (
 // PresetLibraryModel is the dedicated screen for browsing and tagging the
 // preset library at ~/.lingtai-tui/presets/.
 type PresetLibraryModel struct {
-	presets []preset.Preset
-	cursor  int
-	lang    string // "en", "zh", or "wen" — drives tier label rendering
+	presets   []preset.Preset
+	cursor    int
+	lang      string // "en", "zh", or "wen" — drives tier label rendering
 	globalDir string // ~/.lingtai-tui — plumbed through to PresetEditorModel
 	// activeRef is the home-shortened path of the currently-active
 	// preset for the agent this view is scoped to (manifest.preset.
@@ -110,10 +110,10 @@ type PresetLibraryModel struct {
 	// the agent's allow-list. Compared against preset.RefFor(p).
 	activeRef string
 
-	focus    presetLibraryFocus
-	tierIdx  int    // selection within the tag picker (0..len(tierValues), last = "untag")
-	saveErr  string // short error from the last save attempt
-	editor   PresetEditorModel // active when focus == presetLibFocusEditor
+	focus   presetLibraryFocus
+	tierIdx int               // selection within the tag picker (0..len(tierValues), last = "untag")
+	saveErr string            // short error from the last save attempt
+	editor  PresetEditorModel // active when focus == presetLibFocusEditor
 
 	width  int
 	height int
@@ -346,8 +346,9 @@ func (m PresetLibraryModel) Update(msg tea.Msg) (PresetLibraryModel, tea.Cmd) {
 			m.focus = presetLibFocusEditor
 			m.saveErr = ""
 			return m, m.editor.Init()
-		case "r":
-			// Reload from disk.
+		case "ctrl+r", "r":
+			// Reload from disk. ctrl+r is the canonical refresh key; bare r
+			// is preserved as the pre-existing alias for this picker view.
 			m.presets, _ = preset.List()
 			if m.cursor >= len(m.presets) {
 				m.cursor = len(m.presets) - 1

--- a/tui/internal/tui/projects.go
+++ b/tui/internal/tui/projects.go
@@ -228,7 +228,9 @@ func (m ProjectsModel) Update(msg tea.Msg) (ProjectsModel, tea.Cmd) {
 				return m, func() tea.Msg { return agoraTabToggleMsg{} }
 			}
 			return m, nil
-		case "r":
+		case "ctrl+r", "r":
+			// ctrl+r is the canonical refresh across views; bare r is kept
+			// as a pre-existing alias for this list-only view.
 			return m, m.loadData
 		default:
 			m.viewport, cmd = m.viewport.Update(msg)

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -173,6 +173,9 @@ func (m PropsModel) Update(msg tea.Msg) (PropsModel, tea.Cmd) {
 				return m, nil
 			}
 			return m, func() tea.Msg { return ViewChangeMsg{View: "mail"} }
+		case "ctrl+r":
+			// Reload the dashboard data (network, tokens, agent status) from disk.
+			return m, m.loadData
 		case "ctrl+t":
 			m.pickerOpen = true
 			for i, n := range m.agentNodes {

--- a/tui/internal/tui/system.go
+++ b/tui/internal/tui/system.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/anthropics/lingtai-tui/i18n"
@@ -181,6 +181,18 @@ func (m SystemModel) Init() tea.Cmd {
 	return tea.Batch(m.inner.Init(), m.loadAgents)
 }
 
+func (m SystemModel) reloadInner() (SystemModel, tea.Cmd) {
+	entries := buildAgentSystemEntries(m.selectedDir)
+	m.inner = NewMarkdownViewer(entries, systemTitleFor(m.selectedDir))
+	m.inner.FooterHint = i18n.T("hints.props_select")
+	if m.width > 0 && m.height > 0 {
+		var cmd tea.Cmd
+		m.inner, cmd = m.inner.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+		return m, cmd
+	}
+	return m, nil
+}
+
 const (
 	systemHeaderLines = 2
 	systemFooterLines = 2
@@ -225,6 +237,8 @@ func (m SystemModel) Update(msg tea.Msg) (SystemModel, tea.Cmd) {
 			return m.updatePicker(msg)
 		}
 		switch msg.String() {
+		case "ctrl+r":
+			return m.reloadInner()
 		case "ctrl+t":
 			if len(m.agentNodes) == 0 {
 				return m, nil


### PR DESCRIPTION
## Summary
- adds a canonical `Ctrl+R` refresh shortcut across TUI views with reloadable data
- preserves the three pre-existing bare-`r` reload handlers (`projects`, `preset_library`, `notification`) while avoiding new bare-`r` shortcuts
- covers the shortcut contract with `internal/tui` tests, including text-editing safety for bare `r`

## Implementation notes
- `Ctrl+R` reloads data/viewer state for mail, props, MCP/addons, doctor, codex, mailbox, library/skills, system, help, projects, presets, notifications, and existing daemon handling.
- Text-editing views keep bare `r` as normal typed input; this PR does not add global bare-`r` interception.
- Existing bare-`r` reloads are retained only where they already existed on `origin/main`.

## Tests
- `cd tui && go test ./internal/tui`
- `cd tui && go test ./...`

## Diff audit
- New refresh shortcut: `ctrl+r`.
- No new bare-`r` handlers were introduced; bare-`r` changes only add Ctrl+R aliases to existing handlers.
