### PR TITLE
fix(tui): preserve setup identity fields

### DIFF
--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -545,6 +545,9 @@ func NewSetupModeModel(baseDir, globalDir, orchDir, orchName string) FirstRunMod
 					// treating the whole file as the inner manifest.
 					inner = existing
 				}
+				if agentName, _ := inner["agent_name"].(string); agentName != "" {
+					m.setupOrchName = agentName
+				}
 				m.setupKeepPreset = preset.Preset{
 					Name:        "keep_current",
 					Description: preset.PresetDescription{Summary: i18n.T("setup.keep_current_preset")},
@@ -1852,6 +1855,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 						CovenantFile:   m.covenantInput.Value(),
 						PrincipleFile:  m.principleInput.Value(),
 						SoulFile:       m.soulFlowInput.Value(),
+						CommentFile:    m.commentInput.Value(),
 						AllowedPresets: m.allowedPresetRefs(),
 					}
 					var selectedAddons []string
@@ -1915,6 +1919,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					CovenantFile:   m.covenantInput.Value(),
 					PrincipleFile:  m.principleInput.Value(),
 					SoulFile:       m.soulFlowInput.Value(),
+					CommentFile:    m.commentInput.Value(),
 					AllowedPresets: m.allowedPresetRefs(),
 					// CommentFile is set by stepRecipe from the chosen recipe
 				}
@@ -3775,7 +3780,9 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 			m.soulFlowInput.SetValue(s)
 			m.soulFlowDirty = true
 		}
-		if s, ok := m.setupKeepInitJSON["comment"].(string); ok {
+		if s, ok := m.setupKeepInitJSON["comment_file"].(string); ok && s != "" {
+			m.commentInput.SetValue(s)
+		} else if s, ok := m.setupKeepInitJSON["comment"].(string); ok {
 			m.commentInput.SetValue(s)
 		}
 	}
@@ -4328,7 +4335,7 @@ func (m FirstRunModel) performSetupSaveOnly() (FirstRunModel, tea.Cmd) {
 		lang = "en"
 	}
 	projectRoot := filepath.Dir(m.baseDir)
-	if commentPath := resolveRecipeComment(projectRoot, lang); commentPath != "" {
+	if commentPath := resolveRecipeComment(projectRoot, lang); m.pendingAgentOpts.CommentFile == "" && commentPath != "" {
 		m.pendingAgentOpts.CommentFile = commentPath
 	}
 	if covenantPath := resolveRecipeCovenant(projectRoot, lang); covenantPath != "" {

--- a/tui/internal/tui/firstrun_test.go
+++ b/tui/internal/tui/firstrun_test.go
@@ -376,6 +376,71 @@ func TestSetupModeDefaultsToKeepCurrentPreset(t *testing.T) {
 	}
 }
 
+func TestSetupModePrefillsAgentNameAndCommentFile(t *testing.T) {
+	baseDir := t.TempDir()
+	globalDir := t.TempDir()
+	orchDir := filepath.Join(baseDir, "manager")
+	if err := os.MkdirAll(orchDir, 0o755); err != nil {
+		t.Fatalf("mkdir orchDir: %v", err)
+	}
+	commentPath := filepath.Join(t.TempDir(), "comment.md")
+	initJSON := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "岩",
+			"language":   "zh",
+		},
+		"comment_file": commentPath,
+		"comment":      "legacy-comment-should-not-win",
+	}
+	data, err := json.Marshal(initJSON)
+	if err != nil {
+		t.Fatalf("marshal init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(orchDir, "init.json"), data, 0o644); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+
+	m := NewSetupModeModel(baseDir, globalDir, orchDir, "manager")
+	m.enterAgentNameDir(m.currentPreset())
+
+	if got := m.nameInput.Value(); got != "岩" {
+		t.Fatalf("setup agent name prefill = %q, want init.json manifest.agent_name", got)
+	}
+	if got := m.commentInput.Value(); got != commentPath {
+		t.Fatalf("setup comment prefill = %q, want comment_file %q", got, commentPath)
+	}
+}
+
+func TestSetupModePrefillsLegacyCommentWhenCommentFileMissing(t *testing.T) {
+	baseDir := t.TempDir()
+	globalDir := t.TempDir()
+	orchDir := filepath.Join(baseDir, "manager")
+	if err := os.MkdirAll(orchDir, 0o755); err != nil {
+		t.Fatalf("mkdir orchDir: %v", err)
+	}
+	initJSON := map[string]interface{}{
+		"manifest": map[string]interface{}{
+			"agent_name": "岩",
+			"language":   "zh",
+		},
+		"comment": "legacy-comment.md",
+	}
+	data, err := json.Marshal(initJSON)
+	if err != nil {
+		t.Fatalf("marshal init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(orchDir, "init.json"), data, 0o644); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+
+	m := NewSetupModeModel(baseDir, globalDir, orchDir, "manager")
+	m.enterAgentNameDir(m.currentPreset())
+
+	if got := m.commentInput.Value(); got != "legacy-comment.md" {
+		t.Fatalf("setup legacy comment prefill = %q", got)
+	}
+}
+
 func TestSetupModeEnterOnKeepCurrentAdvancesToAgentPresets(t *testing.T) {
 	m := FirstRunModel{
 		setupMode: true,


### PR DESCRIPTION
## Summary
- prefill `/setup` agent name from existing `init.json` `manifest.agent_name`
- preserve and prefill `comment_file` through setup save paths, with legacy `comment` fallback
- add regression tests for `/setup` identity/comment prefill behavior

## Tests
- `cd tui && go test ./internal/tui ./internal/preset`

## Context
This prevents `/setup` from making an existing agent appear to lose its configured identity/comment after upgrades, avoiding repeated local hotpatches.
