### PR TITLE
Resolve migration version collision

### DIFF
--- a/portal/internal/migrate/ANATOMY.md
+++ b/portal/internal/migrate/ANATOMY.md
@@ -9,7 +9,7 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 ## Components
 
 ### Registry (`migrate.go`)
-- `CurrentVersion` (`migrate.go:11`) — `36`. Must match the TUI's `CurrentVersion` exactly; the cross-binary contract requires lockstep bumps.
+- `CurrentVersion` (`migrate.go:11`) — `39`. Must match the TUI's `CurrentVersion` exactly; the cross-binary contract requires lockstep bumps.
 - `metaFile` struct (`migrate.go:13-15`) — `{"version": N}` shape of `.lingtai/meta.json`.
 - `Migration` type (`migrate.go:18-22`) — version + name + function.
 - `migrations` slice (`migrate.go:25-61`) — the append-only ordered list of all 36 migrations. **Real** entries have a named migration function; **no-op stubs** use `func(_ string) error { return nil }`.
@@ -28,11 +28,15 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 - **m030** — `preset-dir-split` — rewrites flat `presets/` paths to `templates/` or `saved/` subdirs (shared).
 - **m031** — `drop-legacy-intrinsic-capabilities` — drops `psyche`/`email` from `init.json` (shared).
 - **m035** — `remove-brief` (`m035_remove_brief.go:13`). Portal mirror of the TUI's brief-cleanup migration: deletes `system/brief.md` for each agent, drops `brief`/`brief_file` from `init.json`, and drops `brief` from `human/settings.json`. Touches shared on-disk state — either binary may be the first to open a post-secretary-removal project, so identical logic lives in both packages.
+- **m038** — `agent-init-skills-paths` (`m038_agent_init_skills_paths.go`). Restores missing `skills.paths` in per-agent `init.json` files hit by the preset editor model-switch bug (PR #312). Shared on-disk state — whichever binary migrates first must repair.
+- **m039** — `agent-init-context-preset-repair` (`m039_agent_init_context_preset_repair.go`). Combined catch-up: (1) calls `migrateAgentInitSkillsPaths` idempotently, then (2) copies legacy root `manifest.context_limit` into `manifest.llm.context_limit`, and (3) rewrites stale codex.json preset refs. The dual call ensures projects stamped at v38 by either old branch binary receive both repairs. See "Versions 38 and 39 — collision history" below.
+
+**Versions 38 and 39 — collision history.** PR #340 (`docs/guide-custom-preset-tutorial`) and PR #357 (`fix/agent-init-context-preset-migration-20260615`) independently claimed migration version 38. The collision was discovered when a project migrated by one branch binary got `data version 38 is newer than this binary supports (37)` after returning to origin/main. Resolution in `fix/migration-version-collision-20260620`: PR #340's repair (skills-paths) takes v38; PR #357's repair (context/preset) takes v39. m039 calls m038's function idempotently first, so any project previously stamped at v38 by either old binary still receives both repairs. See `tui/internal/migrate/ANATOMY.md` for the canonical version and the collision-recovery pattern note.
 
 ### No-op stubs (preserve version slots)
-m005 (`soul-inquiry-source`), m007 (`normalize-ledger`), m008 (`recipe-state`), m009 (`procedures`), m010 (`legacy-addons-warn`), m011 (`session-backfill`), m012 (`session-resort`), m013 (`agora-rename`), m014 (`skills-groups`), m016 (`rename-pad-codex-library`), m017 (`rename-preset-caps`), m018 (`library-split`), m019 (`procedures-english-only`), m020 (`pseudo-agent-subscriptions`), m021 (`library-paths`), m022 (`recipe-lang-suffix`), m023 (`recipe-state-rename`), m024 (`add-active-preset`), m025 (`preset-description-object`), m032 (`cleanup-codex-oauth`), m033 (`strip-codex-api-key-env`), m034 (`library-skills-caps`). m036 (`sqlite-log-backfill`). (m035 is real — listed above.)
+m005 (`soul-inquiry-source`), m007 (`normalize-ledger`), m008 (`recipe-state`), m009 (`procedures`), m010 (`legacy-addons-warn`), m011 (`session-backfill`), m012 (`session-resort`), m013 (`agora-rename`), m014 (`skills-groups`), m016 (`rename-pad-codex-library`), m017 (`rename-preset-caps`), m018 (`library-split`), m019 (`procedures-english-only`), m020 (`pseudo-agent-subscriptions`), m021 (`library-paths`), m022 (`recipe-lang-suffix`), m023 (`recipe-state-rename`), m024 (`add-active-preset`), m025 (`preset-description-object`), m032 (`cleanup-codex-oauth`), m033 (`strip-codex-api-key-env`), m034 (`library-skills-caps`), m036 (`sqlite-log-backfill`), m037 (`preset-skills-paths`). (m035, m038, m039 are real — listed above.)
 
-All are `TUI-only` — they touch `.tui-asset/`, global preset files, the TUI's saved-preset directory, or TUI-side capability aliases. The portal doesn't care about these but must hold the version slot so `meta.json` version numbers match.
+All stubs are `TUI-only` — they touch `.tui-asset/`, global preset files, the TUI's saved-preset directory, or TUI-side capability aliases. The portal doesn't care about these but must hold the version slot so `meta.json` version numbers match.
 
 ### Core functions
 - `StampCurrent(lingtaiDir)` (`migrate.go:60-78`) — writes `meta.json` at `CurrentVersion` without running migrations. Used for fresh projects.
@@ -60,3 +64,4 @@ All are `TUI-only` — they touch `.tui-asset/`, global preset files, the TUI's 
 - **Lockstep bumps.** After any migration bump, rebuild both binaries: `(cd tui && make build) && (cd portal && make build)`. A stale portal binary against a freshly-migrated project fails with the same "newer than this binary supports" error.
 - **m002 (`tape-normalize`) is a historical no-op.** It was real in an earlier portal version but its work is now done by `ReconstructTape` in `portal/internal/fs/reconstruct.go` at startup. The version slot is preserved; the function body is `return nil`.
 - **No-op stubs are documented inline** in the registry (`migrate.go:25-59`) with TUI-only comments. Adding a new stub should follow the same pattern: version, name, explicit `Fn: func(_ string) error { return nil }`, and a `// TUI-only:` comment.
+- **Collision-recovery pattern.** When two branches claim the same version and one has already migrated a real project, assign the earlier repair to the lower claimed version and add a combined catch-up at the next free slot. The catch-up calls the earlier function idempotently first, then applies its own logic. See m039 and `tui/internal/migrate/ANATOMY.md` for the canonical example and rule.

--- a/portal/internal/migrate/collision_repair_test.go
+++ b/portal/internal/migrate/collision_repair_test.go
@@ -1,0 +1,196 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestPortalCollision_From37_GetsBothRepairs proves a project at v37 receives
+// both m038 (skills-paths) and m039 (context-preset repair) and ends at 39.
+func TestPortalCollision_From37_GetsBothRepairs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAgentInitPortal(t, lingtaiDir, "agent1", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "capabilities": {"skills": {"library_limit": 10}},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	writeMeta(t, lingtaiDir, 37)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	meta := readMeta(t, lingtaiDir)
+	if meta.Version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", meta.Version, CurrentVersion)
+	}
+
+	initPath := filepath.Join(lingtaiDir, "agent1", "init.json")
+	skills := readAgentSkillsPortal(t, initPath)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+	manifest := readManifestPortal(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("preset.active = %#v, want %q", got, want)
+	}
+}
+
+// TestPortalCollision_AlreadyAt38_SkillsPathsBranch simulates a project stamped
+// at v38 by the PR #340 binary; the new binary must apply m039 (which includes
+// both skills-paths idempotent + context-preset repair).
+func TestPortalCollision_AlreadyAt38_SkillsPathsBranch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAgentInitPortal(t, lingtaiDir, "agent1", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "capabilities": {
+      "skills": {"paths": ["../.library_shared", "~/.lingtai-tui/utilities"]}
+    },
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	writeMeta(t, lingtaiDir, 38)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	meta := readMeta(t, lingtaiDir)
+	if meta.Version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", meta.Version, CurrentVersion)
+	}
+
+	initPath := filepath.Join(lingtaiDir, "agent1", "init.json")
+	manifest := readManifestPortal(t, initPath)
+
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("preset.active = %#v, want %q", got, want)
+	}
+	skills := readAgentSkillsPortal(t, initPath)
+	wantPaths := []interface{}{"../.library_shared", "~/.lingtai-tui/utilities"}
+	if !reflect.DeepEqual(skills["paths"], wantPaths) {
+		t.Fatalf("skills.paths damaged: %#v", skills["paths"])
+	}
+}
+
+// TestPortalCollision_AlreadyAt38_ContextPresetBranch simulates a project stamped
+// at v38 by the PR #357 binary; the new binary must apply m039 (which calls
+// skills-paths idempotent first, then no-ops the already-done preset repair).
+func TestPortalCollision_AlreadyAt38_ContextPresetBranch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	replacement := filepath.Join(savedDir, "codex-gpt5.5.json")
+	if err := os.WriteFile(replacement, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAgentInitPortal(t, lingtaiDir, "agent1", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "capabilities": {"bash": {"yolo": true}},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+      "default": "~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex-gpt5.5.json"]
+    }
+  }
+}`)
+
+	writeMeta(t, lingtaiDir, 38)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	meta := readMeta(t, lingtaiDir)
+	if meta.Version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", meta.Version, CurrentVersion)
+	}
+
+	initPath := filepath.Join(lingtaiDir, "agent1", "init.json")
+
+	skills := readAgentSkillsPortal(t, initPath)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+	manifest := readManifestPortal(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("preset.active = %#v, want %q", got, want)
+	}
+}

--- a/portal/internal/migrate/m038_agent_init_skills_paths.go
+++ b/portal/internal/migrate/m038_agent_init_skills_paths.go
@@ -1,0 +1,118 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var defaultPresetSkillsPaths = []interface{}{
+	"../.library_shared",
+	"~/.lingtai-tui/utilities",
+}
+
+// migrateAgentInitSkillsPaths is the portal copy of TUI m038 (see
+// tui/internal/migrate/m038_agent_init_skills_paths.go — keep the logic
+// identical). Agents materialized while the preset editor model-switch bug
+// (PR #312) was live carry damaged init.json: a manifest.capabilities map
+// whose skills entry lost its paths kwarg (or the skills entry — or the
+// whole capabilities map — outright).
+//
+// This repair touches shared on-disk state, so whichever binary migrates
+// the project first must perform it: a no-op stub here would let a
+// portal-first launch stamp meta.json at 38 and silently skip the TUI's
+// repair forever.
+//
+// Walks every agent directory under the project's .lingtai/ dir and adds
+// the default skills paths where missing:
+//
+//   - existing skills.paths values are preserved exactly
+//   - other skills config and other capability entries are untouched
+//   - a missing manifest.capabilities map is created
+//   - a non-map manifest.capabilities (or manifest) means skip that file
+//
+// Best-effort: malformed init.json is logged to stderr and skipped; a single
+// broken agent must not stall the migration.
+func migrateAgentInitSkillsPaths(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		patchAgentInitSkillsPathsFile(filepath.Join(lingtaiDir, name, "init.json"))
+	}
+	return nil
+}
+
+func patchAgentInitSkillsPathsFile(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // dirs without init.json are not agents
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: skipping %s — unparseable init.json: %v\n", path, err)
+		return
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		if _, exists := manifest["capabilities"]; exists {
+			return // non-map capabilities: not a shape we understand, leave alone
+		}
+		caps = map[string]interface{}{}
+		manifest["capabilities"] = caps
+	}
+	if !patchPresetSkillsPathsMap(caps) {
+		return
+	}
+	updated, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "m038: marshal failed for %s: %v\n", path, err)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, updated, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: write tmp failed for %s: %v\n", path, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: rename failed for %s: %v\n", path, err)
+		_ = os.Remove(tmp)
+	}
+}
+
+// patchPresetSkillsPathsMap ensures caps has a skills entry with a paths kwarg,
+// without touching any existing paths value or sibling config. Reports whether
+// caps changed.
+func patchPresetSkillsPathsMap(caps map[string]interface{}) bool {
+	skillsRaw, hasSkills := caps["skills"]
+	if !hasSkills {
+		caps["skills"] = map[string]interface{}{"paths": append([]interface{}{}, defaultPresetSkillsPaths...)}
+		return true
+	}
+	skillsCfg, ok := skillsRaw.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if _, hasPaths := skillsCfg["paths"]; hasPaths {
+		return false
+	}
+	skillsCfg["paths"] = append([]interface{}{}, defaultPresetSkillsPaths...)
+	return true
+}

--- a/portal/internal/migrate/m038_agent_init_skills_paths_test.go
+++ b/portal/internal/migrate/m038_agent_init_skills_paths_test.go
@@ -1,0 +1,184 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeAgentInitPortal writes an agent init.json under <lingtaiDir>/<name>/init.json.
+// Named with a suffix to avoid collision with any future TUI-ported helper.
+func writeAgentInitPortal(t *testing.T, lingtaiDir, name, body string) string {
+	t.Helper()
+	dir := filepath.Join(lingtaiDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	p := filepath.Join(dir, "init.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func readAgentSkillsPortal(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("patched init.json is not valid json: %v\n%s", err, data)
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing or not a map: %s", data)
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("capabilities missing or not a map: %s", data)
+	}
+	skills, ok := caps["skills"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("skills missing or not a map: %s", data)
+	}
+	return skills
+}
+
+func readManifestPortal(t *testing.T, initPath string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", initPath, err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", initPath, err, data)
+	}
+	manifest, ok := m["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing in %s", initPath)
+	}
+	return manifest
+}
+
+func toStringSlicePortal(t *testing.T, raw interface{}) []string {
+	t.Helper()
+	items, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("allowed is %T, want []interface{}", raw)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("allowed entry is %T, want string", item)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func TestPortalM038_PatchesMultipleAgents(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	orch := writeAgentInitPortal(t, lingtaiDir, "orch",
+		`{"manifest":{"capabilities":{"skills":{"library_limit":42},"web_search":{"provider":"zhipu"}}}}`)
+	scout := writeAgentInitPortal(t, lingtaiDir, "scout",
+		`{"manifest":{"capabilities":{"bash":{"yolo":true}}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	orchSkills := readAgentSkillsPortal(t, orch)
+	if !reflect.DeepEqual(orchSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("orch skills.paths = %#v, want %#v", orchSkills["paths"], defaultPresetSkillsPaths)
+	}
+	if got := orchSkills["library_limit"]; got != float64(42) {
+		t.Fatalf("orch existing skills config overwritten: %#v", orchSkills)
+	}
+
+	scoutSkills := readAgentSkillsPortal(t, scout)
+	if !reflect.DeepEqual(scoutSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("scout skills.paths = %#v, want %#v", scoutSkills["paths"], defaultPresetSkillsPaths)
+	}
+
+	data, _ := os.ReadFile(orch)
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	caps := doc["manifest"].(map[string]interface{})["capabilities"].(map[string]interface{})
+	ws, ok := caps["web_search"].(map[string]interface{})
+	if !ok || ws["provider"] != "zhipu" {
+		t.Fatalf("web_search entry damaged: %#v", caps["web_search"])
+	}
+}
+
+func TestPortalM038_CreatesMissingCapabilitiesMap(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	path := writeAgentInitPortal(t, lingtaiDir, "orch", `{"manifest":{"llm":{"provider":"custom"}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := readAgentSkillsPortal(t, path)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+}
+
+func TestPortalM038_PreservesCustomPaths(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	content := `{"manifest":{"capabilities":{"skills":{"paths":["./custom-skills"]}}}}`
+	path := writeAgentInitPortal(t, lingtaiDir, "orch", content)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Fatalf("init.json with custom paths was rewritten: %s", data)
+	}
+}
+
+func TestPortalM038_SkipsMalformedAndNonMapCases(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	malformed := writeAgentInitPortal(t, lingtaiDir, "broken", `{"manifest":`)
+	nonMapCaps := writeAgentInitPortal(t, lingtaiDir, "weird-caps",
+		`{"manifest":{"capabilities":["skills"]}}`)
+	good := writeAgentInitPortal(t, lingtaiDir, "zz-good", `{"manifest":{"capabilities":{}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, path := range map[string]string{
+		"malformed": malformed, "non-map capabilities": nonMapCaps,
+	} {
+		before := map[string]string{
+			"malformed":            `{"manifest":`,
+			"non-map capabilities": `{"manifest":{"capabilities":["skills"]}}`,
+		}[name]
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != before {
+			t.Fatalf("%s init.json should be unchanged, got: %s", name, data)
+		}
+	}
+
+	skills := readAgentSkillsPortal(t, good)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("valid sibling not patched: %#v", skills["paths"])
+	}
+}

--- a/portal/internal/migrate/m039_agent_init_context_preset_repair.go
+++ b/portal/internal/migrate/m039_agent_init_context_preset_repair.go
@@ -1,0 +1,238 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// staleCodexRef is the legacy saved-preset ref that no longer resolves on
+// machines whose codex preset was renamed. legacyCodexReplacement is the file
+// that supersedes it when present.
+const (
+	staleCodexRef          = "~/.lingtai-tui/presets/saved/codex.json"
+	legacyCodexReplacement = "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+)
+
+// migrateAgentInitContextPresetRepair is the portal copy of TUI m039 (see
+// tui/internal/migrate/m039_agent_init_context_preset_repair.go — keep logic
+// in sync). Repairs already-created agent init.json files so legacy agents
+// stop dying in refresh/relaunch loops.
+//
+// Two independent defects are healed, both observed in the same incident:
+//
+//  1. Legacy root context limit. Older init.json carried the context window
+//     as manifest.context_limit at the manifest root, before the canonical
+//     home moved to manifest.llm.context_limit. An agent with the root value
+//     but no llm value refreshes into a relaunch-dead loop. When the root
+//     value is present and llm.context_limit is absent, copy it down. The
+//     root key is preserved for backward compatibility — this migration does
+//     not introduce a hard failure and does not strip it. When both exist and
+//     conflict, the canonical manifest.llm.context_limit wins and is never
+//     overwritten.
+//
+//  2. Stale saved-preset pointer. The incident agent's preset active/default/
+//     allowed pointed at ~/.lingtai-tui/presets/saved/codex.json, which had
+//     been renamed to codex-gpt5.5.json. When the stale ref is present, or
+//     active/default point at another missing preset, and the replacement file
+//     exists on disk, active/default are rewritten and the allowed list gains
+//     the replacement while dropping the stale entry.
+//     Unrelated allowed entries that resolve to existing files are preserved.
+//
+// Version numbering note: this repair was originally authored as m038 in
+// PR #357 (fix/agent-init-context-preset-migration-20260615). PR #340
+// (docs/guide-custom-preset-tutorial) independently also claimed v38 for
+// migrateAgentInitSkillsPaths. The collision was resolved in
+// fix/migration-version-collision-20260620: skills-paths takes v38 and this
+// repair takes v39.
+//
+// Catch-up design: m039 intentionally calls migrateAgentInitSkillsPaths
+// first (idempotent) so that a project previously stamped at v38 by the PR
+// #357 binary (which ran only the context/preset repair, skipping m038 by
+// version) still receives both repairs when upgraded to this binary.
+// Similarly, a project stamped at v38 by the PR #340 binary (which ran only
+// skills-paths, skipping the context/preset repair) skips m038 (already at
+// v38) but gets both via m039's combined call.
+//
+// Best-effort and idempotent: a single broken init.json logs to stderr and
+// the migration continues. Files are only rewritten when something actually
+// changed. Atomic temp+rename writes match the surrounding migration style.
+func migrateAgentInitContextPresetRepair(lingtaiDir string) error {
+	// Apply skills-paths repair first (idempotent — no-ops if already done by m038).
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		return err
+	}
+	return migrateAgentInitContextPresetRepairOnly(lingtaiDir)
+}
+
+// migrateAgentInitContextPresetRepairOnly is the context/preset half of m039.
+// It is split out so the combined m039 entry point can call skills-paths first
+// without creating a recursive or indirect call cycle.
+func migrateAgentInitContextPresetRepairOnly(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		agentDir := filepath.Join(lingtaiDir, name)
+		initPath := filepath.Join(agentDir, "init.json")
+		data, err := os.ReadFile(initPath)
+		if err != nil {
+			continue // non-agent dir (library/asset) or unreadable — skip
+		}
+		var init map[string]interface{}
+		if err := json.Unmarshal(data, &init); err != nil {
+			fmt.Fprintf(os.Stderr, "m039: skipping %s — unparseable init.json: %v\n",
+				agentDir, err)
+			continue
+		}
+		manifest, ok := init["manifest"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		changed := repairManifestContextLimit(manifest)
+		if repairManifestPreset(manifest) {
+			changed = true
+		}
+		if !changed {
+			continue
+		}
+
+		if err := writePresetInit(initPath, init); err != nil {
+			fmt.Fprintf(os.Stderr, "m039: write %s: %v\n", agentDir, err)
+		}
+	}
+	return nil
+}
+
+// repairManifestContextLimit copies a legacy root manifest.context_limit into
+// manifest.llm.context_limit when the llm value is absent. The canonical llm
+// value is never overwritten. Returns true if the manifest was modified.
+func repairManifestContextLimit(manifest map[string]interface{}) bool {
+	root, hasRoot := manifest["context_limit"]
+	if !hasRoot {
+		return false
+	}
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		llm = map[string]interface{}{}
+		manifest["llm"] = llm
+	}
+	if _, hasLLM := llm["context_limit"]; hasLLM {
+		// Both present: canonical llm value wins, leave it untouched. Equal or
+		// conflicting, the result is the same — never overwrite llm.
+		return false
+	}
+	llm["context_limit"] = root
+	return true
+}
+
+// repairManifestPreset rewrites stale codex.json preset pointers to the
+// codex-gpt5.5.json replacement when that file exists. Returns true if the
+// manifest was modified.
+func repairManifestPreset(manifest map[string]interface{}) bool {
+	preset, ok := manifest["preset"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Only act when the replacement actually exists on disk; otherwise leave
+	// the pointers alone rather than fabricating a dead ref.
+	if !presetRefExists(legacyCodexReplacement) {
+		return false
+	}
+
+	changed := false
+	needsReplacementAllowed := false
+	for _, key := range []string{"active", "default"} {
+		if s, ok := preset[key].(string); ok && presetRefNeedsRepair(s) {
+			preset[key] = legacyCodexReplacement
+			changed = true
+			needsReplacementAllowed = true
+		}
+	}
+
+	if rawAllowed, ok := preset["allowed"].([]interface{}); ok {
+		var rebuilt []interface{}
+		seen := map[string]struct{}{}
+		appendUnique := func(s string) {
+			if _, dup := seen[s]; dup {
+				return
+			}
+			seen[s] = struct{}{}
+			rebuilt = append(rebuilt, s)
+		}
+		droppedStale := false
+		for _, e := range rawAllowed {
+			s, ok := e.(string)
+			if !ok {
+				rebuilt = append(rebuilt, e) // preserve non-string entries verbatim
+				continue
+			}
+			if refIsStaleCodex(s) {
+				droppedStale = true
+				continue // drop the stale codex.json pointer
+			}
+			appendUnique(s)
+		}
+		if droppedStale || needsReplacementAllowed {
+			// Ensure the replacement is authorized. Prepend it so it sits where
+			// the stale entry used to be (ordering is not semantically significant,
+			// but keeping the replacement visible is friendlier).
+			if _, present := seen[legacyCodexReplacement]; !present {
+				rebuilt = append([]interface{}{legacyCodexReplacement}, rebuilt...)
+			}
+			preset["allowed"] = rebuilt
+			changed = true
+		}
+	} else if needsReplacementAllowed {
+		preset["allowed"] = []interface{}{legacyCodexReplacement}
+		changed = true
+	}
+
+	return changed
+}
+
+// presetRefNeedsRepair reports whether a required active/default preset ref
+// should be rewritten to the known-good codex-gpt5.5 replacement. The explicit
+// stale codex ref is always repaired; other refs are repaired only when they do
+// not resolve to a file.
+func presetRefNeedsRepair(ref string) bool {
+	if refIsStaleCodex(ref) {
+		return true
+	}
+	return !presetRefExists(ref)
+}
+
+// refIsStaleCodex reports whether a preset ref points at the renamed
+// codex.json, comparing tilde and absolute forms equal.
+func refIsStaleCodex(ref string) bool {
+	return presetRefsEqual(ref, staleCodexRef)
+}
+
+// presetRefsEqual compares two preset refs for equality after tilde expansion,
+// so ~/-prefixed and absolute forms of the same path compare equal.
+func presetRefsEqual(a, b string) bool {
+	return expandTilde(a) == expandTilde(b)
+}
+
+// presetRefExists reports whether a preset ref resolves to an existing file.
+func presetRefExists(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	info, err := os.Stat(expandTilde(ref))
+	return err == nil && !info.IsDir()
+}

--- a/portal/internal/migrate/m039_agent_init_context_preset_repair_test.go
+++ b/portal/internal/migrate/m039_agent_init_context_preset_repair_test.go
@@ -1,0 +1,187 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPortalM039_LegacyRootContextCopiedToLLM(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInitPortal(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifestPortal(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	if got := manifest["context_limit"]; got != float64(300000) {
+		t.Fatalf("root context_limit = %#v, want preserved 300000", got)
+	}
+}
+
+func TestPortalM039_LegacyRootContextCreatesMissingLLMBlock(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInitPortal(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifestPortal(t, initPath)
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("llm block not created: %#v", manifest)
+	}
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+}
+
+func TestPortalM039_ExistingLLMContextWinsOnConflict(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInitPortal(t, lingtaiDir, "bob", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y", "context_limit": 128000}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifestPortal(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(128000) {
+		t.Fatalf("llm.context_limit = %#v, want canonical 128000 preserved", got)
+	}
+}
+
+func TestPortalM039_StalePresetMigratedWhenReplacementExists(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInitPortal(t, lingtaiDir, "carol", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifestPortal(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("active = %#v, want %q", got, want)
+	}
+	if got := preset["default"]; got != want {
+		t.Fatalf("default = %#v, want %q", got, want)
+	}
+	allowed := preset["allowed"].([]interface{})
+	if !reflect.DeepEqual(allowed, []interface{}{want}) {
+		t.Fatalf("allowed = %#v, want [%q]", allowed, want)
+	}
+}
+
+func TestPortalM039_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInitPortal(t, lingtaiDir, "erin", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 1: %v", err)
+	}
+	after1, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 1: %v", err)
+	}
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 2: %v", err)
+	}
+	after2, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 2: %v", err)
+	}
+	if string(after1) != string(after2) {
+		t.Fatalf("second run changed file:\n--- 1 ---\n%s\n--- 2 ---\n%s", after1, after2)
+	}
+}
+
+func TestPortalM039_SkipsNonAgentDirs(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+
+	humanInit := writeAgentInitPortal(t, lingtaiDir, "human", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	dotInit := writeAgentInitPortal(t, lingtaiDir, ".portal", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+
+	humanBefore, _ := os.ReadFile(humanInit)
+	dotBefore, _ := os.ReadFile(dotInit)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	humanAfter, _ := os.ReadFile(humanInit)
+	dotAfter, _ := os.ReadFile(dotInit)
+	if string(humanBefore) != string(humanAfter) {
+		t.Fatalf("human init.json mutated: %s", humanAfter)
+	}
+	if string(dotBefore) != string(dotAfter) {
+		t.Fatalf(".portal init.json mutated: %s", dotAfter)
+	}
+}

--- a/portal/internal/migrate/migrate.go
+++ b/portal/internal/migrate/migrate.go
@@ -8,7 +8,13 @@ import (
 )
 
 // CurrentVersion is the latest migration version compiled into this binary.
-const CurrentVersion = 37
+// Version history:
+//
+//	37 — preset-skills-paths (TUI-only no-op)
+//	38 — agent-init-skills-paths (shared): from PR #340
+//	39 — agent-init-context-preset-repair (shared): from PR #357
+//	     (both PRs independently claimed v38; resolved in fix/migration-version-collision-20260620)
+const CurrentVersion = 39
 
 type metaFile struct {
 	Version int `json:"version"`
@@ -60,6 +66,8 @@ var migrations = []Migration{
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},                                           // shared: strips brief.md + brief_file/brief keys after secretary removal
 	{Version: 36, Name: "sqlite-log-backfill", Fn: func(_ string) error { return nil }},                   // TUI-only: optional command-line SQLite log backfill prompt/progress
 	{Version: 37, Name: "preset-skills-paths", Fn: func(_ string) error { return nil }},                   // TUI-only: patches saved preset skill path overrides
+	{Version: 38, Name: "agent-init-skills-paths", Fn: migrateAgentInitSkillsPaths},                       // shared: restores missing skills.paths in agent init.json (PR #340)
+	{Version: 39, Name: "agent-init-context-preset-repair", Fn: migrateAgentInitContextPresetRepair},      // shared: copies legacy root context_limit into llm + rewrites stale codex preset pointers (PR #357)
 }
 
 // StampCurrent writes meta.json at CurrentVersion without running any

--- a/tui/internal/migrate/ANATOMY.md
+++ b/tui/internal/migrate/ANATOMY.md
@@ -26,6 +26,11 @@ Versioned, append-only, forward-only migration system for per-project `.lingtai/
 | m034 | `tui/internal/migrate/m034_library_skills_caps.go:23` | rename capability keys `codex`→`library` and `library`→`skills` |
 | m035 | `tui/internal/migrate/m035_remove_brief.go:13` | strip secretary-era brief plumbing: delete `system/brief.md`, drop `brief`/`brief_file` keys from each agent `init.json`, drop `brief` from `human/settings.json` |
 | m036 | `tui/internal/migrate/m036_sqlite_log_backfill.go:34` | optional command-line prompt/progress to backfill stopped agents' historical `events.jsonl` into derived `logs/log.sqlite`; safe to skip |
+| m037 | `tui/internal/migrate/m037_preset_skills_paths.go` | patch saved preset skill path overrides for the shared-library split |
+| m038 | `tui/internal/migrate/m038_agent_init_skills_paths.go` | restore missing `skills.paths` in per-agent `init.json` (PR #340) |
+| m039 | `tui/internal/migrate/m039_agent_init_context_preset_repair.go` | combined catch-up: (1) calls m038 idempotently to cover projects stamped at v38 by the PR #357 binary, (2) copies legacy root `context_limit` into `llm.context_limit`, (3) rewrites stale codex preset refs (PR #357 + collision resolution) |
+
+**Versions 38 and 39 — collision history.** PR #340 and PR #357 independently claimed migration version 38. The collision was discovered when a project migrated by one branch binary got `data version 38 is newer than this binary supports (37)` after returning to origin/main. Resolution in `fix/migration-version-collision-20260620`: PR #340's repair (skills-paths) takes v38; PR #357's repair (context/preset) takes v39 as a combined catch-up that also calls m038 idempotently, so any project previously stamped at v38 by either old binary still receives both repairs.
 
 Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002 is a no-op `func(_ string) error { return nil }` — it preserves the version slot.
 
@@ -45,7 +50,7 @@ Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002
 ## State
 
 - **`<project>/.lingtai/meta.json`** — `{"version": <N>, "addon_comment_cleanup_notified": <bool>}`. Written atomically (temp+rename) on every migration run.
-- **Per-agent `init.json`** — mutated by several migrations (m017 rename caps, m024 add active preset, m026 path form, m027 strip media, m028 addons→MCP, m029 allowed list, m034 library/skills capability keys).
+- **Per-agent `init.json`** — mutated by several migrations (m017 rename caps, m024 add active preset, m026 path form, m027 strip media, m028 addons→MCP, m029 allowed list, m034 library/skills capability keys, m038 skills.paths, m039 context/preset repair).
 
 ## Notes
 
@@ -56,3 +61,4 @@ Each migration file exports one `func migrateXxx(lingtaiDir string) error`. m002
 - **Version-check error.** `Run` returns `"data version N is newer than this binary supports (M); upgrade lingtai-tui"` when meta.json version exceeds `CurrentVersion`.
 - **Idempotent.** Migrations are designed to be re-runnable — they check preconditions and skip if already applied (e.g. m029 checks for existing `allowed` list).
 - **Optional sidecar backfill.** m036 is a TUI-only, user-confirmed command-line migration for the kernel SQLite log sidecar. It warns that large histories may take time, shows progress when confirmed, and emphasizes that skipping does not affect normal use because JSONL remains the source of truth.
+- **Collision-recovery pattern.** When two branches claim the same version number and one has already migrated a real project, use a combined catch-up entry at the next free version: call the earlier branch's function idempotently first, then the later branch's logic. This ensures any project stamped at the collision version by either old binary still receives both repairs on next launch. See m039 for the canonical example.

--- a/tui/internal/migrate/collision_repair_test.go
+++ b/tui/internal/migrate/collision_repair_test.go
@@ -1,0 +1,219 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestCollision_From37_GetsBothRepairs proves a project at v37 (origin/main state
+// before any collision PR) receives both m038 (skills-paths) and m039
+// (context-preset repair) and ends at CurrentVersion=39.
+func TestCollision_From37_GetsBothRepairs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a fake replacement preset so the preset repair can fire.
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Agent that needs BOTH repairs:
+	//   - skills.paths missing from capabilities (m038 target)
+	//   - root context_limit without llm.context_limit (m039 target)
+	//   - stale codex.json preset pointer (m039 target)
+	writeAgentInit(t, lingtaiDir, "agent1", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "capabilities": {"skills": {"library_limit": 10}},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	// Start at v37.
+	writeMeta(t, lingtaiDir, 37)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Version must reach 39.
+	meta := readMeta(t, lingtaiDir)
+	if meta.Version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", meta.Version, CurrentVersion)
+	}
+
+	initPath := filepath.Join(lingtaiDir, "agent1", "init.json")
+	// m038: skills.paths should have been added.
+	skills := readAgentSkills(t, initPath)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths after m038 = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+	// m039: llm.context_limit should have been set from root.
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit after m039 = %#v, want 300000", got)
+	}
+	// m039: stale codex preset should have been rewritten.
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("preset.active after m039 = %#v, want %q", got, want)
+	}
+}
+
+// TestCollision_AlreadyAt38_SkillsPathsBranch simulates a project stamped at
+// v38 by the PR #340 binary (which ran migrateAgentInitSkillsPaths but not
+// the context/preset repair). Running the new binary should run only m039.
+func TestCollision_AlreadyAt38_SkillsPathsBranch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Agent already received m038 (skills.paths present) but still needs m039.
+	writeAgentInit(t, lingtaiDir, "agent1", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "capabilities": {
+      "skills": {"paths": ["../.library_shared", "~/.lingtai-tui/utilities"]}
+    },
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	// Simulate PR #340 binary: project is at v38, skills-paths already applied.
+	writeMeta(t, lingtaiDir, 38)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	meta := readMeta(t, lingtaiDir)
+	if meta.Version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", meta.Version, CurrentVersion)
+	}
+
+	initPath := filepath.Join(lingtaiDir, "agent1", "init.json")
+	manifest := readManifest(t, initPath)
+
+	// m039: llm.context_limit must have been set.
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	// m039: stale preset rewritten.
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("preset.active = %#v, want %q", got, want)
+	}
+	// m038 result (skills.paths) must still be intact.
+	skills := readAgentSkills(t, initPath)
+	wantPaths := []interface{}{"../.library_shared", "~/.lingtai-tui/utilities"}
+	if !reflect.DeepEqual(skills["paths"], wantPaths) {
+		t.Fatalf("skills.paths damaged: %#v", skills["paths"])
+	}
+}
+
+// TestCollision_AlreadyAt38_ContextPresetBranch simulates a project stamped at
+// v38 by the PR #357 binary (which ran migrateAgentInitContextPresetRepair but
+// not skills-paths). Running the new binary should run only m038 (then m039,
+// which is idempotent since the preset repair already ran).
+func TestCollision_AlreadyAt38_ContextPresetBranch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	if err := os.MkdirAll(lingtaiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	replacement := filepath.Join(savedDir, "codex-gpt5.5.json")
+	if err := os.WriteFile(replacement, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Agent already received PR #357 repair: llm.context_limit set, preset
+	// points at replacement. Still needs m038 (skills.paths missing).
+	writeAgentInit(t, lingtaiDir, "agent1", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "capabilities": {"bash": {"yolo": true}},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+      "default": "~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex-gpt5.5.json"]
+    }
+  }
+}`)
+
+	// Simulate PR #357 binary: project is at v38, context/preset already applied.
+	writeMeta(t, lingtaiDir, 38)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	meta := readMeta(t, lingtaiDir)
+	if meta.Version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", meta.Version, CurrentVersion)
+	}
+
+	initPath := filepath.Join(lingtaiDir, "agent1", "init.json")
+
+	// m038: skills.paths must have been added by m038.
+	skills := readAgentSkills(t, initPath)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+
+	// m039 must not have damaged the already-repaired fields.
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000 (must not be zeroed)", got)
+	}
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("preset.active = %#v, want %q (already repaired, must not change)", got, want)
+	}
+}

--- a/tui/internal/migrate/m038_agent_init_skills_paths.go
+++ b/tui/internal/migrate/m038_agent_init_skills_paths.go
@@ -1,0 +1,95 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// migrateAgentInitSkillsPaths is the per-project companion to m037. m037
+// repaired global saved presets hit by the preset editor model-switch bug
+// (PR #312), but agents materialized while the bug was live carry the same
+// damage in their own init.json: a manifest.capabilities map whose skills
+// entry lost its paths kwarg (or the skills entry — or the whole
+// capabilities map — outright). Those agents won't pick up the repaired
+// preset until their next explicit preset refresh, so the already-written
+// init.json is the target that actually matters.
+//
+// Walks every agent directory under the project's .lingtai/ dir and adds the
+// default skills paths where missing, using the same rules as m037:
+//
+//   - existing skills.paths values are preserved exactly
+//   - other skills config and other capability entries are untouched
+//   - a missing manifest.capabilities map is created
+//   - a non-map manifest.capabilities (or manifest) means skip that file
+//
+// Best-effort: malformed init.json is logged to stderr and skipped; a single
+// broken agent must not stall the migration.
+//
+// Shared on-disk state: the portal carries an identical copy
+// (portal/internal/migrate/m038_agent_init_skills_paths.go) because whichever
+// binary migrates the project first must perform the repair — keep the two
+// in sync.
+func migrateAgentInitSkillsPaths(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		patchAgentInitSkillsPathsFile(filepath.Join(lingtaiDir, name, "init.json"))
+	}
+	return nil
+}
+
+func patchAgentInitSkillsPathsFile(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // dirs without init.json are not agents
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: skipping %s — unparseable init.json: %v\n", path, err)
+		return
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		if _, exists := manifest["capabilities"]; exists {
+			return // non-map capabilities: not a shape we understand, leave alone
+		}
+		caps = map[string]interface{}{}
+		manifest["capabilities"] = caps
+	}
+	if !patchPresetSkillsPathsMap(caps) {
+		return
+	}
+	updated, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "m038: marshal failed for %s: %v\n", path, err)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, updated, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: write tmp failed for %s: %v\n", path, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		fmt.Fprintf(os.Stderr, "m038: rename failed for %s: %v\n", path, err)
+		_ = os.Remove(tmp)
+	}
+}

--- a/tui/internal/migrate/m038_agent_init_skills_paths_test.go
+++ b/tui/internal/migrate/m038_agent_init_skills_paths_test.go
@@ -1,0 +1,156 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeAgentInit(t *testing.T, lingtaiDir, agent, content string) string {
+	t.Helper()
+	agentDir := filepath.Join(lingtaiDir, agent)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(agentDir, "init.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readAgentSkills(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("patched init.json is not valid json: %v\n%s", err, data)
+	}
+	manifest, ok := doc["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing or not a map: %s", data)
+	}
+	caps, ok := manifest["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("capabilities missing or not a map: %s", data)
+	}
+	skills, ok := caps["skills"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("skills missing or not a map: %s", data)
+	}
+	return skills
+}
+
+func TestMigrateAgentInitSkillsPathsPatchesMultipleAgents(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	// skills entry present but paths lost
+	orch := writeAgentInit(t, lingtaiDir, "orch",
+		`{"manifest":{"capabilities":{"skills":{"library_limit":42},"web_search":{"provider":"zhipu"}}}}`)
+	// skills entry lost entirely
+	scout := writeAgentInit(t, lingtaiDir, "scout",
+		`{"manifest":{"capabilities":{"bash":{"yolo":true}}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	orchSkills := readAgentSkills(t, orch)
+	if !reflect.DeepEqual(orchSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("orch skills.paths = %#v, want %#v", orchSkills["paths"], defaultPresetSkillsPaths)
+	}
+	if got := orchSkills["library_limit"]; got != float64(42) {
+		t.Fatalf("orch existing skills config overwritten: %#v", orchSkills)
+	}
+
+	scoutSkills := readAgentSkills(t, scout)
+	if !reflect.DeepEqual(scoutSkills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("scout skills.paths = %#v, want %#v", scoutSkills["paths"], defaultPresetSkillsPaths)
+	}
+
+	// sibling capability entries survive
+	data, _ := os.ReadFile(orch)
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	caps := doc["manifest"].(map[string]interface{})["capabilities"].(map[string]interface{})
+	ws, ok := caps["web_search"].(map[string]interface{})
+	if !ok || ws["provider"] != "zhipu" {
+		t.Fatalf("web_search entry damaged: %#v", caps["web_search"])
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsCreatesMissingCapabilitiesMap(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	path := writeAgentInit(t, lingtaiDir, "orch", `{"manifest":{"llm":{"provider":"custom"}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	skills := readAgentSkills(t, path)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("skills.paths = %#v, want %#v", skills["paths"], defaultPresetSkillsPaths)
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsPreservesCustomPaths(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	content := `{"manifest":{"capabilities":{"skills":{"paths":["./custom-skills"]}}}}`
+	path := writeAgentInit(t, lingtaiDir, "orch", content)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// File must be byte-identical: nothing to patch means no rewrite.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Fatalf("init.json with custom paths was rewritten: %s", data)
+	}
+}
+
+func TestMigrateAgentInitSkillsPathsSkipsMalformedAndNonMapCases(t *testing.T) {
+	lingtaiDir := t.TempDir()
+	malformed := writeAgentInit(t, lingtaiDir, "broken", `{"manifest":`)
+	nonMapCaps := writeAgentInit(t, lingtaiDir, "weird-caps",
+		`{"manifest":{"capabilities":["skills"]}}`)
+	nonMapManifest := writeAgentInit(t, lingtaiDir, "weird-manifest",
+		`{"manifest":"nope"}`)
+	// a valid sibling proves the migration continues past the broken ones
+	good := writeAgentInit(t, lingtaiDir, "zz-good", `{"manifest":{"capabilities":{}}}`)
+
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, path := range map[string]string{
+		"malformed": malformed, "non-map capabilities": nonMapCaps, "non-map manifest": nonMapManifest,
+	} {
+		before := map[string]string{
+			"malformed":            `{"manifest":`,
+			"non-map capabilities": `{"manifest":{"capabilities":["skills"]}}`,
+			"non-map manifest":     `{"manifest":"nope"}`,
+		}[name]
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != before {
+			t.Fatalf("%s init.json should be unchanged, got: %s", name, data)
+		}
+	}
+
+	skills := readAgentSkills(t, good)
+	if !reflect.DeepEqual(skills["paths"], defaultPresetSkillsPaths) {
+		t.Fatalf("valid sibling not patched: %#v", skills["paths"])
+	}
+}

--- a/tui/internal/migrate/m039_agent_init_context_preset_repair.go
+++ b/tui/internal/migrate/m039_agent_init_context_preset_repair.go
@@ -1,0 +1,240 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// staleCodexRef is the legacy saved-preset ref that no longer resolves on
+// machines whose codex preset was renamed. legacyCodexReplacement is the file
+// that supersedes it when present.
+const (
+	staleCodexRef          = "~/.lingtai-tui/presets/saved/codex.json"
+	legacyCodexReplacement = "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+)
+
+// migrateAgentInitContextPresetRepair repairs already-created agent init.json
+// files so legacy agents stop dying in refresh/relaunch loops.
+//
+// Two independent defects are healed, both observed in the same incident:
+//
+//  1. Legacy root context limit. Older init.json carried the context window
+//     as manifest.context_limit at the manifest root, before the canonical
+//     home moved to manifest.llm.context_limit. An agent with the root value
+//     but no llm value refreshes into a relaunch-dead loop. When the root
+//     value is present and llm.context_limit is absent, copy it down. The
+//     root key is preserved for backward compatibility — this migration does
+//     not introduce a hard failure and does not strip it. When both exist and
+//     conflict, the canonical manifest.llm.context_limit wins and is never
+//     overwritten.
+//
+//  2. Stale saved-preset pointer. The incident agent's preset active/default/
+//     allowed pointed at ~/.lingtai-tui/presets/saved/codex.json, which had
+//     been renamed to codex-gpt5.5.json. When the stale ref is present, or
+//     active/default point at another missing preset, and the replacement file
+//     exists on disk, active/default are rewritten and the allowed list gains
+//     the replacement while dropping the stale entry.
+//     Unrelated allowed entries that resolve to existing files are preserved.
+//
+// Version numbering note: this repair was originally authored as m038 in
+// PR #357 (fix/agent-init-context-preset-migration-20260615). PR #340
+// (docs/guide-custom-preset-tutorial) independently also claimed v38 for
+// migrateAgentInitSkillsPaths. The collision was resolved in
+// fix/migration-version-collision-20260620: skills-paths takes v38 and this
+// repair takes v39.
+//
+// Catch-up design: m039 intentionally calls migrateAgentInitSkillsPaths
+// first (idempotent) so that a project previously stamped at v38 by the PR
+// #357 binary (which ran only the context/preset repair, skipping m038 by
+// version) still receives both repairs when upgraded to this binary.
+// Similarly, a project stamped at v38 by the PR #340 binary (which ran only
+// skills-paths, skipping the context/preset repair) skips m038 (already at
+// v38) but gets both via m039's combined call.
+//
+// Best-effort and idempotent: a single broken init.json logs to stderr and
+// the migration continues. Files are only rewritten when something actually
+// changed. Atomic temp+rename writes match the surrounding migration style.
+//
+// Shared on-disk state: the portal carries an identical copy
+// (portal/internal/migrate/m039_agent_init_context_preset_repair.go) —
+// keep logic in sync.
+func migrateAgentInitContextPresetRepair(lingtaiDir string) error {
+	// Apply skills-paths repair first (idempotent — no-ops if already done by m038).
+	if err := migrateAgentInitSkillsPaths(lingtaiDir); err != nil {
+		return err
+	}
+	return migrateAgentInitContextPresetRepairOnly(lingtaiDir)
+}
+
+// migrateAgentInitContextPresetRepairOnly is the context/preset half of m039.
+// It is split out so the combined m039 entry point can call skills-paths first
+// without creating a recursive or indirect import cycle.
+func migrateAgentInitContextPresetRepairOnly(lingtaiDir string) error {
+	entries, err := os.ReadDir(lingtaiDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .lingtai dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == "" || name[0] == '.' || name == "human" {
+			continue
+		}
+		agentDir := filepath.Join(lingtaiDir, name)
+		initPath := filepath.Join(agentDir, "init.json")
+		data, err := os.ReadFile(initPath)
+		if err != nil {
+			continue // non-agent dir (library/asset) or unreadable — skip
+		}
+		var init map[string]interface{}
+		if err := json.Unmarshal(data, &init); err != nil {
+			fmt.Fprintf(os.Stderr, "m039: skipping %s — unparseable init.json: %v\n",
+				agentDir, err)
+			continue
+		}
+		manifest, ok := init["manifest"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		changed := repairManifestContextLimit(manifest)
+		if repairManifestPreset(manifest) {
+			changed = true
+		}
+		if !changed {
+			continue
+		}
+
+		if err := writePresetInit(initPath, init); err != nil {
+			fmt.Fprintf(os.Stderr, "m039: write %s: %v\n", agentDir, err)
+		}
+	}
+	return nil
+}
+
+// repairManifestContextLimit copies a legacy root manifest.context_limit into
+// manifest.llm.context_limit when the llm value is absent. The canonical llm
+// value is never overwritten. Returns true if the manifest was modified.
+func repairManifestContextLimit(manifest map[string]interface{}) bool {
+	root, hasRoot := manifest["context_limit"]
+	if !hasRoot {
+		return false
+	}
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		llm = map[string]interface{}{}
+		manifest["llm"] = llm
+	}
+	if _, hasLLM := llm["context_limit"]; hasLLM {
+		// Both present: canonical llm value wins, leave it untouched. Equal or
+		// conflicting, the result is the same — never overwrite llm.
+		return false
+	}
+	llm["context_limit"] = root
+	return true
+}
+
+// repairManifestPreset rewrites stale codex.json preset pointers to the
+// codex-gpt5.5.json replacement when that file exists. Returns true if the
+// manifest was modified.
+func repairManifestPreset(manifest map[string]interface{}) bool {
+	preset, ok := manifest["preset"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Only act when the replacement actually exists on disk; otherwise leave
+	// the pointers alone rather than fabricating a dead ref.
+	if !presetRefExists(legacyCodexReplacement) {
+		return false
+	}
+
+	changed := false
+	needsReplacementAllowed := false
+	for _, key := range []string{"active", "default"} {
+		if s, ok := preset[key].(string); ok && presetRefNeedsRepair(s) {
+			preset[key] = legacyCodexReplacement
+			changed = true
+			needsReplacementAllowed = true
+		}
+	}
+
+	if rawAllowed, ok := preset["allowed"].([]interface{}); ok {
+		var rebuilt []interface{}
+		seen := map[string]struct{}{}
+		appendUnique := func(s string) {
+			if _, dup := seen[s]; dup {
+				return
+			}
+			seen[s] = struct{}{}
+			rebuilt = append(rebuilt, s)
+		}
+		droppedStale := false
+		for _, e := range rawAllowed {
+			s, ok := e.(string)
+			if !ok {
+				rebuilt = append(rebuilt, e) // preserve non-string entries verbatim
+				continue
+			}
+			if refIsStaleCodex(s) {
+				droppedStale = true
+				continue // drop the stale codex.json pointer
+			}
+			appendUnique(s)
+		}
+		if droppedStale || needsReplacementAllowed {
+			// Ensure the replacement is authorized. Prepend it so it sits where
+			// the stale entry used to be (ordering is not semantically significant,
+			// but keeping the replacement visible is friendlier).
+			if _, present := seen[legacyCodexReplacement]; !present {
+				rebuilt = append([]interface{}{legacyCodexReplacement}, rebuilt...)
+			}
+			preset["allowed"] = rebuilt
+			changed = true
+		}
+	} else if needsReplacementAllowed {
+		preset["allowed"] = []interface{}{legacyCodexReplacement}
+		changed = true
+	}
+
+	return changed
+}
+
+// presetRefNeedsRepair reports whether a required active/default preset ref
+// should be rewritten to the known-good codex-gpt5.5 replacement. The explicit
+// stale codex ref is always repaired; other refs are repaired only when they do
+// not resolve to a file.
+func presetRefNeedsRepair(ref string) bool {
+	if refIsStaleCodex(ref) {
+		return true
+	}
+	return !presetRefExists(ref)
+}
+
+// refIsStaleCodex reports whether a preset ref points at the renamed
+// codex.json, comparing tilde and absolute forms equal.
+func refIsStaleCodex(ref string) bool {
+	return presetRefsEqual(ref, staleCodexRef)
+}
+
+// presetRefsEqual compares two preset refs for equality after tilde expansion,
+// so ~/-prefixed and absolute forms of the same path compare equal.
+func presetRefsEqual(a, b string) bool {
+	return expandTilde(a) == expandTilde(b)
+}
+
+// presetRefExists reports whether a preset ref resolves to an existing file.
+func presetRefExists(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	info, err := os.Stat(expandTilde(ref))
+	return err == nil && !info.IsDir()
+}

--- a/tui/internal/migrate/m039_agent_init_context_preset_repair_test.go
+++ b/tui/internal/migrate/m039_agent_init_context_preset_repair_test.go
@@ -1,0 +1,345 @@
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func readManifest(t *testing.T, initPath string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", initPath, err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", initPath, err, data)
+	}
+	manifest, ok := m["manifest"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("manifest missing in %s", initPath)
+	}
+	return manifest
+}
+
+func toStringSlice(t *testing.T, raw interface{}) []string {
+	t.Helper()
+	items, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("allowed is %T, want []interface{}", raw)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("allowed entry is %T, want string", item)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestM039_LegacyRootContextCopiedToLLM verifies the incident's core repair:
+// a legacy root manifest.context_limit with no manifest.llm.context_limit gets
+// the value copied into manifest.llm.context_limit.
+func TestM039_LegacyRootContextCopiedToLLM(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+	// Root context_limit preserved for backward compatibility.
+	if got := manifest["context_limit"]; got != float64(300000) {
+		t.Fatalf("root context_limit = %#v, want preserved 300000", got)
+	}
+}
+
+func TestM039_LegacyRootContextCreatesMissingLLMBlock(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "context_limit": 300000
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm, ok := manifest["llm"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("llm block not created: %#v", manifest)
+	}
+	if got := llm["context_limit"]; got != float64(300000) {
+		t.Fatalf("llm.context_limit = %#v, want 300000", got)
+	}
+}
+
+func TestM039_ExistingLLMContextWinsOnConflict(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "bob", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y", "context_limit": 128000}
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	llm := manifest["llm"].(map[string]interface{})
+	if got := llm["context_limit"]; got != float64(128000) {
+		t.Fatalf("llm.context_limit = %#v, want canonical 128000 preserved", got)
+	}
+}
+
+// TestM039_StalePresetMigratedWhenReplacementExists verifies that stale
+// codex.json active/default/allowed pointers are rewritten to the existing
+// codex-gpt5.5.json replacement.
+func TestM039_StalePresetMigratedWhenReplacementExists(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	// The replacement exists; the stale codex.json does NOT.
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "carol", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	want := "~/.lingtai-tui/presets/saved/codex-gpt5.5.json"
+	if got := preset["active"]; got != want {
+		t.Fatalf("active = %#v, want %q", got, want)
+	}
+	if got := preset["default"]; got != want {
+		t.Fatalf("default = %#v, want %q", got, want)
+	}
+	allowed := preset["allowed"].([]interface{})
+	if !reflect.DeepEqual(allowed, []interface{}{want}) {
+		t.Fatalf("allowed = %#v, want [%q]", allowed, want)
+	}
+}
+
+// TestM039_PreservesUnrelatedExistingAllowedEntries verifies the migration
+// keeps unrelated allowed entries that resolve to existing files, only
+// dropping the stale codex.json pointer.
+func TestM039_PreservesUnrelatedExistingAllowedEntries(t *testing.T) {
+	tmp := t.TempDir()
+	home := tmp
+	t.Setenv("HOME", home)
+
+	savedDir := filepath.Join(home, ".lingtai-tui", "presets", "saved")
+	templatesDir := filepath.Join(home, ".lingtai-tui", "presets", "templates")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir saved: %v", err)
+	}
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(savedDir, "codex-gpt5.5.json"),
+		filepath.Join(templatesDir, "minimax.json"),
+	} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "dave", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y", "context_limit": 300000},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/templates/minimax.json",
+      "allowed": [
+        "~/.lingtai-tui/presets/saved/codex.json",
+        "~/.lingtai-tui/presets/templates/minimax.json"
+      ]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	if got := preset["active"]; got != "~/.lingtai-tui/presets/saved/codex-gpt5.5.json" {
+		t.Fatalf("active = %#v, want replacement", got)
+	}
+	if got := preset["default"]; got != "~/.lingtai-tui/presets/templates/minimax.json" {
+		t.Fatalf("default = %#v, want unchanged minimax", got)
+	}
+	allowed := preset["allowed"].([]interface{})
+	want := []interface{}{
+		"~/.lingtai-tui/presets/saved/codex-gpt5.5.json",
+		"~/.lingtai-tui/presets/templates/minimax.json",
+	}
+	if !reflect.DeepEqual(allowed, want) {
+		t.Fatalf("allowed = %#v, want %#v", allowed, want)
+	}
+}
+
+// TestM039_SkipsNonAgentDirs verifies that dotfile dirs, the human mailbox,
+// and dirs without init.json are not touched.
+func TestM039_SkipsNonAgentDirs(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+
+	humanInit := writeAgentInit(t, lingtaiDir, "human", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	dotInit := writeAgentInit(t, lingtaiDir, ".portal", `{"manifest":{"context_limit":300000,"llm":{}}}`)
+	libDir := filepath.Join(lingtaiDir, "library")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "note.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write note: %v", err)
+	}
+
+	humanBefore, _ := os.ReadFile(humanInit)
+	dotBefore, _ := os.ReadFile(dotInit)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	humanAfter, _ := os.ReadFile(humanInit)
+	dotAfter, _ := os.ReadFile(dotInit)
+	if string(humanBefore) != string(humanAfter) {
+		t.Fatalf("human init.json mutated: %s", humanAfter)
+	}
+	if string(dotBefore) != string(dotAfter) {
+		t.Fatalf(".portal init.json mutated: %s", dotAfter)
+	}
+}
+
+func TestM039_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	savedDir := filepath.Join(tmp, ".lingtai-tui", "presets", "saved")
+	if err := os.MkdirAll(savedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "codex-gpt5.5.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "erin", `{
+  "manifest": {
+    "context_limit": 300000,
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/.lingtai-tui/presets/saved/codex.json",
+      "default": "~/.lingtai-tui/presets/saved/codex.json",
+      "allowed": ["~/.lingtai-tui/presets/saved/codex.json"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 1: %v", err)
+	}
+	after1, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 1: %v", err)
+	}
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate 2: %v", err)
+	}
+	after2, err := os.ReadFile(initPath)
+	if err != nil {
+		t.Fatalf("read after 2: %v", err)
+	}
+	if string(after1) != string(after2) {
+		t.Fatalf("second run changed file:\n--- 1 ---\n%s\n--- 2 ---\n%s", after1, after2)
+	}
+}
+
+func TestM039_MissingActiveDefaultPresetGetsReplacementAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	replacement := filepath.Join(tmp, ".lingtai-tui", "presets", "saved", "codex-gpt5.5.json")
+	if err := os.MkdirAll(filepath.Dir(replacement), 0o755); err != nil {
+		t.Fatalf("mkdir replacement dir: %v", err)
+	}
+	if err := os.WriteFile(replacement, []byte(`{"name":"codex-gpt5.5"}`), 0o644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+
+	other := filepath.Join(tmp, "other-existing.json")
+	if err := os.WriteFile(other, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write other preset: %v", err)
+	}
+
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	initPath := writeAgentInit(t, lingtaiDir, "alice", `{
+  "manifest": {
+    "llm": {"provider": "x", "model": "y"},
+    "preset": {
+      "active": "~/missing-active.json",
+      "default": "~/missing-default.json",
+      "allowed": ["`+other+`"]
+    }
+  }
+}`)
+
+	if err := migrateAgentInitContextPresetRepair(lingtaiDir); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	manifest := readManifest(t, initPath)
+	preset := manifest["preset"].(map[string]interface{})
+	if preset["active"] != legacyCodexReplacement || preset["default"] != legacyCodexReplacement {
+		t.Fatalf("active/default not repaired: %#v", preset)
+	}
+	allowed := toStringSlice(t, preset["allowed"])
+	expected := []string{legacyCodexReplacement, other}
+	if !reflect.DeepEqual(allowed, expected) {
+		t.Fatalf("allowed = %#v, want %#v", allowed, expected)
+	}
+}

--- a/tui/internal/migrate/migrate.go
+++ b/tui/internal/migrate/migrate.go
@@ -9,7 +9,13 @@ import (
 
 // CurrentVersion is the latest migration version compiled into this binary.
 // IMPORTANT: when bumping, also bump portal/internal/migrate/migrate.go (see CLAUDE.md).
-const CurrentVersion = 37
+// CurrentVersion history:
+//
+//	37 — preset-skills-paths (m037)
+//	38 — agent-init-skills-paths (m038): from PR #340
+//	39 — agent-init-context-preset-repair (m039): from PR #357
+//	     (both PRs independently claimed v38; resolved in fix/migration-version-collision-20260620)
+const CurrentVersion = 39
 
 type metaFile struct {
 	Version                     int  `json:"version"`
@@ -62,6 +68,8 @@ var migrations = []Migration{
 	{Version: 35, Name: "remove-brief", Fn: migrateRemoveBrief},
 	{Version: 36, Name: "sqlite-log-backfill", Fn: migrateSQLiteLogBackfill},
 	{Version: 37, Name: "preset-skills-paths", Fn: migratePresetSkillsPaths},
+	{Version: 38, Name: "agent-init-skills-paths", Fn: migrateAgentInitSkillsPaths},
+	{Version: 39, Name: "agent-init-context-preset-repair", Fn: migrateAgentInitContextPresetRepair},
 }
 
 // Run executes all pending migrations on the given .lingtai/ directory.

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
@@ -140,6 +140,32 @@ TUI and portal share `meta.json` but have separate migration registries. **When 
 - TUI-only migrations → add a no-op stub in the portal registry.
 - Otherwise the portal refuses to open any project the TUI has already touched.
 
+### Migration-version / rebuild incident checklist
+
+Follow this checklist whenever you hit `data version N is newer than this binary supports (M)` or suspect a version collision between open branches:
+
+1. **Check the project's stamped version:**
+   ```bash
+   python3 -c "import json,pathlib; print(json.loads(pathlib.Path('.lingtai/meta.json').read_text())['version'])"
+   ```
+
+2. **Check `CurrentVersion` in BOTH packages of the exact checkout being built:**
+   ```bash
+   grep 'const CurrentVersion' tui/internal/migrate/migrate.go portal/internal/migrate/migrate.go
+   ```
+   Both must match. A mismatch means an incomplete bump — the portal refuses any project the TUI has already touched.
+
+3. **After installing or switching dev binaries, launch and smoke-test the target project — not just `--version`.** A binary that prints the right version string may still refuse to open a project with a higher `meta.json` version.
+
+4. **Do not install a feature-branch binary that bumps migrations into shared dev projects** unless that migration PR is the intended runtime path or you can roll `main` forward to include it. A single-file `make build` on the wrong branch contaminates every project it touches.
+
+5. **If two open branches claim the same migration number:**
+   - Stop. Do not build or launch either binary into a shared project.
+   - Identify which branch (if any) has already migrated real projects to that version.
+   - Renumber and combine before any further binary migrates real projects: assign the earlier repair to the lower claimed version, add a combined catch-up at the next free slot, and have the catch-up call the earlier function idempotently. See `tui/internal/migrate/ANATOMY.md` → "Collision-recovery pattern".
+
+6. **Emergency rollback is NOT editing `meta.json` downward.** That path corrupts data that was written by the higher-version migration. The only safe recovery is to build and install a binary whose `CurrentVersion` meets or exceeds the project's current version.
+
 ## Three-locale rule
 
 Adding an i18n key means updating all three of `en.json`, `zh.json`, `wen.json` in **both** `tui/i18n/` and (where applicable) `portal/i18n/`. Missing translations show as the raw key on screen — they don't fall back.


### PR DESCRIPTION
## Summary
- resolve the migration-version collision between open PRs #340 and #357, which both claimed data migration version 38
- define v38 as the agent init skills-paths repair and v39 as the context/preset repair, with v39 intentionally re-running the v38 repair as a catch-up path for projects already stamped v38 by either old branch
- bump both TUI and Portal migration `CurrentVersion` to 39
- add collision-recovery tests for clean v37 projects and projects already stamped v38 by either old branch shape
- update migration anatomy and lingtai-dev-guide gotchas with a concrete rebuild/version checklist

## Why
A real dev project reached `.lingtai/meta.json` version 38 via a feature-branch binary while `origin/main` still supported only version 37. Reinstalling a main-derived TUI then failed with:

```text
migration error: data version 38 is newer than this binary supports (37); upgrade lingtai-tui
```

Root cause: two open branches independently used migration slot 38. This PR rolls the shared migration chain forward so main can safely handle clean v37 projects and projects already stamped v38 by either branch.

## Validation
- `(cd tui && go test ./internal/migrate -count=1)`
- `(cd portal && go test ./internal/migrate -count=1)`
- `(cd tui && go vet ./internal/migrate)`
- `(cd portal && go vet ./internal/migrate)`
- `git diff --check`

## Notes
- Supersedes the migration portions of #340 and #357; those branches should not be merged as-is with their duplicate `m038` numbering.
- This PR does not close #340/#357 wholesale because they may contain broader documentation/context, but their migration-number collision must be resolved through this combined/renumbered chain.
