### PR TITLE
Show timezone and CLI token usage in daemons view

### DIFF
--- a/tui/internal/tui/daemons.go
+++ b/tui/internal/tui/daemons.go
@@ -556,11 +556,11 @@ func (m DaemonsModel) renderDetail(maxW int) string {
 		{i18n.T("daemons.current_tool"), d.CurrentTool},
 		{i18n.T("daemons.turn"), turnText(d.Turn, d.MaxTurns)},
 		{i18n.T("daemons.duration"), daemonDuration(d)},
-		{i18n.T("daemons.started"), d.StartedAt},
-		{i18n.T("daemons.updated"), d.UpdatedAt},
-		{i18n.T("daemons.completed"), d.CompletedAt},
-		{i18n.T("daemons.finished"), d.FinishedAt},
-		{i18n.T("daemons.last_event"), d.LastEventAt},
+		{i18n.T("daemons.started"), formatDaemonTimestamp(d.StartedAt)},
+		{i18n.T("daemons.updated"), formatDaemonTimestamp(d.UpdatedAt)},
+		{i18n.T("daemons.completed"), formatDaemonTimestamp(d.CompletedAt)},
+		{i18n.T("daemons.finished"), formatDaemonTimestamp(d.FinishedAt)},
+		{i18n.T("daemons.last_event"), formatDaemonTimestamp(d.LastEventAt)},
 		{i18n.T("daemons.tokens"), daemonTokenText(d.Tokens)},
 	}
 	for _, row := range meta {
@@ -718,6 +718,13 @@ func readDaemonSummary(dir string) (daemonSummary, error) {
 	item.Chats = readDaemonChats(filepath.Join(dir, "history", "chat_history.jsonl"))
 	item.Result = readDaemonResult(filepath.Join(dir, "result.txt"))
 	item.Tokens = readDaemonTokens(filepath.Join(dir, "logs", "token_ledger.jsonl"))
+	// CLI backends (claude/claude-p, codex, opencode, cursor) never write a
+	// per-call token_ledger.jsonl, but the kernel may keep UI-only running
+	// totals in daemon.json. Fall back to those so their usage still shows;
+	// the per-call ledger remains authoritative whenever it exists.
+	if item.Tokens.Calls == 0 {
+		item.Tokens = daemonTokensFromState(raw)
+	}
 	if item.ModifiedTime.IsZero() {
 		item.ModifiedTime = newestTimestamp(item.StartedAt, item.UpdatedAt, item.CompletedAt, item.FinishedAt, item.LastEventAt)
 	}
@@ -814,13 +821,81 @@ func readDaemonTokens(path string) daemonTokenSummary {
 		if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
 			continue
 		}
-		total.Input += intField(raw, "input")
-		total.Output += intField(raw, "output")
-		total.Thinking += intField(raw, "thinking")
-		total.Cached += intField(raw, "cached")
+		entry := tokenEntryFromRaw(raw)
+		total.Input += entry.Input
+		total.Output += entry.Output
+		total.Thinking += entry.Thinking
+		total.Cached += entry.Cached
 		total.Calls++
 	}
 	return total
+}
+
+// tokenEntryFromRaw extracts per-call token counts from one ledger entry,
+// tolerating two schemas:
+//
+//   - the kernel's canonical ledger ("input"/"output"/"thinking"/"cached"),
+//     written by lingtai-backend daemons; and
+//   - Anthropic Messages-API field names ("input_tokens"/"output_tokens" plus
+//     "cache_read_input_tokens"/"cache_creation_input_tokens" and
+//     "reasoning_tokens"/"thinking_tokens"), as carried by Claude Code /
+//     claude-p usage payloads.
+//
+// Canonical fields take precedence when both appear; cached folds together
+// cache-read and cache-creation so the displayed number matches the kernel's
+// normalized "cached" (raw + read + write) convention.
+func tokenEntryFromRaw(raw map[string]any) daemonTokenSummary {
+	pick := func(keys ...string) int {
+		for _, k := range keys {
+			if _, ok := raw[k]; ok {
+				return intField(raw, k)
+			}
+		}
+		return 0
+	}
+	var e daemonTokenSummary
+	e.Input = pick("input", "input_tokens")
+	e.Output = pick("output", "output_tokens")
+	e.Thinking = pick("thinking", "thinking_tokens", "reasoning_tokens", "reasoning")
+	if _, ok := raw["cached"]; ok {
+		e.Cached = intField(raw, "cached")
+	} else {
+		e.Cached = intField(raw, "cache_read_input_tokens") + intField(raw, "cache_creation_input_tokens")
+	}
+	return e
+}
+
+// daemonTokensFromState reads daemon.json running token totals. Current
+// claude-p/claude-code runs store UI-only usage in "cli_tokens"; older
+// daemon.json files may only have the legacy "tokens" snapshot. Calls stays
+// 0 for the legacy snapshot because it does not retain a per-call count.
+func daemonTokensFromState(raw map[string]any) daemonTokenSummary {
+	// CLI backends such as claude-p intentionally do not write LingTai token
+	// ledgers. The kernel persists their UI-only usage in cli_tokens so
+	// /daemons can still show what Claude Code reported. Older daemon.json
+	// files only have tokens, so keep that as a fallback.
+	if block, ok := raw["cli_tokens"].(map[string]any); ok {
+		cli := daemonTokenSummary{
+			Input:    intField(block, "input"),
+			Output:   intField(block, "output"),
+			Thinking: intField(block, "thinking"),
+			Cached:   intField(block, "cached"),
+			Calls:    intField(block, "calls"),
+		}
+		if cli.Calls > 0 || cli.Input+cli.Output+cli.Thinking+cli.Cached > 0 {
+			return cli
+		}
+	}
+	block, ok := raw["tokens"].(map[string]any)
+	if !ok {
+		return daemonTokenSummary{}
+	}
+	return daemonTokenSummary{
+		Input:    intField(block, "input"),
+		Output:   intField(block, "output"),
+		Thinking: intField(block, "thinking"),
+		Cached:   intField(block, "cached"),
+	}
 }
 
 func splitLines(s string) []string {
@@ -975,11 +1050,22 @@ func daemonDuration(d daemonSummary) string {
 }
 
 func daemonTokenText(t daemonTokenSummary) string {
-	if t.Calls == 0 {
+	total := t.Input + t.Output + t.Thinking
+	// Nothing to show when there are neither calls nor token totals. The
+	// daemon.json fallback (CLI backends) yields totals with Calls==0, so we
+	// can't gate on Calls alone.
+	if t.Calls == 0 && total == 0 && t.Cached == 0 {
 		return ""
 	}
-	total := t.Input + t.Output + t.Thinking
-	return fmt.Sprintf("%d calls / %d tokens (in %d, out %d, think %d, cached %d)", t.Calls, total, t.Input, t.Output, t.Thinking, t.Cached)
+	if t.Calls == 0 {
+		// daemon.json snapshot: totals without a per-call count.
+		return fmt.Sprintf("%s tokens (in %s, out %s, think %s, cached %s)",
+			formatComma(int64(total)), formatComma(int64(t.Input)), formatComma(int64(t.Output)),
+			formatComma(int64(t.Thinking)), formatComma(int64(t.Cached)))
+	}
+	return fmt.Sprintf("%s calls / %s tokens (in %s, out %s, think %s, cached %s)",
+		formatComma(int64(t.Calls)), formatComma(int64(total)), formatComma(int64(t.Input)),
+		formatComma(int64(t.Output)), formatComma(int64(t.Thinking)), formatComma(int64(t.Cached)))
 }
 
 func parseDaemonTime(ts string) (time.Time, bool) {
@@ -1004,10 +1090,29 @@ func formatSeconds(seconds float64) string {
 }
 
 func shortTime(ts string) string {
+	return formatDaemonTimestamp(ts)
+}
+
+// formatDaemonTimestamp renders a daemon timestamp in local time with an
+// explicit UTC offset marker, keeping seconds resolution because daemon
+// events fire at sub-minute granularity (for example,
+// 2026-06-12 20:00:05 U-7:00). Mirrors the /kanban offset style
+// (utcOffsetLabel) without coupling to its minute-only format.
+//
+// Non-parseable legacy strings keep the old compact behavior: the leading
+// "YYYY-MM-DD HH:MM:SS" slice with the RFC3339 "T" replaced by a space.
+func formatDaemonTimestamp(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		local := t.Local()
+		return local.Format("2006-01-02 15:04:05") + " " + utcOffsetLabel(local)
+	}
 	if len(ts) >= 19 {
 		return strings.ReplaceAll(ts[:19], "T", " ")
 	}
-	return ts
+	return strings.ReplaceAll(ts, "T", " ")
 }
 
 func appendWrappedFull(lines []string, text string, maxW int, prefix string) []string {

--- a/tui/internal/tui/daemons_test.go
+++ b/tui/internal/tui/daemons_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -170,6 +171,11 @@ func TestRenderDetailShowsPresetNearBackend(t *testing.T) {
 }
 
 func TestRenderDetailShowsDaemonTimingAndTokens(t *testing.T) {
+	// Pin the zone so the localized timestamps below are deterministic.
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
 	m := DaemonsModel{
 		items: []daemonSummary{{
 			Dir:         "/tmp/daemons/em-7",
@@ -183,7 +189,7 @@ func TestRenderDetailShowsDaemonTimingAndTokens(t *testing.T) {
 		}},
 	}
 	out := m.renderDetail(120)
-	for _, want := range []string{"duration", "6s", "finished", "2026-06-09T01:02:09Z", "last event", "2026-06-09T01:02:06Z", "tokens", "2 calls / 20 tokens"} {
+	for _, want := range []string{"duration", "6s", "finished", "2026-06-08 18:02:09 U-7:00", "last event", "2026-06-08 18:02:06 U-7:00", "tokens", "2 calls / 20 tokens"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("renderDetail missing %q; got:\n%s", want, out)
 		}
@@ -302,4 +308,157 @@ func testDaemonsModelWithItems(t *testing.T, count, height int) DaemonsModel {
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: height})
 	m, _ = m.Update(daemonsLoadMsg{selectedDir: agentDir, items: items})
 	return m
+}
+
+func TestDaemonTimestampRendersLocalOffset(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
+	got := formatDaemonTimestamp("2026-06-13T03:00:05Z")
+	want := "2026-06-12 20:00:05 U-7:00"
+	if got != want {
+		t.Fatalf("formatDaemonTimestamp() = %q, want %q", got, want)
+	}
+}
+
+func TestDaemonTimestampKeepsInvalidLegacyCompact(t *testing.T) {
+	// Non-parseable legacy strings fall back to the old compact trim.
+	got := formatDaemonTimestamp("2026-06-13T03:00:05-no-zone-here")
+	want := "2026-06-13 03:00:05"
+	if got != want {
+		t.Fatalf("formatDaemonTimestamp() = %q, want legacy compact %q", got, want)
+	}
+	if got := formatDaemonTimestamp(""); got != "" {
+		t.Fatalf("formatDaemonTimestamp(\"\") = %q, want empty", got)
+	}
+}
+
+func TestRenderDetailTimestampsUseLocalOffset(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("test", -7*60*60)
+
+	m := DaemonsModel{
+		items: []daemonSummary{{
+			Dir:         "/tmp/daemons/em-7",
+			State:       "done",
+			Backend:     "lingtai",
+			StartedAt:   "2026-06-09T01:02:03Z",
+			FinishedAt:  "2026-06-09T01:02:09Z",
+			LastEventAt: "2026-06-09T01:02:06Z",
+			Chats: []daemonChat{
+				{Role: "assistant", Kind: "reply", Text: "chat line", TS: "2026-06-09T01:02:07Z"},
+			},
+			Events: []daemonEvent{
+				{Event: "tool_call", Name: "read", Raw: `{"event":"tool_call"}`, TS: "2026-06-09T01:02:05Z"},
+			},
+		}},
+	}
+	out := m.renderDetail(120)
+	// Metadata + row timestamps all rendered in local time with a U-offset
+	// marker. The raw RFC3339 "Z" form must not survive into the view.
+	for _, want := range []string{
+		"2026-06-08 18:02:03 U-7:00", // started
+		"2026-06-08 18:02:09 U-7:00", // finished
+		"2026-06-08 18:02:06 U-7:00", // last event
+		"2026-06-08 18:02:07 U-7:00", // chat row
+		"2026-06-08 18:02:05 U-7:00", // event row
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("renderDetail missing local-offset time %q; got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "2026-06-09T01:02") {
+		t.Fatalf("renderDetail leaked raw RFC3339 timestamp; got:\n%s", out)
+	}
+}
+
+func TestReadDaemonTokensSupportsClaudeNativeFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token_ledger.jsonl")
+	// Claude Code / claude-p style usage: Anthropic Messages-API field names
+	// (input_tokens/output_tokens/cache_read_input_tokens/cache_creation_input_tokens
+	// + reasoning_tokens), mixed with one canonical-schema row.
+	body := strings.Join([]string{
+		`{"input_tokens":100,"output_tokens":40,"reasoning_tokens":7,"cache_read_input_tokens":60,"cache_creation_input_tokens":20}`,
+		`{"input":5,"output":3,"thinking":1,"cached":2}`,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readDaemonTokens(path)
+	// input = 100 + 5; output = 40 + 3; thinking = 7 + 1;
+	// cached = (cache_read 60 + cache_creation 20) + 2.
+	if got.Calls != 2 || got.Input != 105 || got.Output != 43 || got.Thinking != 8 || got.Cached != 82 {
+		t.Fatalf("claude-native tokens not summed: %#v", got)
+	}
+}
+
+func TestReadDaemonSummaryFallsBackToDaemonJSONTokens(t *testing.T) {
+	dir := t.TempDir()
+	// claude-p / CLI backends never write a token_ledger.jsonl, but the
+	// kernel keeps a running tokens block in daemon.json. Surface that when
+	// the ledger is absent so CLI-backend usage still shows.
+	body := `{"backend":"claude-p","state":"done","tokens":{"input":1200,"output":340,"thinking":15,"cached":900}}`
+	if err := os.WriteFile(filepath.Join(dir, "daemon.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readDaemonSummary(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tokens.Input != 1200 || got.Tokens.Output != 340 || got.Tokens.Thinking != 15 || got.Tokens.Cached != 900 {
+		t.Fatalf("daemon.json tokens fallback not applied: %#v", got.Tokens)
+	}
+	// Calls is unknown from the daemon.json snapshot; daemonTokenText must
+	// still render when only the block totals are present.
+	// total = input + output + thinking = 1200 + 340 + 15 = 1555.
+	txt := daemonTokenText(got.Tokens)
+	if !strings.Contains(txt, "1,555 tokens") {
+		t.Fatalf("daemonTokenText(%#v) = %q, want a token total", got.Tokens, txt)
+	}
+}
+
+func TestReadDaemonSummaryFallsBackToCLITokens(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"backend":"claude-p","state":"done","tokens":{"input":0,"output":0,"thinking":0,"cached":0},"cli_tokens":{"input":6950,"output":4,"thinking":0,"cached":18689,"calls":1}}`
+	if err := os.WriteFile(filepath.Join(dir, "daemon.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readDaemonSummary(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tokens.Input != 6950 || got.Tokens.Output != 4 || got.Tokens.Cached != 18689 || got.Tokens.Calls != 1 {
+		t.Fatalf("cli_tokens fallback not applied: %#v", got.Tokens)
+	}
+	txt := daemonTokenText(got.Tokens)
+	if !strings.Contains(txt, "1 calls") || !strings.Contains(txt, "6,954 tokens") || !strings.Contains(txt, "cached 18,689") {
+		t.Fatalf("daemonTokenText(%#v) = %q, want cli token details", got.Tokens, txt)
+	}
+}
+
+func TestReadDaemonSummaryPrefersLedgerOverDaemonJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "logs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"backend":"lingtai","tokens":{"input":1,"output":1,"thinking":1,"cached":1}}`
+	if err := os.WriteFile(filepath.Join(dir, "daemon.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "logs", "token_ledger.jsonl"),
+		[]byte(`{"input":50,"output":20,"thinking":3,"cached":10}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readDaemonSummary(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The per-call ledger is authoritative when present; the daemon.json
+	// block is only a fallback.
+	if got.Tokens.Calls != 1 || got.Tokens.Input != 50 || got.Tokens.Output != 20 {
+		t.Fatalf("ledger should win over daemon.json block: %#v", got.Tokens)
+	}
 }


### PR DESCRIPTION
## Summary
- render `/daemons` metadata, chat, and event timestamps in local time with explicit UTC offset
- display daemon token totals from ledger, daemon.json tokens, and new kernel `cli_tokens` for claude-p/Claude Code usage
- add focused timestamp and token-display tests

## Tests
- `go test ./internal/tui`
- `go test ./...` (from `tui/`)
- `git diff --check`