### PR TITLE
Stream TUI JSONL ledger reads

### DIFF
--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -19,13 +19,15 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 | `WriteInquiry` | `tui/internal/fs/agent.go:211` | writes `.inquiry` signal file; no-op if `.inquiry` or `.inquiry.taken` exists |
 | `DiscoverAgents(baseDir)` | `tui/internal/fs/agent.go:240` | scans for all subdirectories with `.agent.json` |
 | `ReadStatus(dir)` | `tui/internal/fs/agent.go:303` | reads `.status.json` → `AgentStatus` (tokens, runtime) |
-| `ReadContextStats(dir)` | `tui/internal/fs/agent.go:315` | summarizes retained `history/chat_history.jsonl`: entries, role counts, text input/output, tool calls/results, and per-tool distribution |
-| `AggregateTokens(dirs)` | `tui/internal/fs/agent.go:439` | sums `TokenTotals` across multiple agent ledgers |
-| `SumTokenLedger(path)` | `tui/internal/fs/agent.go:458` | sums a single main-agent `token_ledger.jsonl` → `TokenTotals`, skipping historical daemon-mirrored rows (`source=daemon`, `em_id`, or `run_id`) |
-| `SumTokenLedgerByProvider` | `tui/internal/fs/agent.go:513` | groups main-agent ledger entries by derived provider name + recent N entries, skipping daemon-mirrored rows so `/kanban` main detail stays separate from daemon detail |
+| `ReadContextStats(dir)` | `tui/internal/fs/agent.go:320` | summarizes retained `history/chat_history.jsonl`: entries, role counts, text input/output, tool calls/results, and per-tool distribution |
+| `AggregateTokens(dirs)` | `tui/internal/fs/agent.go:434` | sums `TokenTotals` across multiple agent ledgers |
+| `SumTokenLedger(path)` | `tui/internal/fs/agent.go:451` | sums a single main-agent `token_ledger.jsonl` → `TokenTotals`, skipping historical daemon-mirrored rows (`source=daemon`, `em_id`, or `run_id`) |
+| `SumTokenLedgerByProvider` | `tui/internal/fs/agent.go:549` | groups main-agent ledger entries by derived provider name + recent N entries, skipping daemon-mirrored rows so `/kanban` main detail stays separate from daemon detail |
+| **jsonl.go** | | |
+| `forEachJSONLLine(path, fn)` | `tui/internal/fs/jsonl.go:16` | streams JSONL files one line at a time without `ReadFile`/`strings.Split`, avoiding duplicate buffers and Scanner token limits for ledger/history hot paths |
 | **daemon_ledger.go** | | |
-| `DaemonRecentLedger(agentDir, recentN)` | `tui/internal/fs/daemon_ledger.go:41` | aggregates recent per-call token ledgers from `daemons/<run_id>/logs/token_ledger.jsonl`, newest first, tagged with daemon run id/handle/state for kanban Ctrl+D split lanes |
-| `DeriveLedgerProvider` | `tui/internal/fs/agent.go:525` | maps endpoint host / model prefix → canonical provider name |
+| `DaemonRecentLedger(agentDir, recentN)` | `tui/internal/fs/daemon_ledger.go:40` | aggregates recent per-call token ledgers from `daemons/<run_id>/logs/token_ledger.jsonl`, newest first, tagged with daemon run id/handle/state for kanban Ctrl+D split lanes |
+| `DeriveLedgerProvider` | `tui/internal/fs/agent.go:600` | maps endpoint host / model prefix → canonical provider name |
 | **heartbeat.go** | | |
 | `IsAlive(dir, thresholdSec)` | `tui/internal/fs/heartbeat.go:11` | reads `.agent.heartbeat` unix timestamp, returns `age < threshold` |
 | `IsAliveHuman()` | `tui/internal/fs/heartbeat.go:24` | always `true` |

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 )
 
 // agentManifest is the raw JSON shape of .agent.json.
@@ -317,25 +319,16 @@ func ReadStatus(dir string) AgentStatus {
 // treated as empty/partial data so the kanban detail view remains best-effort.
 func ReadContextStats(dir string) ContextStats {
 	var stats ContextStats
-	data, err := os.ReadFile(filepath.Join(dir, "history", "chat_history.jsonl"))
-	if err != nil {
-		return stats
-	}
-
 	callCounts := map[string]int{}
 	resultCounts := map[string]int{}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	_ = forEachJSONLLine(filepath.Join(dir, "history", "chat_history.jsonl"), func(line []byte) {
 		var entry struct {
 			Role    string          `json:"role"`
 			System  string          `json:"system"`
 			Content json.RawMessage `json:"content"`
 		}
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			continue
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return
 		}
 
 		stats.Entries++
@@ -397,7 +390,7 @@ func ReadContextStats(dir string) ContextStats {
 				}
 			}
 		}
-	}
+	})
 
 	names := make([]string, 0, len(callCounts)+len(resultCounts))
 	seen := map[string]bool{}
@@ -457,29 +450,72 @@ func AggregateTokens(dirs []string) TokenTotals {
 // missing or unreadable.
 func SumTokenLedger(path string) TokenTotals {
 	var t TokenTotals
-	data, err := os.ReadFile(path)
-	if err != nil {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
 		return t
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	if cached, ok := cachedTokenLedgerTotals(path, info); ok {
+		return cached
+	}
+
+	t, err = sumTokenLedgerFile(path)
+	if err != nil {
+		return TokenTotals{}
+	}
+	storeTokenLedgerTotals(path, info, t)
+	return t
+}
+
+func sumTokenLedgerFile(path string) (TokenTotals, error) {
+	var t TokenTotals
+	err := forEachJSONLLine(path, func(line []byte) {
 		var entry LedgerEntry
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			continue
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return
 		}
 		if isDaemonLedgerEntry(entry) {
-			continue
+			return
 		}
 		t.Input += entry.Input
 		t.Output += entry.Output
 		t.Thinking += entry.Thinking
 		t.Cached += entry.Cached
 		t.APICalls++
+	})
+	return t, err
+}
+
+type tokenLedgerCacheEntry struct {
+	size    int64
+	modTime time.Time
+	totals  TokenTotals
+}
+
+var tokenLedgerTotalsCache = struct {
+	sync.Mutex
+	byPath map[string]tokenLedgerCacheEntry
+}{byPath: map[string]tokenLedgerCacheEntry{}}
+
+func cachedTokenLedgerTotals(path string, info os.FileInfo) (TokenTotals, bool) {
+	key := filepath.Clean(path)
+	tokenLedgerTotalsCache.Lock()
+	defer tokenLedgerTotalsCache.Unlock()
+	entry, ok := tokenLedgerTotalsCache.byPath[key]
+	if !ok || entry.size != info.Size() || !entry.modTime.Equal(info.ModTime()) {
+		return TokenTotals{}, false
 	}
-	return t
+	return entry.totals, true
+}
+
+func storeTokenLedgerTotals(path string, info os.FileInfo, totals TokenTotals) {
+	key := filepath.Clean(path)
+	tokenLedgerTotalsCache.Lock()
+	defer tokenLedgerTotalsCache.Unlock()
+	tokenLedgerTotalsCache.byPath[key] = tokenLedgerCacheEntry{
+		size:    info.Size(),
+		modTime: info.ModTime(),
+		totals:  totals,
+	}
 }
 
 // LedgerEntry is a single per-call line from logs/token_ledger.jsonl
@@ -514,22 +550,13 @@ func SumTokenLedgerByProvider(path string, recentN int) (
 	byProvider map[string]TokenTotals, recent []LedgerEntry,
 ) {
 	byProvider = map[string]TokenTotals{}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return byProvider, nil
-	}
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	_ = forEachJSONLLine(path, func(line []byte) {
 		var entry LedgerEntry
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			continue
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return
 		}
 		if isDaemonLedgerEntry(entry) {
-			continue
+			return
 		}
 		provider := DeriveLedgerProvider(entry.Endpoint, entry.Model)
 		t := byProvider[provider]
@@ -540,7 +567,11 @@ func SumTokenLedgerByProvider(path string, recentN int) (
 		t.APICalls++
 		byProvider[provider] = t
 		recent = append(recent, entry)
-	}
+		if recentN > 0 && len(recent) > recentN {
+			copy(recent, recent[len(recent)-recentN:])
+			recent = recent[:recentN]
+		}
+	})
 	// Trim to the last recentN entries, newest last in file → newest at
 	// the end of `recent`. Reverse so callers can iterate "newest first".
 	if recentN > 0 && len(recent) > recentN {

--- a/tui/internal/fs/agent_test.go
+++ b/tui/internal/fs/agent_test.go
@@ -418,3 +418,70 @@ func TestSumTokenLedgerByProviderSkipsDaemonRows(t *testing.T) {
 		t.Fatalf("daemon deepseek row should be excluded: %#v", byProvider)
 	}
 }
+
+func TestSumTokenLedgerStreamsLongLines(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	entry := LedgerEntry{
+		Input:  3,
+		Output: 4,
+		Cached: 6,
+		Model:  strings.Repeat("m", 70*1024),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ledgerPath, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	totals := SumTokenLedger(ledgerPath)
+	if totals.APICalls != 1 || totals.Input != 3 || totals.Output != 4 || totals.Cached != 6 {
+		t.Fatalf("totals = %+v, want long line counted", totals)
+	}
+}
+
+func TestSumTokenLedgerCacheInvalidatesOnSizeChange(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	first := `{"input":1,"output":2}` + "\n"
+	if err := os.WriteFile(ledgerPath, []byte(first), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if totals := SumTokenLedger(ledgerPath); totals.APICalls != 1 || totals.Input != 1 || totals.Output != 2 {
+		t.Fatalf("first totals = %+v, want one row", totals)
+	}
+
+	second := first + `{"input":3,"output":4}` + "\n"
+	if err := os.WriteFile(ledgerPath, []byte(second), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if totals := SumTokenLedger(ledgerPath); totals.APICalls != 2 || totals.Input != 4 || totals.Output != 6 {
+		t.Fatalf("second totals = %+v, want cache invalidated after append", totals)
+	}
+}
+
+func TestSumTokenLedgerByProviderBoundsRecent(t *testing.T) {
+	dir := t.TempDir()
+	ledgerPath := filepath.Join(dir, "token_ledger.jsonl")
+	body := strings.Join([]string{
+		`{"ts":"2026-06-20T03:00:00Z","input":1,"model":"gpt-5.5","endpoint":"https://api.openai.com/v1"}`,
+		`{"ts":"2026-06-20T03:00:01Z","input":2,"model":"gpt-5.5","endpoint":"https://api.openai.com/v1"}`,
+		`{"ts":"2026-06-20T03:00:02Z","input":3,"model":"deepseek-v4","endpoint":"https://api.deepseek.com"}`,
+	}, "\n")
+	if err := os.WriteFile(ledgerPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	byProvider, recent := SumTokenLedgerByProvider(ledgerPath, 2)
+	if len(recent) != 2 {
+		t.Fatalf("recent len = %d, want 2: %#v", len(recent), recent)
+	}
+	if recent[0].TS != "2026-06-20T03:00:02Z" || recent[1].TS != "2026-06-20T03:00:01Z" {
+		t.Fatalf("recent order = %#v, want newest two first", recent)
+	}
+	if byProvider["openai"].APICalls != 2 || byProvider["deepseek"].APICalls != 1 {
+		t.Fatalf("byProvider = %#v, want all provider totals", byProvider)
+	}
+}

--- a/tui/internal/fs/daemon_ledger.go
+++ b/tui/internal/fs/daemon_ledger.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 )
 
 // DaemonLedgerEntry is a single per-call token_ledger.jsonl line from a
@@ -102,21 +101,13 @@ func readDaemonIdentity(path string) daemonIdentity {
 // file into LedgerEntry values (file order preserved). Missing file or
 // malformed lines are skipped silently.
 func readLedgerEntries(path string) []LedgerEntry {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil
-	}
 	var out []LedgerEntry
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	_ = forEachJSONLLine(path, func(line []byte) {
 		var e LedgerEntry
-		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			continue
+		if err := json.Unmarshal(line, &e); err != nil {
+			return
 		}
 		out = append(out, e)
-	}
+	})
 	return out
 }

--- a/tui/internal/fs/jsonl.go
+++ b/tui/internal/fs/jsonl.go
@@ -1,0 +1,40 @@
+package fs
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+)
+
+const jsonlReaderBufferSize = 64 * 1024
+
+// forEachJSONLLine streams a JSONL file one line at a time. Blank lines are
+// skipped. It intentionally uses Reader.ReadBytes instead of bufio.Scanner so
+// unusually large JSON payloads are not silently capped at Scanner's default
+// 64 KiB token limit.
+func forEachJSONLLine(path string, fn func([]byte)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	r := bufio.NewReaderSize(f, jsonlReaderBufferSize)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			line = bytes.TrimSpace(line)
+			if len(line) > 0 {
+				fn(line)
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared streaming JSONL reader for TUI filesystem hot paths
- stream context stats, main token ledger, provider ledger, and daemon ledger reads instead of full `ReadFile + string + Split`
- cache `SumTokenLedger` totals by ledger path + file size + mtime so `/props` refreshes can skip unchanged ledgers
- bound provider-detail recent calls while preserving all provider totals
- update `tui/internal/fs/ANATOMY.md` for the new helper and shifted citations

## Validation
- `git diff --check`
- custom fs ANATOMY citation checker: 47 Go citations checked
- `cd tui && go test ./...`

## Notes
- Scope intentionally avoids Mail/SessionCache, daemon view, and library view changes.
- JSONL streaming uses `bufio.Reader.ReadBytes` rather than `bufio.Scanner` to avoid Scanner's default 64 KiB token cap.
