### PR TITLE
Preserve portal meta sibling fields

### DIFF
--- a/portal/internal/migrate/migrate.go
+++ b/portal/internal/migrate/migrate.go
@@ -96,12 +96,18 @@ func Run(lingtaiDir string) error {
 	metaPath := filepath.Join(lingtaiDir, "meta.json")
 
 	current := 0
+	rawMeta := map[string]json.RawMessage{}
 	if data, err := os.ReadFile(metaPath); err == nil {
+		if err := json.Unmarshal(data, &rawMeta); err != nil {
+			return fmt.Errorf("parse meta.json: %w", err)
+		}
 		var m metaFile
 		if err := json.Unmarshal(data, &m); err != nil {
 			return fmt.Errorf("parse meta.json: %w", err)
 		}
 		current = m.Version
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read meta.json: %w", err)
 	}
 
 	if current > CurrentVersion {
@@ -124,8 +130,21 @@ func Run(lingtaiDir string) error {
 		}
 	}
 
-	// Write new version atomically (write temp + rename)
-	newMeta, _ := json.Marshal(metaFile{Version: CurrentVersion})
+	// Write new version atomically (write temp + rename) while preserving
+	// sibling fields that may be maintained by the TUI binary in the shared
+	// .lingtai/meta.json file.
+	if rawMeta == nil {
+		rawMeta = map[string]json.RawMessage{}
+	}
+	versionData, err := json.Marshal(CurrentVersion)
+	if err != nil {
+		return fmt.Errorf("marshal meta.json version: %w", err)
+	}
+	rawMeta["version"] = versionData
+	newMeta, err := json.Marshal(rawMeta)
+	if err != nil {
+		return fmt.Errorf("marshal meta.json: %w", err)
+	}
 	tmpPath := metaPath + ".tmp"
 	if err := os.WriteFile(tmpPath, newMeta, 0o644); err != nil {
 		return fmt.Errorf("write meta.json.tmp: %w", err)

--- a/portal/internal/migrate/migrate_test.go
+++ b/portal/internal/migrate/migrate_test.go
@@ -55,6 +55,64 @@ func TestRunRejectsTooNew(t *testing.T) {
 	}
 }
 
+func TestRunPreservesMetaSiblingFields(t *testing.T) {
+	dir := t.TempDir()
+	lingtaiDir := filepath.Join(dir, ".lingtai")
+	os.MkdirAll(lingtaiDir, 0o755)
+
+	writeFile(t, filepath.Join(lingtaiDir, "meta.json"), `{
+		"version": 38,
+		"addon_comment_cleanup_notified": true,
+		"custom_state": {"owner": "tui"},
+		"list_state": [1, 2, 3]
+	}`)
+
+	if err := Run(lingtaiDir); err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(lingtaiDir, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta.json: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse meta.json as raw map: %v", err)
+	}
+
+	var version int
+	if err := json.Unmarshal(raw["version"], &version); err != nil {
+		t.Fatalf("parse version: %v", err)
+	}
+	if version != CurrentVersion {
+		t.Fatalf("version = %d, want %d", version, CurrentVersion)
+	}
+
+	var notified bool
+	if err := json.Unmarshal(raw["addon_comment_cleanup_notified"], &notified); err != nil {
+		t.Fatalf("parse addon_comment_cleanup_notified: %v", err)
+	}
+	if !notified {
+		t.Fatal("addon_comment_cleanup_notified was not preserved")
+	}
+
+	var custom map[string]string
+	if err := json.Unmarshal(raw["custom_state"], &custom); err != nil {
+		t.Fatalf("parse custom_state: %v", err)
+	}
+	if custom["owner"] != "tui" {
+		t.Fatalf("custom_state = %#v, want owner=tui", custom)
+	}
+
+	var list []int
+	if err := json.Unmarshal(raw["list_state"], &list); err != nil {
+		t.Fatalf("parse list_state: %v", err)
+	}
+	if len(list) != 3 || list[2] != 3 {
+		t.Fatalf("list_state = %#v, want [1 2 3]", list)
+	}
+}
+
 func TestMigrateTopologyToPortal(t *testing.T) {
 	dir := t.TempDir()
 	lingtaiDir := filepath.Join(dir, ".lingtai")

--- a/portal/internal/migrate/parity_test.go
+++ b/portal/internal/migrate/parity_test.go
@@ -1,0 +1,77 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+type registryEntry struct {
+	Version int
+	Name    string
+}
+
+func TestMigrationCurrentVersionMatchesTUI(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	portalVersion, portalEntries := readMigrationRegistry(t, filepath.Join(repoRoot, "portal", "internal", "migrate", "migrate.go"))
+	tuiVersion, tuiEntries := readMigrationRegistry(t, filepath.Join(repoRoot, "tui", "internal", "migrate", "migrate.go"))
+
+	if portalVersion != tuiVersion {
+		t.Fatalf("portal CurrentVersion = %d, TUI CurrentVersion = %d", portalVersion, tuiVersion)
+	}
+	if len(portalEntries) != portalVersion {
+		t.Fatalf("portal migrations = %d, CurrentVersion = %d", len(portalEntries), portalVersion)
+	}
+	if len(tuiEntries) != tuiVersion {
+		t.Fatalf("TUI migrations = %d, CurrentVersion = %d", len(tuiEntries), tuiVersion)
+	}
+}
+
+func readMigrationRegistry(t *testing.T, path string) (int, []registryEntry) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(data)
+
+	versionMatch := regexp.MustCompile(`const\s+CurrentVersion\s*=\s*(\d+)`).FindStringSubmatch(text)
+	if versionMatch == nil {
+		t.Fatalf("CurrentVersion not found in %s", path)
+	}
+	version, err := strconv.Atoi(versionMatch[1])
+	if err != nil {
+		t.Fatalf("parse CurrentVersion in %s: %v", path, err)
+	}
+
+	entryMatches := regexp.MustCompile(`\{Version:\s*(\d+),\s*Name:\s*"([^"]+)"`).FindAllStringSubmatch(text, -1)
+	if len(entryMatches) == 0 {
+		t.Fatalf("no migrations found in %s", path)
+	}
+	entries := make([]registryEntry, 0, len(entryMatches))
+	seen := map[int]string{}
+	for _, match := range entryMatches {
+		entryVersion, err := strconv.Atoi(match[1])
+		if err != nil {
+			t.Fatalf("parse migration version in %s: %v", path, err)
+		}
+		name := match[2]
+		if prev, ok := seen[entryVersion]; ok {
+			t.Fatalf("duplicate migration version %d in %s: %s and %s", entryVersion, path, prev, name)
+		}
+		seen[entryVersion] = name
+		entries = append(entries, registryEntry{Version: entryVersion, Name: name})
+	}
+	for i, entry := range entries {
+		wantVersion := i + 1
+		if entry.Version != wantVersion {
+			t.Fatalf("migration %q in %s has version %d, want contiguous version %d", entry.Name, path, entry.Version, wantVersion)
+		}
+	}
+	if entries[len(entries)-1].Version != version {
+		t.Fatalf("%s has CurrentVersion %d but last migration version %d", path, version, entries[len(entries)-1].Version)
+	}
+	return version, entries
+}


### PR DESCRIPTION
## Summary
- preserve non-version sibling fields when Portal migrations rewrite shared `.lingtai/meta.json`
- add a regression test covering TUI-owned/custom sibling fields during Portal migration
- add a lightweight Portal/TUI migration current-version/registry-continuity guard

## Validation
- `git diff --check`
- `cd portal && go test ./internal/...`
- `cd tui && go test ./internal/migrate`

## Note
- `cd portal && go test ./...` was not used as the main validation in this fresh worktree because the root package expects generated `portal/web/dist` for `go:embed`.
