### PR TITLE
Make Codex reasoning effort default to xhigh

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -483,6 +483,7 @@
   "preset_editor.field_provider": "provider",
   "preset_editor.field_model": "model",
   "preset_editor.field_service_tier": "service_tier",
+  "preset_editor.field_thinking": "Reasoning effort",
   "preset_editor.field_api_compat": "api_compat",
   "preset_editor.field_base_url": "base_url",
   "preset_editor.field_api_key_env": "api_key_env",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -478,6 +478,7 @@
   "preset_editor.field_provider": "提供商",
   "preset_editor.field_model": "模型",
   "preset_editor.field_service_tier": "服务层",
+  "preset_editor.field_thinking": "推理强度",
   "preset_editor.field_api_compat": "API 兼容",
   "preset_editor.field_base_url": "端点",
   "preset_editor.field_api_key_env": "密钥环境变量",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -478,6 +478,7 @@
   "preset_editor.field_provider": "提供商",
   "preset_editor.field_model": "模型",
   "preset_editor.field_service_tier": "服务层级",
+  "preset_editor.field_thinking": "推理强度",
   "preset_editor.field_api_compat": "API 兼容",
   "preset_editor.field_base_url": "端点",
   "preset_editor.field_api_key_env": "密钥环境变量",

--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1022,6 +1022,11 @@ func codexPreset() Preset {
 				"provider": "codex", "model": "gpt-5.5",
 				"api_key": nil, "api_key_env": "",
 				"base_url": "https://chatgpt.com/backend-api/codex",
+				// LingTai is the primary brain, so Codex runs at maximum
+				// reasoning effort by default. Carried explicitly
+				// here (not a UI-only fallback) so the running session and
+				// generated init.json actually receive xhigh.
+				"thinking": "xhigh",
 			},
 			"capabilities": map[string]interface{}{
 				"web_search": cx,

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -294,6 +294,9 @@ func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
 	if _, ok := llm["service_tier"]; ok {
 		t.Fatalf("codex preset default should omit llm.service_tier; got %#v", llm["service_tier"])
 	}
+	if _, ok := llm["thinking"]; ok {
+		t.Fatalf("codex preset default should omit llm.thinking; got %#v", llm["thinking"])
+	}
 
 	tmpDir := t.TempDir()
 	lingtaiDir := filepath.Join(tmpDir, ".lingtai")
@@ -317,6 +320,9 @@ func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
 	generatedLLM := manifest["llm"].(map[string]interface{})
 	if _, ok := generatedLLM["service_tier"]; ok {
 		t.Fatalf("generated codex init.json should omit llm.service_tier; got %#v", generatedLLM["service_tier"])
+	}
+	if _, ok := generatedLLM["thinking"]; ok {
+		t.Fatalf("generated codex init.json should omit llm.thinking; got %#v", generatedLLM["thinking"])
 	}
 }
 

--- a/tui/internal/preset/preset_test.go
+++ b/tui/internal/preset/preset_test.go
@@ -285,7 +285,7 @@ func TestGenerateInitJSON_ProducesValidJSON(t *testing.T) {
 	})
 }
 
-func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
+func TestCodexPresetDefaultOmitsServiceTierAndSetsThinking(t *testing.T) {
 	p := codexPreset()
 	llm, ok := p.Manifest["llm"].(map[string]interface{})
 	if !ok {
@@ -294,8 +294,11 @@ func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
 	if _, ok := llm["service_tier"]; ok {
 		t.Fatalf("codex preset default should omit llm.service_tier; got %#v", llm["service_tier"])
 	}
-	if _, ok := llm["thinking"]; ok {
-		t.Fatalf("codex preset default should omit llm.thinking; got %#v", llm["thinking"])
+	// LingTai is the primary brain, so the default Codex preset carries
+	// reasoning effort xhigh explicitly (not a UI-only fallback) so the
+	// running session actually receives it.
+	if got, ok := llm["thinking"].(string); !ok || got != "xhigh" {
+		t.Fatalf("codex preset default should set llm.thinking=xhigh; got %#v", llm["thinking"])
 	}
 
 	tmpDir := t.TempDir()
@@ -321,8 +324,8 @@ func TestCodexPresetDefaultOmitsServiceTier(t *testing.T) {
 	if _, ok := generatedLLM["service_tier"]; ok {
 		t.Fatalf("generated codex init.json should omit llm.service_tier; got %#v", generatedLLM["service_tier"])
 	}
-	if _, ok := generatedLLM["thinking"]; ok {
-		t.Fatalf("generated codex init.json should omit llm.thinking; got %#v", generatedLLM["thinking"])
+	if got, ok := generatedLLM["thinking"].(string); !ok || got != "xhigh" {
+		t.Fatalf("generated codex init.json should set llm.thinking=xhigh; got %#v", generatedLLM["thinking"])
 	}
 }
 

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -49,6 +49,7 @@ const (
 	feProvider
 	feModel
 	feServiceTier
+	feThinking
 	feAPICompat
 	feBaseURL
 	feAPIKey
@@ -77,7 +78,7 @@ var capFieldNames = map[editorField]string{
 // optional/provider-conditional capabilities appear as editable rows.
 var editorFieldOrder = []editorField{
 	feName, feSummary, feTier, feGains, feLoses,
-	feProvider, feModel, feServiceTier, feAPICompat, feBaseURL, feAPIKey,
+	feProvider, feModel, feServiceTier, feThinking, feAPICompat, feBaseURL, feAPIKey,
 	feCapWebSearch, feCapVision,
 	feSave,
 }
@@ -158,6 +159,10 @@ var providerModels = map[string][]string{
 }
 
 var codexServiceTierOptions = []string{"normal", "fast"}
+
+var codexThinkingOptions = []string{"low", "medium", "high", "xhigh"}
+
+const presetEditorFieldLabelWidth = 18
 
 // modelHasVision reports whether a given model accepts image input.
 // Drives both the disabled-row rendering and the model-switch default
@@ -625,7 +630,7 @@ func (m *PresetEditorModel) openInline() (PresetEditorModel, tea.Cmd) {
 			m.input.Focus()
 			m.mode = emInline
 		}
-	case feServiceTier:
+	case feServiceTier, feThinking:
 		if m.isCodexProvider() {
 			m.cycleFocused(+1)
 		}
@@ -885,6 +890,30 @@ func (m *PresetEditorModel) setCodexServiceTier(tier string) {
 	llm["service_tier"] = "fast"
 }
 
+func (m PresetEditorModel) codexThinking() string {
+	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
+	switch asString(llm["thinking"]) {
+	case "low", "medium", "high", "xhigh":
+		return asString(llm["thinking"])
+	default:
+		return "high"
+	}
+}
+
+func (m *PresetEditorModel) setCodexThinking(effort string) {
+	llm := m.llmMap()
+	if asString(llm["provider"]) != "codex" {
+		delete(llm, "thinking")
+		return
+	}
+	switch effort {
+	case "low", "medium", "xhigh":
+		llm["thinking"] = effort
+	default:
+		delete(llm, "thinking")
+	}
+}
+
 func normalizeServiceTier(manifest map[string]interface{}) {
 	llm, _ := manifest["llm"].(map[string]interface{})
 	if llm == nil || asString(llm["provider"]) != "codex" {
@@ -894,6 +923,28 @@ func normalizeServiceTier(manifest map[string]interface{}) {
 		return
 	}
 	delete(llm, "service_tier")
+}
+
+func normalizeThinking(manifest map[string]interface{}) {
+	llm, _ := manifest["llm"].(map[string]interface{})
+	if llm == nil {
+		return
+	}
+	if asString(llm["provider"]) != "codex" {
+		delete(llm, "thinking")
+		return
+	}
+	switch asString(llm["thinking"]) {
+	case "low", "medium", "xhigh":
+		return
+	default:
+		delete(llm, "thinking")
+	}
+}
+
+func normalizeLLMForCommit(manifest map[string]interface{}) {
+	normalizeServiceTier(manifest)
+	normalizeThinking(manifest)
 }
 
 // setExtra writes into Description.Extra, allocating the map on first
@@ -944,6 +995,9 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 		opts := []string{"minimax", "zhipu", "mimo", "deepseek", "nvidia", "openrouter", "codex", "custom"}
 		newProvider := cycleString(opts, m.fieldString(f), dir)
 		m.llmMap()["provider"] = newProvider
+		if newProvider != "codex" {
+			delete(m.llmMap(), "thinking")
+		}
 		// Reset model to the new provider's first canonical entry when the
 		// current model isn't valid for the new provider. Without this, a
 		// minimax→zhipu switch leaves "MiniMax-M3" in model
@@ -992,6 +1046,10 @@ func (m *PresetEditorModel) cycleFocused(dir int) {
 	case feServiceTier:
 		if m.isCodexProvider() {
 			m.setCodexServiceTier(cycleString(codexServiceTierOptions, m.codexServiceTier(), dir))
+		}
+	case feThinking:
+		if m.isCodexProvider() {
+			m.setCodexThinking(cycleString(codexThinkingOptions, m.codexThinking(), dir))
 		}
 	case feTier:
 		// Cycle ""→1→2→3→4→5→"" with → and reverse with ←. tierValues
@@ -1064,7 +1122,7 @@ func (m PresetEditorModel) commit() (PresetEditorModel, tea.Cmd) {
 			delete(llm, "api_key_env")
 		}
 	}
-	normalizeServiceTier(committed.Manifest)
+	normalizeLLMForCommit(committed.Manifest)
 	return m, func() tea.Msg {
 		return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 	}
@@ -1098,7 +1156,7 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 		m.mode = emBrowse
 		m.cloneNameInput.Blur()
 		committed := clonePresetForEditor(m.working)
-		normalizeServiceTier(committed.Manifest)
+		normalizeLLMForCommit(committed.Manifest)
 		return m, func() tea.Msg {
 			return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 		}
@@ -1116,7 +1174,7 @@ func (m PresetEditorModel) updateClonePrompt(msg tea.KeyMsg) (PresetEditorModel,
 		m.mode = emBrowse
 		m.cloneNameInput.Blur()
 		committed := clonePresetForEditor(m.working)
-		normalizeServiceTier(committed.Manifest)
+		normalizeLLMForCommit(committed.Manifest)
 		return m, func() tea.Msg {
 			return PresetEditorCommitMsg{Preset: committed, APIKey: m.apiKey, APIKeySet: m.apiKeySet}
 		}
@@ -1163,6 +1221,8 @@ func (m PresetEditorModel) fieldString(f editorField) string {
 		return s
 	case feServiceTier:
 		return m.codexServiceTier()
+	case feThinking:
+		return m.codexThinking()
 	case feAPICompat:
 		s, _ := llm["api_compat"].(string)
 		return s
@@ -1332,6 +1392,9 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 	if m.fieldVisible(feServiceTier) {
 		rows = append(rows, row(feServiceTier, m.row(feServiceTier, lbl("service_tier"), m.codexServiceTier(), width-4)))
 	}
+	if m.fieldVisible(feThinking) {
+		rows = append(rows, row(feThinking, m.row(feThinking, lbl("thinking"), m.codexThinking(), width-4)))
+	}
 	rows = append(rows, row(feAPICompat, m.row(feAPICompat, lbl("api_compat"), asString(llm["api_compat"]), width-4)))
 	rows = append(rows, row(feBaseURL, m.row(feBaseURL, lbl("base_url"), asString(llm["base_url"]), width-4)))
 	rows = append(rows, row(feAPIKey, m.row(feAPIKey, lbl("api_key"), m.fieldString(feAPIKey), width-4)))
@@ -1366,7 +1429,7 @@ func (m PresetEditorModel) formRows(width int) []presetEditorRow {
 // strip render when the provider has a known model list, so all
 // options are visible at once and ←/→ visibly moves the dot.
 func (m PresetEditorModel) row(f editorField, key, value string, width int) string {
-	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Width(15)
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Width(presetEditorFieldLabelWidth)
 	marker := "  "
 	valStyle := lipgloss.NewStyle()
 	focused := editorFieldOrder[m.cursor] == f
@@ -1387,6 +1450,11 @@ func (m PresetEditorModel) row(f editorField, key, value string, width int) stri
 			return marker + keyStyle.Render(key) + strip
 		}
 	}
+	if f == feThinking {
+		if strip := m.thinkingRadioStrip(focused, valStyle); strip != "" {
+			return marker + keyStyle.Render(key) + strip
+		}
+	}
 	if f == feBaseURL {
 		if strip := m.baseURLRadioStrip(focused, valStyle); strip != "" {
 			return marker + keyStyle.Render(key) + strip
@@ -1396,7 +1464,7 @@ func (m PresetEditorModel) row(f editorField, key, value string, width int) stri
 		value = "—"
 	}
 	if f != feTier {
-		value = truncate(value, width-lipgloss.Width(marker)-15)
+		value = truncate(value, width-lipgloss.Width(marker)-presetEditorFieldLabelWidth)
 	}
 	return marker + keyStyle.Render(key) + valStyle.Render(value)
 }
@@ -1572,6 +1640,27 @@ func (m PresetEditorModel) serviceTierRadioStrip(focused bool, valStyle lipgloss
 	return strings.Join(parts, "  ")
 }
 
+func (m PresetEditorModel) thinkingRadioStrip(focused bool, valStyle lipgloss.Style) string {
+	if !m.isCodexProvider() {
+		return ""
+	}
+	current := m.codexThinking()
+	subtle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	parts := make([]string, 0, len(codexThinkingOptions))
+	for _, effort := range codexThinkingOptions {
+		if effort == current {
+			if focused {
+				parts = append(parts, valStyle.Render("● "+effort))
+			} else {
+				parts = append(parts, "● "+effort)
+			}
+		} else {
+			parts = append(parts, subtle.Render("○ "+effort))
+		}
+	}
+	return strings.Join(parts, "  ")
+}
+
 // baseURLRadioStrip renders the base_url field as a horizontal radio
 // strip showing region labels (e.g. "● CN  ○ INTL") when the current
 // provider has regional endpoints. Returns "" when there's no region
@@ -1607,7 +1696,7 @@ func (m PresetEditorModel) isCyclable(f editorField) bool {
 	switch f {
 	case feProvider, feAPICompat, feTier:
 		return true
-	case feServiceTier:
+	case feServiceTier, feThinking:
 		return m.isCodexProvider()
 	case feModel:
 		provider := asString(m.llmMap()["provider"])
@@ -1744,7 +1833,7 @@ func (m *PresetEditorModel) ensureFocusedVisible() {
 
 func (m PresetEditorModel) fieldVisible(f editorField) bool {
 	switch f {
-	case feServiceTier:
+	case feServiceTier, feThinking:
 		return m.isCodexProvider()
 	default:
 		return true

--- a/tui/internal/tui/preset_editor.go
+++ b/tui/internal/tui/preset_editor.go
@@ -890,13 +890,18 @@ func (m *PresetEditorModel) setCodexServiceTier(tier string) {
 	llm["service_tier"] = "fast"
 }
 
+// codexDefaultThinking is the reasoning effort LingTai applies to Codex
+// when a preset omits (or carries an invalid) llm.thinking. LingTai is the
+// primary brain, so it runs Codex at maximum effort by default.
+const codexDefaultThinking = "xhigh"
+
 func (m PresetEditorModel) codexThinking() string {
 	llm, _ := m.working.Manifest["llm"].(map[string]interface{})
 	switch asString(llm["thinking"]) {
 	case "low", "medium", "high", "xhigh":
 		return asString(llm["thinking"])
 	default:
-		return "high"
+		return codexDefaultThinking
 	}
 }
 
@@ -907,10 +912,12 @@ func (m *PresetEditorModel) setCodexThinking(effort string) {
 		return
 	}
 	switch effort {
-	case "low", "medium", "xhigh":
+	case "low", "medium", "high", "xhigh":
 		llm["thinking"] = effort
 	default:
-		delete(llm, "thinking")
+		// Absent/invalid resolves to the Codex default, persisted
+		// explicitly so the running session actually receives xhigh.
+		llm["thinking"] = codexDefaultThinking
 	}
 }
 
@@ -935,10 +942,13 @@ func normalizeThinking(manifest map[string]interface{}) {
 		return
 	}
 	switch asString(llm["thinking"]) {
-	case "low", "medium", "xhigh":
+	case "low", "medium", "high", "xhigh":
 		return
 	default:
-		delete(llm, "thinking")
+		// Codex with absent/invalid thinking is normalized to the default
+		// so committed/cloned/generated presets explicitly carry it and the
+		// running session receives xhigh rather than a UI-only fallback.
+		llm["thinking"] = codexDefaultThinking
 	}
 }
 

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -42,6 +42,10 @@ func testPresetEditorPreset() preset.Preset {
 }
 
 func testCodexPresetEditorPreset(serviceTier interface{}) preset.Preset {
+	return testCodexPresetEditorPresetWithThinking(serviceTier, nil)
+}
+
+func testCodexPresetEditorPresetWithThinking(serviceTier interface{}, thinking interface{}) preset.Preset {
 	llm := map[string]interface{}{
 		"provider":    "codex",
 		"model":       "gpt-5.5",
@@ -51,6 +55,9 @@ func testCodexPresetEditorPreset(serviceTier interface{}) preset.Preset {
 	}
 	if serviceTier != nil {
 		llm["service_tier"] = serviceTier
+	}
+	if thinking != nil {
+		llm["thinking"] = thinking
 	}
 	return preset.Preset{
 		Name:        "codex-test",
@@ -497,6 +504,145 @@ func TestPresetEditorCodexServiceTierDisplayAndCommitNormalization(t *testing.T)
 				t.Fatalf("committed service_tier=%q, want fast", got)
 			}
 		})
+	}
+}
+
+func TestPresetEditorCodexThinkingRowAndOptions(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset(nil), "en", nil, "", false)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+	view := m.View()
+
+	if !m.fieldVisible(feThinking) {
+		t.Fatalf("codex reasoning effort row should be visible")
+	}
+	if got := m.fieldString(feThinking); got != "high" {
+		t.Fatalf("empty llm.thinking displays %q, want high", got)
+	}
+	if !strings.Contains(view, "Reasoning effort") {
+		t.Fatalf("codex editor should render Reasoning effort row; view:\n%s", view)
+	}
+	for _, effort := range codexThinkingOptions {
+		if !strings.Contains(view, effort) {
+			t.Fatalf("codex editor should render thinking option %q; view:\n%s", effort, view)
+		}
+	}
+}
+
+func TestPresetEditorCodexThinkingSelectionAndCommit(t *testing.T) {
+	cases := []struct {
+		effort    string
+		wantSaved bool
+	}{
+		{effort: "low", wantSaved: true},
+		{effort: "medium", wantSaved: true},
+		{effort: "high"},
+		{effort: "xhigh", wantSaved: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.effort, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPreset(nil), "en", nil, "", false)
+			m.cursor = editorFieldOrderIndex(t, feThinking)
+			m.setCodexThinking(tc.effort)
+			if got := m.fieldString(feThinking); got != tc.effort {
+				t.Fatalf("thinking display = %q, want %q", got, tc.effort)
+			}
+
+			_, cmd := m.commit()
+			commit := cmd().(PresetEditorCommitMsg)
+			llm := commit.Preset.Manifest["llm"].(map[string]interface{})
+			got, saved := llm["thinking"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("committed thinking saved=%v, want %v; value=%#v", saved, tc.wantSaved, llm["thinking"])
+			}
+			if saved && got != tc.effort {
+				t.Fatalf("committed thinking=%q, want %q", got, tc.effort)
+			}
+		})
+	}
+}
+
+func TestPresetEditorCodexThinkingDisplayAndCommitNormalization(t *testing.T) {
+	cases := []struct {
+		name        string
+		thinking    interface{}
+		wantDisplay string
+		wantSaved   bool
+		wantValue   string
+	}{
+		{name: "absent", thinking: nil, wantDisplay: "high"},
+		{name: "explicit high", thinking: "high", wantDisplay: "high"},
+		{name: "low", thinking: "low", wantDisplay: "low", wantSaved: true, wantValue: "low"},
+		{name: "unknown", thinking: "turbo", wantDisplay: "high"},
+		{name: "wrong type", thinking: 12, wantDisplay: "high"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPresetWithThinking(nil, tc.thinking), "en", nil, "", false)
+			if got := m.fieldString(feThinking); got != tc.wantDisplay {
+				t.Fatalf("thinking display = %q, want %q", got, tc.wantDisplay)
+			}
+			_, cmd := m.commit()
+			commit := cmd().(PresetEditorCommitMsg)
+			llm := commit.Preset.Manifest["llm"].(map[string]interface{})
+			got, saved := llm["thinking"].(string)
+			if saved != tc.wantSaved {
+				t.Fatalf("committed thinking saved=%v, want %v; value=%#v", saved, tc.wantSaved, llm["thinking"])
+			}
+			if saved && got != tc.wantValue {
+				t.Fatalf("committed thinking=%q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestPresetEditorThinkingHiddenAndRemovedForNonCodex(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testPresetEditorPreset(), "en", nil, "", false)
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	llm["thinking"] = "low"
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 80})
+	view := m.View()
+
+	if m.fieldVisible(feThinking) {
+		t.Fatalf("reasoning effort row should be hidden for non-codex provider")
+	}
+	if strings.Contains(view, "Reasoning effort") || strings.Contains(view, "llm.thinking") {
+		t.Fatalf("non-codex editor should not render thinking row; view:\n%s", view)
+	}
+
+	m.cursor = editorFieldOrderIndex(t, feServiceTier)
+	m.normalizeCursor()
+	if editorFieldOrder[m.cursor] == feThinking {
+		t.Fatalf("cursor landed on hidden thinking field for non-codex preset")
+	}
+
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if _, ok := committedLLM["thinking"]; ok {
+		t.Fatalf("non-codex commit should remove llm.thinking; got %#v", committedLLM["thinking"])
+	}
+}
+
+func TestPresetEditorProviderSwitchClearsThinking(t *testing.T) {
+	m := NewPresetEditorModelWithBuiltinFlag(testCodexPresetEditorPresetWithThinking(nil, "low"), "en", nil, "", false)
+	m.cursor = editorFieldOrderIndex(t, feProvider)
+
+	m.cycleFocused(+1) // codex -> custom in provider picker order.
+	llm := m.working.Manifest["llm"].(map[string]interface{})
+	if got := llm["provider"]; got != "custom" {
+		t.Fatalf("provider after cycling from codex = %#v, want custom", got)
+	}
+	if _, ok := llm["thinking"]; ok {
+		t.Fatalf("provider switch away from codex should remove llm.thinking; got %#v", llm["thinking"])
+	}
+
+	_, cmd := m.commit()
+	commit := cmd().(PresetEditorCommitMsg)
+	committedLLM := commit.Preset.Manifest["llm"].(map[string]interface{})
+	if _, ok := committedLLM["thinking"]; ok {
+		t.Fatalf("non-codex commit after provider switch should omit llm.thinking; got %#v", committedLLM["thinking"])
 	}
 }
 

--- a/tui/internal/tui/preset_editor_test.go
+++ b/tui/internal/tui/preset_editor_test.go
@@ -515,8 +515,8 @@ func TestPresetEditorCodexThinkingRowAndOptions(t *testing.T) {
 	if !m.fieldVisible(feThinking) {
 		t.Fatalf("codex reasoning effort row should be visible")
 	}
-	if got := m.fieldString(feThinking); got != "high" {
-		t.Fatalf("empty llm.thinking displays %q, want high", got)
+	if got := m.fieldString(feThinking); got != "xhigh" {
+		t.Fatalf("empty llm.thinking displays %q, want xhigh", got)
 	}
 	if !strings.Contains(view, "Reasoning effort") {
 		t.Fatalf("codex editor should render Reasoning effort row; view:\n%s", view)
@@ -535,7 +535,7 @@ func TestPresetEditorCodexThinkingSelectionAndCommit(t *testing.T) {
 	}{
 		{effort: "low", wantSaved: true},
 		{effort: "medium", wantSaved: true},
-		{effort: "high"},
+		{effort: "high", wantSaved: true},
 		{effort: "xhigh", wantSaved: true},
 	}
 
@@ -570,11 +570,12 @@ func TestPresetEditorCodexThinkingDisplayAndCommitNormalization(t *testing.T) {
 		wantSaved   bool
 		wantValue   string
 	}{
-		{name: "absent", thinking: nil, wantDisplay: "high"},
-		{name: "explicit high", thinking: "high", wantDisplay: "high"},
+		{name: "absent", thinking: nil, wantDisplay: "xhigh", wantSaved: true, wantValue: "xhigh"},
+		{name: "explicit high", thinking: "high", wantDisplay: "high", wantSaved: true, wantValue: "high"},
 		{name: "low", thinking: "low", wantDisplay: "low", wantSaved: true, wantValue: "low"},
-		{name: "unknown", thinking: "turbo", wantDisplay: "high"},
-		{name: "wrong type", thinking: 12, wantDisplay: "high"},
+		{name: "explicit xhigh", thinking: "xhigh", wantDisplay: "xhigh", wantSaved: true, wantValue: "xhigh"},
+		{name: "unknown", thinking: "turbo", wantDisplay: "xhigh", wantSaved: true, wantValue: "xhigh"},
+		{name: "wrong type", thinking: 12, wantDisplay: "xhigh", wantSaved: true, wantValue: "xhigh"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Repairs and supersedes TZZheng's original `lingtai#280` on top of current `main`, now with Jason's requested Codex default reasoning effort of `xhigh`.

This includes the original PR #280 behavior:
- adds a Codex-only `Reasoning effort` row in the TUI preset editor;
- supports `low / medium / high / xhigh`;
- stores the selected value in `manifest.llm.thinking`;
- clears `thinking` for non-Codex providers.

Additional repair in this branch:
- Codex now defaults to `xhigh`, not `high`;
- generated Codex presets/init explicitly include `manifest.llm.thinking = "xhigh"`, so the runtime receives a real xhigh default rather than a UI-only display default;
- absent/invalid Codex values normalize to `xhigh` on save;
- all valid values remain selectable and persisted.

Kernel support for `thinking: "xhigh"` has already landed in `lingtai-kernel#457` (`582ce4a8bb2fa397ea37b871acd0a9c1894094c7`).

## Validation

- `git diff --check`
- `cd tui && go test ./internal/preset ./internal/tui`
- `cd tui && go test ./...`
- `cd tui && make build`
- Verified `lingtai-kernel` `origin/main` includes `xhigh` in thinking schema/tests and maps it to OpenAI Responses `reasoning.effort`.

## Notes

Original external PR #280 is not merged by this PR; this is the replacement/repair branch Jason approved after requesting default `xhigh`.
