### PR TITLE
fix(tui): exclude daemon rows from main token ledgers

### DIFF
--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -21,8 +21,8 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 | `ReadStatus(dir)` | `tui/internal/fs/agent.go:303` | reads `.status.json` → `AgentStatus` (tokens, runtime) |
 | `ReadContextStats(dir)` | `tui/internal/fs/agent.go:315` | summarizes retained `history/chat_history.jsonl`: entries, role counts, text input/output, tool calls/results, and per-tool distribution |
 | `AggregateTokens(dirs)` | `tui/internal/fs/agent.go:439` | sums `TokenTotals` across multiple agent ledgers |
-| `SumTokenLedger(path)` | `tui/internal/fs/agent.go:454` | sums a single `token_ledger.jsonl` → `TokenTotals` |
-| `SumTokenLedgerByProvider` | `tui/internal/fs/agent.go:499` | groups ledger entries by derived provider name + recent N entries |
+| `SumTokenLedger(path)` | `tui/internal/fs/agent.go:458` | sums a single main-agent `token_ledger.jsonl` → `TokenTotals`, skipping historical daemon-mirrored rows (`source=daemon`, `em_id`, or `run_id`) |
+| `SumTokenLedgerByProvider` | `tui/internal/fs/agent.go:513` | groups main-agent ledger entries by derived provider name + recent N entries, skipping daemon-mirrored rows so `/kanban` main detail stays separate from daemon detail |
 | **daemon_ledger.go** | | |
 | `DaemonRecentLedger(agentDir, recentN)` | `tui/internal/fs/daemon_ledger.go:41` | aggregates recent per-call token ledgers from `daemons/<run_id>/logs/token_ledger.jsonl`, newest first, tagged with daemon run id/handle/state for kanban Ctrl+D split lanes |
 | `DeriveLedgerProvider` | `tui/internal/fs/agent.go:525` | maps endpoint host / model prefix → canonical provider name |
@@ -77,7 +77,7 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 ## Connections
 
 - **Called by `tui/internal/tui/`** — every Bubble Tea screen reads agent state through this package (network home, agent detail, mail viewer, kanban, session log).
-- **Reads from agent working directories** — `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/*/`, `logs/token_ledger.jsonl`, `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
+- **Reads from agent working directories** — `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/*/`, `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
 - **Writes signal files** (the only agent-owned files the TUI writes): `.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`, `.refresh`/`.refresh.taken`.
 - **Writes human outbox mail** — `WriteMail` for human (pseudo-agent) writes to `human/mailbox/outbox/<mailbox-id>/`.
 - **Calls `ipinfo.io`** — `ResolveLocation` makes an HTTP call; `UpdateHumanLocation` caches result in human's `.agent.json`.
@@ -90,7 +90,7 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 
 ## State
 
-- **Reads (never writes)**: `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/inbox/*`, `mailbox/sent/*`, `logs/token_ledger.jsonl`, `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
+- **Reads (never writes)**: `.agent.json`, `.agent.heartbeat`, `.status.json`, `mailbox/inbox/*`, `mailbox/sent/*`, `logs/token_ledger.jsonl` (main rows only for agent totals/detail), `logs/events.jsonl`, `logs/soul_inquiry.jsonl`, `logs/soul_flow.jsonl`, `delegates/ledger.jsonl`, `mailbox/contacts.json`, `daemons/*/daemon.json`, `daemons/*/logs/token_ledger.jsonl`.
 - **Writes**: signal files (`.sleep`, `.suspend`, `.interrupt`, `.prompt`, `.inquiry`), human `mailbox/outbox/*`, human `.agent.json` location field.
 
 ## Notes

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -451,8 +451,10 @@ func AggregateTokens(dirs []string) TokenTotals {
 	return t
 }
 
-// SumTokenLedger reads a token_ledger.jsonl file and sums all entries.
-// Returns zero totals if the file is missing or unreadable.
+// SumTokenLedger reads a token_ledger.jsonl file and sums main-agent entries.
+// Daemon-sourced rows are skipped because they are reported separately from
+// daemons/<run_id>/logs/token_ledger.jsonl. Returns zero totals if the file is
+// missing or unreadable.
 func SumTokenLedger(path string) TokenTotals {
 	var t TokenTotals
 	data, err := os.ReadFile(path)
@@ -464,13 +466,11 @@ func SumTokenLedger(path string) TokenTotals {
 		if line == "" {
 			continue
 		}
-		var entry struct {
-			Input    int64 `json:"input"`
-			Output   int64 `json:"output"`
-			Thinking int64 `json:"thinking"`
-			Cached   int64 `json:"cached"`
-		}
+		var entry LedgerEntry
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if isDaemonLedgerEntry(entry) {
 			continue
 		}
 		t.Input += entry.Input
@@ -484,8 +484,10 @@ func SumTokenLedger(path string) TokenTotals {
 
 // LedgerEntry is a single per-call line from logs/token_ledger.jsonl
 // surfaced to UI consumers (the kanban detail view, primarily). Older
-// entries written before kernel v0.7.x have no Model/Endpoint — those
-// fields are simply empty.
+// entries written before kernel v0.7.x have no Model/Endpoint/Source — those
+// fields are simply empty. Source/EmID/RunID let readers distinguish parent
+// agent calls from historical daemon rows that were mirrored into parent
+// ledgers.
 type LedgerEntry struct {
 	TS       string `json:"ts"`
 	Input    int64  `json:"input"`
@@ -494,14 +496,18 @@ type LedgerEntry struct {
 	Cached   int64  `json:"cached"`
 	Model    string `json:"model,omitempty"`
 	Endpoint string `json:"endpoint,omitempty"`
+	Source   string `json:"source,omitempty"`
+	EmID     string `json:"em_id,omitempty"`
+	RunID    string `json:"run_id,omitempty"`
 }
 
-// SumTokenLedgerByProvider reads a token_ledger.jsonl, groups entries
-// by derived provider name, and returns the totals plus the most-recent
+// SumTokenLedgerByProvider reads a token_ledger.jsonl, groups main-agent
+// entries by derived provider name, and returns the totals plus the most-recent
 // `recentN` raw entries (newest first). Provider attribution comes from
 // the entry's `endpoint` host when present; falls back to a `model`
 // prefix match; otherwise "unknown".
 //
+// Daemon-sourced rows are skipped here and rendered from daemon run ledgers.
 // Missing/unreadable file returns empty maps and nil entries — caller
 // renders an empty state rather than erroring.
 func SumTokenLedgerByProvider(path string, recentN int) (
@@ -520,6 +526,9 @@ func SumTokenLedgerByProvider(path string, recentN int) (
 		}
 		var entry LedgerEntry
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if isDaemonLedgerEntry(entry) {
 			continue
 		}
 		provider := DeriveLedgerProvider(entry.Endpoint, entry.Model)
@@ -541,6 +550,12 @@ func SumTokenLedgerByProvider(path string, recentN int) (
 		recent[i], recent[j] = recent[j], recent[i]
 	}
 	return byProvider, recent
+}
+
+func isDaemonLedgerEntry(entry LedgerEntry) bool {
+	return strings.EqualFold(strings.TrimSpace(entry.Source), "daemon") ||
+		strings.TrimSpace(entry.EmID) != "" ||
+		strings.TrimSpace(entry.RunID) != ""
 }
 
 // DeriveLedgerProvider maps a ledger entry's endpoint host (or model

--- a/tui/internal/fs/agent_test.go
+++ b/tui/internal/fs/agent_test.go
@@ -369,3 +369,52 @@ func TestReadContextStatsReturnsZeroWhenHistoryMissing(t *testing.T) {
 		t.Fatalf("expected zero tool stats for missing history, got %+v", stats)
 	}
 }
+
+func TestSumTokenLedgerSkipsDaemonRows(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	body := strings.Join([]string{
+		`{"ts":"2026-06-20T03:00:00Z","input":10,"output":2,"thinking":1,"cached":4,"model":"main"}`,
+		`{"source":"daemon","em_id":"em-1","run_id":"em-1-run","ts":"2026-06-20T03:00:01Z","input":100,"output":20,"thinking":10,"cached":40,"model":"daemon"}`,
+		`{"run_id":"em-2-run","ts":"2026-06-20T03:00:02Z","input":200,"output":40,"thinking":20,"cached":80,"model":"daemon-no-source"}`,
+	}, "\n")
+	if err := os.WriteFile(ledgerPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	totals := SumTokenLedger(ledgerPath)
+	if totals.APICalls != 1 || totals.Input != 10 || totals.Output != 2 || totals.Thinking != 1 || totals.Cached != 4 {
+		t.Fatalf("totals = %+v, want only main row", totals)
+	}
+}
+
+func TestSumTokenLedgerByProviderSkipsDaemonRows(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	body := strings.Join([]string{
+		`{"ts":"2026-06-20T03:00:00Z","input":10,"output":2,"cached":4,"model":"gpt-5.5","endpoint":"https://api.openai.com/v1"}`,
+		`{"source":"daemon","em_id":"em-1","run_id":"em-1-run","ts":"2026-06-20T03:00:01Z","input":100,"output":20,"cached":40,"model":"deepseek-v4-pro","endpoint":"https://api.deepseek.com"}`,
+		`{"em_id":"em-2","ts":"2026-06-20T03:00:02Z","input":200,"output":40,"cached":80,"model":"daemon-no-run"}`,
+	}, "\n")
+	if err := os.WriteFile(ledgerPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	byProvider, recent := SumTokenLedgerByProvider(ledgerPath, 100)
+	if len(recent) != 1 {
+		t.Fatalf("recent len = %d, want 1: %#v", len(recent), recent)
+	}
+	if recent[0].Model != "gpt-5.5" {
+		t.Fatalf("recent[0].Model = %q, want gpt-5.5", recent[0].Model)
+	}
+	if len(byProvider) != 1 {
+		t.Fatalf("provider count = %d, want 1: %#v", len(byProvider), byProvider)
+	}
+	openai := byProvider["openai"]
+	if openai.APICalls != 1 || openai.Input != 10 || openai.Output != 2 || openai.Cached != 4 {
+		t.Fatalf("openai totals = %+v, want only main row", openai)
+	}
+	if _, ok := byProvider["deepseek"]; ok {
+		t.Fatalf("daemon deepseek row should be excluded: %#v", byProvider)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `/kanban` Ctrl+D presentation so main-agent totals/provider breakdown/recent main ledger exclude daemon rows mirrored into the parent ledger.
- Keep the on-disk parent `logs/token_ledger.jsonl` semantics unchanged: parent ledgers may legitimately contain daemon rows for total accounting/history.
- Apply filtering only in the TUI fs read/presentation path: rows with `source:"daemon"`, `em_id`, or `run_id` are skipped when reading main-agent ledger views.
- Keep daemon detail sourced from `daemons/<run_id>/logs/token_ledger.jsonl`, so daemon usage remains visible in the daemon ledger section and is not lost.
- Add regression tests for main totals and provider/recent detail filtering, plus fs anatomy notes.

## Reproduction
Jason reported `/kanban` → Ctrl+D still showed daemon-looking rows in the main ledger for `/Users/huangzesen/work/projects/lingtai-dev/dev-1/.lingtai`.
Local inspection found daemon-marked rows inside parent ledgers:
- `file-search-scout/logs/token_ledger.jsonl`: 234 rows, 106 rows with `source:"daemon"`, `em_id`, or `run_id`
- `mimo-1/logs/token_ledger.jsonl`: 27100 rows, 4636 rows with `source:"daemon"`, `em_id`, or `run_id`
Those rows also exist under daemon run ledgers, so the TUI must separate them while rendering main vs daemon sections.

## Tests
- `cd tui && go test ./internal/fs ./internal/tui ./internal/config ./i18n`
- `cd tui && go test ./...`

## Local validation
- Built a local `lingtai-tui` from this branch plus the temporary local v38 migration compatibility patch.
- Installed it at `/opt/homebrew/bin/lingtai-tui` and verified `lingtai-tui list` from `/Users/huangzesen/work/projects/lingtai-dev/dev-1`.

## Notes
- This does **not** change ledger writing or the parent-ledger accounting model.
- No merge requested without maintainer confirmation.