### PR TITLE
docs: add runtime refresh verification lessons

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -8,7 +8,7 @@ description: >
   publication-bound release workflow, run a runtime self-check, get a PR
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
-version: 2.4.0
+version: 2.4.1
 ---
 
 # LingTai Developer Guide
@@ -96,8 +96,9 @@ drill-down files, not standalone top-level skills.
     Developer/operator runtime self-check after refresh/checkout/preset/MCP
     change: probe which lingtai code is running, confirm editable source and git
     HEAD, verify the active TUI/portal binary and dev-mode symlinks, rebuild from
-    a clean worktree, inspect MCP/addon sources, and report evidence with secrets
-    redacted.
+    a clean worktree, inspect MCP/addon sources, confirm long-lived runtime
+    objects (services/adapters/caches) actually rebuilt after refresh rather than
+    serving stale behaviour, and report evidence with secrets redacted.
 - name: dev-guide-pr-review-deliverables
   location: reference/pr-review-deliverables/SKILL.md
   description: |
@@ -128,7 +129,7 @@ drill-down files, not standalone top-level skills.
 | Diagnose a stuck, errored, or misbehaving LingTai network | `reference/debug-troubleshoot/SKILL.md` |
 | Audit secrets, permissions, MCP config, channels, or data exposure | `reference/security-audit/SKILL.md` |
 | Operate an avatar network over time | `reference/network-governance/SKILL.md` |
-| Verify which runtime/binary is actually running after a refresh or rebuild | `reference/runtime-self-check/SKILL.md` |
+| Verify which runtime/binary is actually running after a refresh or rebuild, or why a fix that's on disk still serves stale behaviour (a long-lived service/adapter/cache that didn't rebuild) | `reference/runtime-self-check/SKILL.md` |
 | Get a PR review-ready: review gates, HTML explainer, PR hygiene | `reference/pr-review-deliverables/SKILL.md` |
 | Turn experience into a durable, de-privatized, PR-ready skill | `reference/skill-stewardship/SKILL.md` |
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: dev-guide-gotchas
 description: >
-  Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, dev-mode rebuilds, editable installs, migrations, localization, authorization gates, and config conventions.
-version: 1.0.0
+  Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, dev-mode rebuilds, editable installs, migrations, localization, authorization gates, config conventions, and rebuild-gate test false-passes.
+version: 1.1.0
 ---
 
 # Gotchas and Known Pitfalls
@@ -172,6 +172,28 @@ The Go module names are `github.com/anthropics/lingtai-tui` and `github.com/anth
 ## Notifications — single-slot wire invariant
 
 At most ONE `system(action="notification")` pair lives in the wire history at any time. When the kernel detects a fingerprint change, it strips the prior pair and reinjects a fresh one. Agents observe the **current** notification state, not a history of arrivals.
+
+## Rebuild-gate test can false-pass on incidental bucket changes
+
+A service/adapter that rebuilds only when a coarse "bucket" of inputs changes
+(e.g. provider / model / base_url / provider-defaults) is hard to test honestly.
+A regression test that asserts "refresh rebuilds the service" can **pass for the
+wrong reason**: if the test fixture also perturbs an unrelated field that feeds
+the same bucket (`max_rpm`, some provider-default), the rebuild fires off that
+incidental change — not the condition under test. The test goes green while the
+real code path it was meant to protect is still broken.
+
+This surfaced while verifying the Codex prompt-cache refresh fix (PRs #406/#411):
+the rebuild gate is bucket-based, so a test must hold the bucket fixed except for
+the *one* condition it is exercising.
+
+**Discipline:** when testing a bucket-gated rebuild, vary only the field under
+test and pin everything else in the bucket. Assert on the *effect* the rebuild is
+supposed to produce (the live object was reconstructed; the expected metadata/
+fingerprint changed), not merely that "a rebuild happened" — otherwise an
+incidental bucket delta gives you a false-pass. See
+`reference/runtime-self-check/SKILL.md` §6 for the live-object verification side
+of the same problem.
 
 ## `uv` vs `pip`
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -6,8 +6,10 @@ description: >
   actually running, confirm the editable source and git HEAD, verify the active
   TUI/portal binary and dev-mode symlinks, rebuild the TUI from a clean release
   worktree, inspect MCP/addon module sources and tool surface, and report
-  evidence safely with secrets redacted.
-version: 1.0.0
+  evidence safely with secrets redacted. Includes verifying that long-lived
+  runtime objects (services/adapters/caches) were actually rebuilt after a
+  refresh, not just that new source is imported.
+version: 1.1.0
 ---
 
 # Runtime Self-Check
@@ -35,6 +37,8 @@ parameterized forms (`<your-lingtai-checkout>`, `~/.lingtai-tui/...`).
 - Right after a `refresh` — verify the runtime picked up the intended code.
 - After switching branches/worktrees or reinstalling the kernel editable.
 - A code fix is merged/built but old behaviour persists ("did it actually load?").
+- A fix is imported but a long-lived service/adapter/cache still serves stale
+  behaviour after `refresh` — source-on-disk ≠ rebuilt-at-runtime (see §6).
 - A preset swap, MCP boot failure, or addon change needs source-of-truth checks.
 - You must report runtime state to a maintainer and want a safe evidence pack.
 
@@ -159,9 +163,47 @@ After a `refresh`, walk this list before trusting new behaviour:
 - [ ] §2 active binary resolves to the expected path; version string matches dev/brew expectation.
 - [ ] §3 if a fix should be live, the relevant binary/kernel was actually rebuilt/reinstalled.
 - [ ] §4 MCP/addon modules import from the expected source; tool surface present.
+- [ ] §6 if a fix "should be live" but behaviour disagrees, the runtime object was actually rebuilt — verified via metadata/fingerprint, not just the import probe.
 - [ ] No secrets, tokens, chat IDs, or private absolute paths captured for the report.
 
-## 6. Safe evidence reporting
+## 6. Live object/adapter lifecycle — source-on-disk ≠ rebuilt-at-runtime
+
+The §1–§2 probes confirm the right *files* are imported. They do **not** prove
+the long-lived runtime *objects* built from those files were rebuilt after a
+`refresh`. A service or adapter constructed once at agent init can survive
+refreshes if the inputs that gate its rebuild did not change — so new source can
+be on disk and imported, yet the live agent still serves a stale object.
+
+This bit the Codex prompt-cache work (PRs #406/#411). The affinity/cache source
+was present and imported, but after a live `refresh` the token ledger still
+showed the old stable id with no `prompt_cache_key` and no rotation. Root cause:
+the agent only rebuilt its `LLMService` when a coarse rebuild-gate bucket
+(provider/model/base_url/provider-defaults) changed; that bucket was stable
+across refresh for this provider, so the old service and its cached adapter
+outlived the refresh. The fix forced a service/adapter rebuild on the relevant
+live refresh while preserving chat-history replay.
+
+The reusable lesson: **when a fix "should be live" but behaviour disagrees,
+grepping or importing the source is not evidence — verify the runtime object.**
+
+- Identify what gates the rebuild of the object in question (a service, adapter,
+  client, or cache). Confirm that gate actually changes when the fix is supposed
+  to take effect — a rebuild that depends on an input stable across refresh will
+  silently never fire.
+- Verify object *identity/lifecycle*, not just presence: was the adapter
+  re-constructed, or is the same instance still alive from agent init?
+- Check the observable metadata the fix is supposed to produce. For cache work
+  that means the token ledger: is `codex_prompt_cache_key` (or the equivalent
+  field) **non-empty**, and does the stable id rotate when it should?
+- Where you can compute a fingerprint, compare before/after concretely — e.g. an
+  old `sha256(anchor)[:8]`-style id versus an epoch-stamped one — rather than
+  trusting "the code looks right."
+
+If the metadata or fingerprint still reflects the old behaviour after refresh,
+the object was not rebuilt regardless of what the import probe says; that is the
+bug, not a red herring.
+
+## 7. Safe evidence reporting
 
 When reporting runtime state to a maintainer, produce a compact, source-labeled
 evidence pack. Recommended shape:


### PR DESCRIPTION
## Summary
- add a runtime self-check lesson for live object/adapter lifecycle: source-on-disk and import path are not enough when services/adapters survive refresh
- document the #406/#411 Codex cache-affinity case as a reusable verification checklist: rebuild gate, runtime object lifecycle, ledger metadata, and stable fingerprints
- add a gotcha about rebuild-gate tests false-passing when incidental provider-default bucket fields change

## Validation
- `git diff --check origin/main...HEAD`
- Python YAML frontmatter parse for the touched skill files
- private-leakage scan for obvious runtime/private terms (`/Users/`, `.lingtai/`, Telegram, agent names, token/event log filenames, API-key-like terms)

## Notes
- This is a small docs-only PR for `lingtai-dev-guide`, requested after the Codex cache-affinity refresh investigation.
