### PR TITLE
Show local timezone in kanban timestamps

### DIFF
--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -460,6 +460,9 @@ func (m PropsModel) renderLeft(maxW int) string {
 				stateColor := StateColor(strings.ToUpper(val))
 				val = lipgloss.NewStyle().Foreground(stateColor).Render(val)
 			} else {
+				if isTimestampPropField(f.key) {
+					val = formatKanbanTimestamp(val)
+				}
 				val = valueStyle.Render(val)
 			}
 			lines = append(lines, "  "+labelStyle.Render(f.label+": ")+val)
@@ -667,7 +670,7 @@ func (m PropsModel) renderRight(maxW int) string {
 	lines = append(lines, "")
 
 	if m.adminStart != "" {
-		lines = append(lines, "  "+labelStyle.Render(i18n.T("props.network_created")+": ")+valueStyle.Render(m.adminStart))
+		lines = append(lines, "  "+labelStyle.Render(i18n.T("props.network_created")+": ")+valueStyle.Render(formatKanbanTimestamp(m.adminStart)))
 		if t, err := time.Parse(time.RFC3339, m.adminStart); err == nil {
 			uptime := time.Since(t)
 			lines = append(lines, "  "+labelStyle.Render(i18n.T("props.network_uptime")+": ")+valueStyle.Render(formatDuration(uptime)))
@@ -935,7 +938,7 @@ func (m PropsModel) renderMainCallRows() []string {
 	}
 
 	lines := []string{
-		"  " + labelStyle.Render(fmt.Sprintf("%-16s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
+		"  " + labelStyle.Render(fmt.Sprintf("%-24s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
 			"time", "provider", "model", "input", "output", "thinking", "cached", "cache%", "endpoint")),
 	}
 	for _, e := range m.detailRecent {
@@ -948,7 +951,7 @@ func (m PropsModel) renderMainCallRows() []string {
 		if endpoint == "" {
 			endpoint = "—"
 		}
-		line := fmt.Sprintf("  %-16s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
+		line := fmt.Sprintf("  %-24s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
 			shortTS(e.TS),
 			provider,
 			model,
@@ -977,7 +980,7 @@ func (m PropsModel) renderDaemonCallRows() []string {
 	}
 
 	lines := []string{
-		"  " + labelStyle.Render(fmt.Sprintf("%-16s  %-10s  %-24s  %-8s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
+		"  " + labelStyle.Render(fmt.Sprintf("%-24s  %-10s  %-24s  %-8s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
 			"time", "daemon", "run", "state", "provider", "model", "input", "output", "thinking", "cached", "cache%", "endpoint")),
 	}
 	for _, e := range m.detailDaemonRecent {
@@ -1002,7 +1005,7 @@ func (m PropsModel) renderDaemonCallRows() []string {
 		if state == "" {
 			state = "—"
 		}
-		line := fmt.Sprintf("  %-16s  %-10s  %-24s  %-8s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
+		line := fmt.Sprintf("  %-24s  %-10s  %-24s  %-8s  %-10s  %-24s  %10s  %10s  %10s  %10s  %7s  %s",
 			shortTS(e.TS),
 			handle,
 			runID,
@@ -1028,13 +1031,45 @@ func formatCacheRate(cached, input int64) string {
 	return fmt.Sprintf("%.1f%%", 100.0*float64(cached)/float64(input))
 }
 
-// shortTS trims an ISO-8601 timestamp to minute precision (2026-04-30T03:14)
-// for compact display, leaving shorter/empty strings untouched.
-func shortTS(ts string) string {
-	if len(ts) > 16 {
-		return ts[:16]
+func isTimestampPropField(key string) bool {
+	switch key {
+	case "started_at", "created_at", "updated_at":
+		return true
+	default:
+		return strings.HasSuffix(key, "_at") || strings.Contains(key, "timestamp")
 	}
-	return ts
+}
+
+// formatKanbanTimestamp renders parseable timestamps in local time with an
+// explicit UTC offset marker (for example, 2026-06-19 20:14 U-7:00).
+// Non-parseable legacy strings keep the old compact trimming behavior.
+func formatKanbanTimestamp(ts string) string {
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		if len(ts) > 16 {
+			return ts[:16]
+		}
+		return ts
+	}
+	local := t.Local()
+	return local.Format("2006-01-02 15:04") + " " + utcOffsetLabel(local)
+}
+
+func utcOffsetLabel(t time.Time) string {
+	_, offset := t.Zone()
+	sign := "+"
+	if offset < 0 {
+		sign = "-"
+		offset = -offset
+	}
+	hours := offset / 3600
+	minutes := (offset % 3600) / 60
+	return fmt.Sprintf("U%s%d:%02d", sign, hours, minutes)
+}
+
+// shortTS renders token-ledger timestamps for compact /kanban tables.
+func shortTS(ts string) string {
+	return formatKanbanTimestamp(ts)
 }
 
 // renderShareBar returns a small unicode bar (filled + empty cells)

--- a/tui/internal/tui/props_test.go
+++ b/tui/internal/tui/props_test.go
@@ -6,11 +6,90 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anthropics/lingtai-tui/i18n"
 	"github.com/anthropics/lingtai-tui/internal/fs"
 	"github.com/charmbracelet/x/ansi"
 )
+
+func TestKanbanTimestampRendersLocalOffset(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
+	got := formatKanbanTimestamp("2026-06-13T03:00:00Z")
+	want := "2026-06-12 20:00 U-7:00"
+	if got != want {
+		t.Fatalf("formatKanbanTimestamp() = %q, want %q", got, want)
+	}
+}
+
+func TestKanbanTimestampKeepsInvalidLegacyCompact(t *testing.T) {
+	got := formatKanbanTimestamp("2026-06-13T03:00:00-without-zone")
+	want := "2026-06-13T03:00"
+	if got != want {
+		t.Fatalf("formatKanbanTimestamp() = %q, want legacy compact %q", got, want)
+	}
+}
+
+func TestPropsRenderLeftShowsStartedAtLocalOffset(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agent.json"), []byte(`{"agent_name":"mimo","started_at":"2026-06-13T03:00:00Z"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := PropsModel{selectedDir: dir}
+	left := ansi.Strip(m.renderLeft(80))
+	if !strings.Contains(left, "2026-06-12 20:00 U-7:00") {
+		t.Fatalf("renderLeft should render started_at in local time with offset:\n%s", left)
+	}
+	if strings.Contains(left, "2026-06-13T03:00:00Z") {
+		t.Fatalf("renderLeft should not show raw UTC started_at:\n%s", left)
+	}
+}
+
+func TestPropsRenderRightShowsNetworkCreatedLocalOffset(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
+	m := PropsModel{adminStart: "2026-06-13T03:00:00Z"}
+	right := ansi.Strip(m.renderRight(80))
+	if !strings.Contains(right, "2026-06-12 20:00 U-7:00") {
+		t.Fatalf("renderRight should render network_created in local time with offset:\n%s", right)
+	}
+	if strings.Contains(right, "2026-06-13T03:00:00Z") {
+		t.Fatalf("renderRight should not show raw UTC timestamp:\n%s", right)
+	}
+}
+
+func TestPropsRecentLanesShowLocalOffsetTimestamps(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
+	m := PropsModel{
+		width: 140,
+		detailRecent: []fs.LedgerEntry{
+			{TS: "2026-06-13T03:00:00Z", Input: 5, Output: 1, Cached: 2, Model: "glm-4.6", Endpoint: "https://z.ai"},
+		},
+		detailDaemonRecent: []fs.DaemonLedgerEntry{
+			{LedgerEntry: fs.LedgerEntry{TS: "2026-06-13T03:00:05Z", Input: 9, Cached: 3}, Handle: "em-1", State: "running"},
+		},
+	}
+	out := ansi.Strip(strings.Join(m.renderRecentCallLanes(), "\n"))
+	if strings.Count(out, "2026-06-12 20:00 U-7:00") != 2 {
+		t.Fatalf("recent lanes should render both main and daemon timestamps with local offset:\n%s", out)
+	}
+	if strings.Contains(out, "2026-06-13T03:00") {
+		t.Fatalf("recent lanes should not show raw/trimmed UTC timestamps:\n%s", out)
+	}
+}
 
 func TestPropsRenderRightShowsRunningDaemons(t *testing.T) {
 	m := PropsModel{


### PR DESCRIPTION
## Summary

- render `/kanban` timestamp fields in local time with an explicit UTC-offset marker like `U-7:00`
- cover agent `started_at`, `network_created`, and Ctrl+D recent main/daemon call timestamps
- keep legacy non-parseable timestamp strings on the old compact fallback path

## Validation

- From `tui/`: `go test ./internal/tui -run 'Test(KanbanTimestamp|Props(RenderLeftShowsStartedAtLocalOffset|RenderRightShowsNetworkCreatedLocalOffset|RecentLanesShowLocalOffsetTimestamps|RecentLanesSingleColumnShowsMainThenDaemons|RecentLanesDoNotTruncateDiagnosticFields))'`
- From `tui/`: `go test ./internal/tui`
- From `tui/`: `go test ./...`
- `git diff --check`
