### PR TITLE
fix(tui): show Ctrl+R hint in kanban

### DIFF
--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -361,9 +361,11 @@ func (m PropsModel) View() string {
 
 	var footerLine string
 	if m.detailOpen {
-		footerLine = "  esc " + i18n.T("props.detail_back_to_summary") + scrollHint
+		footerLine = "  ctrl+r reload " + RuneBullet +
+			" esc " + i18n.T("props.detail_back_to_summary") + scrollHint
 	} else {
-		footerLine = "  " + i18n.T("hints.props_off") + " " + RuneBullet +
+		footerLine = "  ctrl+r reload " + RuneBullet +
+			" " + i18n.T("hints.props_off") + " " + RuneBullet +
 			" esc " + i18n.T("manage.back") + " " + RuneBullet +
 			" " + i18n.T("hints.props_select") + " " + RuneBullet +
 			" ctrl+d " + i18n.T("props.detail_open") + scrollHint


### PR DESCRIPTION
## Summary
- show the canonical `ctrl+r reload` hint in the `/kanban` footer
- include the same hint on the Ctrl+D detail view footer so the shortcut is discoverable there too

## Tests
- `cd tui && go test ./internal/tui`

## Notes
This is a small follow-up to #368. The local rebuilt binary has already been updated with this hint for Jason's machine.
