### PR TITLE
Tighten repo hygiene ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,10 +49,9 @@ app/web/config.json
 app/web/frontend/dist/
 node_modules/
 
-# Superpowers specs and plans (local only)
+# Local-only docs drafts. Keep tracked design docs visible to git;
+# `docs/superpowers/` and `docs/plans/` contain checked-in specs.
 docs/specs/
-docs/superpowers/
-docs/plans/
 docs/zhoubao/
 portal/docs/
 
@@ -82,8 +81,6 @@ _telegram_agent/
 
 # Graphify knowledge-graph output (regenerated locally; see docs/graphify.md)
 graphify-out/
-
-.worktrees
 
 # Local-only files: codex CLI agent guidance, ccusage screenshots
 AGENTS.md

--- a/tui/.gitignore
+++ b/tui/.gitignore
@@ -2,6 +2,11 @@
 /web/dist/*
 !/web/dist/.gitkeep
 /bin/
-packages/*/bin/
+packages/*/bin/*
+!/packages/tui/bin/
+!/packages/tui/bin/lingtai.js
 *.exe
 .DS_Store
+
+# Local logs emitted by TUI tests and runtime smoke runs.
+/internal/tui/logs/


### PR DESCRIPTION
## Summary\n- keep tracked design docs under docs/superpowers and docs/plans visible to git instead of ignoring them as local-only drafts\n- remove a duplicate .worktrees ignore entry\n- make the TUI package-bin ignore rule keep generated bin files ignored while explicitly allowing the tracked npm launcher shim\n- ignore local TUI test/runtime logs under tui/internal/tui/logs\n\n## Audit notes\n- Systematic scan found no node_modules/build binaries tracked\n- Remaining tracked-but-ignored files are the deliberate report HTML files covered by the existing reports/*.html local-output policy\n- Did not delete prompt/archive, discussions, reports, docs assets, or local worktrees\n\n## Validation\n- git diff --check\n- cd tui && go test ./internal/tui ./internal/preset