### PR TITLE
Add dev-guide cache hit rate skill

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -8,7 +8,7 @@ description: >
   publication-bound release workflow, run a runtime self-check, get a PR
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
-version: 2.4.1
+version: 2.5.0
 ---
 
 # LingTai Developer Guide
@@ -115,6 +115,16 @@ drill-down files, not standalone top-level skills.
     seeds, de-privatizing/parameterizing local paths and human details, a
     lightweight pre-publish benchmark, shared-library grooming, and PR-ready skill
     cleanup. Cross-links skills-manual for generic authoring.
+- name: dev-guide-cache-hit-rate
+  location: reference/cache-hit-rate/SKILL.md
+  description: |
+    Compute the recent prompt-cache hit rate from token ledgers over rolling
+    windows (default 1h / 5h / 1d / 3d). Covers the provider-agnostic
+    input/cached fields in logs/token_ledger.jsonl, the formula
+    (sum(cached)/sum(input) per window), timestamp/timezone handling, the
+    daemon double-count hazard, and a read-only stdlib script
+    (scripts/cache_hit_rate.py) for an agent workdir, project root, or single
+    ledger file.
 ```
 
 ## Routing table
@@ -132,6 +142,7 @@ drill-down files, not standalone top-level skills.
 | Verify which runtime/binary is actually running after a refresh or rebuild, or why a fix that's on disk still serves stale behaviour (a long-lived service/adapter/cache that didn't rebuild) | `reference/runtime-self-check/SKILL.md` |
 | Get a PR review-ready: review gates, HTML explainer, PR hygiene | `reference/pr-review-deliverables/SKILL.md` |
 | Turn experience into a durable, de-privatized, PR-ready skill | `reference/skill-stewardship/SKILL.md` |
+| Measure the recent prompt-cache hit rate (1h/5h/1d/3d) from token ledgers | `reference/cache-hit-rate/SKILL.md` |
 
 ## Related skills to load instead or next
 
@@ -191,7 +202,10 @@ lingtai-dev-guide/
     ├── network-governance/SKILL.md
     ├── runtime-self-check/SKILL.md
     ├── pr-review-deliverables/SKILL.md
-    └── skill-stewardship/SKILL.md
+    ├── skill-stewardship/SKILL.md
+    └── cache-hit-rate/
+        ├── SKILL.md
+        └── scripts/cache_hit_rate.py
 ```
 
 Now read the nested reference that matches the task, then verify against current

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: dev-guide-cache-hit-rate
+description: >
+  Nested lingtai-dev-guide reference for computing the recent prompt-cache hit
+  rate from LingTai token ledgers over rolling windows (default 1h / 5h / 1d /
+  3d). Explains the provider-agnostic input/cached fields in
+  logs/token_ledger.jsonl, the exact formula (sum(cached)/sum(input) per
+  window), timestamp/timezone handling, the daemon double-count hazard, and
+  ships a read-only stdlib script (scripts/cache_hit_rate.py) that aggregates an
+  agent workdir, a project root, or a single ledger file. Use when asked how
+  effective prompt caching has been recently, or to diagnose a cache-hit-rate
+  drop after a refresh/affinity/cache-key change.
+version: 1.0.0
+---
+
+# Cache Hit Rate
+
+Nested `lingtai-dev-guide` reference. Read this after the top-level router sends
+you here when you need to know **how well prompt caching has been working
+recently** for one or more LingTai agents — and want a number you can trust,
+grounded in the token ledger rather than guessed.
+
+This pairs with `reference/runtime-self-check/SKILL.md` §6: when a cache/affinity
+fix "should be live," the token ledger is the observable that proves it. This
+reference is the *measurement*; runtime-self-check is the *did-the-object-rebuild*
+diagnosis.
+
+## Core principle
+
+This is a **read-only metric**. It only reads append-only
+`logs/token_ledger.jsonl` files; it never writes, rotates, or mutates runtime
+state. Report rates; do not paste private absolute paths or secrets into
+human-facing deliverables (the ledger itself contains no secrets, but its parent
+paths can be private — generalize to `~/.lingtai-tui/...` or
+`<project>/.lingtai/<agent>/`).
+
+## Data source: the token ledger
+
+Single source of truth: `logs/token_ledger.jsonl`, one JSON object per LLM call,
+written after every call by `lingtai_kernel/token_ledger.py`
+(`append_token_entry`). Every entry carries these required fields:
+
+| Field | Meaning |
+|---|---|
+| `ts` | Call time, UTC, `%Y-%m-%dT%H:%M:%SZ` (always `Z`/UTC). |
+| `input` | **Total** prompt/input tokens for the call. Already **includes** the cached portion. For the Anthropic/Claude adapters this is `raw_input + cache_read + cache_write`. |
+| `output` | Output tokens. |
+| `thinking` | Reasoning/thinking tokens. |
+| `cached` | Cache-**read** input tokens served from the provider prompt cache. A **subset of `input`**. |
+| `model`, `endpoint` | Attribution (which model / base_url produced the tokens). |
+
+Optional tags appear on some entries: `source` (`main`, `soul`, `tc_wake`,
+`daemon`), and for daemon-attributed rows `em_id` / `run_id` / `api_call_id` /
+`codex_*`.
+
+The kernel normalizes every provider's usage into these same fields before
+writing, so the metric below is **provider-agnostic** (verified across
+`gpt-5.5`, `mimo-v2.5-pro`, `deepseek-v4-pro`, and the Anthropic adapters).
+
+Key invariant, confirmed in the adapters (`lingtai/llm/anthropic/adapter.py`,
+`lingtai/llm/claude_agent_sdk/adapter.py`) and empirically over a full ledger:
+`0 <= cached <= input`. So the hit rate is always in `[0, 1]`.
+
+## Formula
+
+For a time window `[now - W, now]`, over all entries whose `ts` lies in the
+window:
+
+```
+hit_rate(W) = sum(cached) / sum(input)
+```
+
+- **Denominator:** `sum(input)` — total input tokens, which already includes
+  cached tokens. This is a token-weighted rate (a 100k-token call counts more
+  than a 1k-token call), which is what you want for "how much of the prompt
+  volume came from cache."
+- **Numerator:** `sum(cached)` — cache-read tokens.
+- **Windows:** rolling lookback from *now* (UTC). Defaults: `1h`, `5h`, `1d`,
+  `3d`. An entry is in the window iff `now - W <= ts <= now`.
+- **Timezone:** ledger timestamps are UTC; "now" is computed in UTC. No local
+  timezone is involved.
+- **Zero denominator:** if a window has no input tokens (no calls, or only
+  zero-input rows), `hit_rate` is reported as `n/a`, never a divide-by-zero.
+- **Missing/garbage rows:** lines that are not valid JSON, lack a parseable
+  `ts`, or lack numeric `input`/`cached` are skipped and counted under
+  `skipped` so silent data loss is visible.
+
+### Caveat: what `cached` includes
+
+The native streaming/non-streaming adapters set `cached = cache_read` only
+(cache *writes* are billed into `input` but are **not** counted as cached). One
+path differs: CLI-backed daemon runs (`lingtai/core/daemon/run_dir.py`) document
+`cached` as `cache_read + cache_creation` because the CLI backend only exposes an
+aggregate. So for CLI-backed entries the rate leans slightly optimistic (it
+treats first-write tokens as "cached"). The `cached <= input` bound still holds,
+so the number is still meaningful; just don't over-interpret sub-percent
+differences on daemon CLI traffic.
+
+## The double-count hazard (important)
+
+Daemon LLM calls are written to **two** ledgers: the daemon's own
+`daemons/<run>/logs/token_ledger.jsonl` **and** the parent agent's
+`logs/token_ledger.jsonl` (tagged with `source="daemon"` + `em_id`/`run_id`).
+If you naively glob `**/logs/token_ledger.jsonl` under a project you will
+**double-count** every daemon token.
+
+The rule this reference (and the script) follow:
+
+- For an **agent workdir**, read only `<workdir>/logs/token_ledger.jsonl`. It
+  already contains the daemon-tagged rows.
+- For a **project root**, read only each direct child
+  `<root>/<agent>/logs/token_ledger.jsonl`; never recurse into `daemons/`.
+
+## Script: `scripts/cache_hit_rate.py`
+
+Deterministic, read-only, **standard library only** (no third-party deps).
+Accepts an agent workdir, a project root, or a single ledger file.
+
+```bash
+SCRIPT=~/.lingtai-tui/utilities/lingtai-dev-guide/reference/cache-hit-rate/scripts/cache_hit_rate.py
+PY="$HOME/.lingtai-tui/runtime/venv/bin/python"   # or any python3.11+
+
+# Current agent workdir (run from e.g. <project>/.lingtai/codex)
+"$PY" "$SCRIPT" .
+
+# A specific agent workdir
+"$PY" "$SCRIPT" <project>/.lingtai/codex
+
+# A whole project root: each agent's ledger, aggregated (daemons not double-counted)
+"$PY" "$SCRIPT" <project>/.lingtai
+
+# A single ledger file, custom windows, JSON output
+"$PY" "$SCRIPT" logs/token_ledger.jsonl --windows 1h 6h 1d --json
+
+# Only main-chat turns; pin the clock for a reproducible result
+"$PY" "$SCRIPT" . --source main --now 2026-06-22T01:00:00Z
+```
+
+Flags: `--windows` (`<int><s|m|h|d|w>`, e.g. `90m 1d 1w`), `--source` (filter to
+one source tag), `--now ISO` (override the clock for deterministic/testing
+runs), `--json`, `--help`.
+
+Example text output:
+
+```
+ window    calls           input          cached  hit_rate
+----------------------------------------------------------
+     1h       43       3,933,316       1,627,648     41.4%
+     5h       43       3,933,316       1,627,648     41.4%
+     1d       43       3,933,316       1,627,648     41.4%
+     3d       43       3,933,316       1,627,648     41.4%
+```
+
+Equal rows across windows just mean all recent activity fell inside the smallest
+window (e.g. a single active session in the last hour).
+
+Exit codes: `0` success (including empty windows); `1` no ledger found under the
+path; `2` bad argument (missing path, bad `--now`, bad `--windows`).
+
+### One-liner without the script
+
+If you only need a single window and don't want to invoke the script:
+
+```bash
+PY="$HOME/.lingtai-tui/runtime/venv/bin/python"
+"$PY" - logs/token_ledger.jsonl 5 <<'PY'
+import json, sys
+from datetime import datetime, timedelta, timezone
+path, hours = sys.argv[1], float(sys.argv[2])
+cut = datetime.now(timezone.utc) - timedelta(hours=hours)
+inp = cac = 0
+for line in open(path):
+    line = line.strip()
+    if not line: continue
+    try: d = json.loads(line)
+    except ValueError: continue
+    ts = d.get("ts","")
+    try: t = datetime.fromisoformat(ts.replace("Z","+00:00"))
+    except ValueError: continue
+    if t >= cut:
+        inp += d.get("input",0); cac += d.get("cached",0)
+print(f"{cac}/{inp} = {100*cac/inp:.1f}%" if inp else "n/a (no input in window)")
+PY
+```
+
+## Troubleshooting
+
+- **`no token_ledger.jsonl found`** — you pointed at a directory that is neither
+  an agent workdir (`logs/token_ledger.jsonl`) nor a project root with child
+  agents. Point at the agent dir (e.g. `.lingtai/codex`) or the `.lingtai/` root,
+  or pass the ledger file path directly.
+- **All windows show `n/a`** — no input tokens in those windows. Either the agent
+  has been idle, or your `--now` predates the activity. Widen the window, drop
+  `--source`, or check `ts` ranges with `head -1` / `tail -1` on the ledger.
+- **Rate looks too high on daemon traffic** — see the CLI `cache_creation`
+  caveat above; CLI-backed `cached` can include first-write tokens.
+- **`skipped` count is non-zero** — corrupt/rotated lines or pre-schema rows.
+  A handful is normal (e.g. a partially written final line). A large fraction
+  suggests schema drift — confirm the ledger still matches
+  `lingtai_kernel/token_ledger.py` before trusting the numbers.
+- **Schema drift** — if a future kernel renames `input`/`cached`/`ts`, this
+  reference and the script must be updated in the same spirit as the
+  "anatomy travels with code" rule. Re-read `lingtai_kernel/token_ledger.py`
+  and the active provider adapter to re-confirm field semantics.
+- **Project-root totals equal one agent's** — expected when only one agent has
+  recent activity; idle colleagues contribute zero to recent windows.
+
+## Validating after a change
+
+To sanity-check the script against a known answer, build a tiny fixture and pin
+`--now`:
+
+```bash
+T=$(mktemp -d); mkdir -p "$T/a/logs"
+printf '%s\n' \
+ '{"source":"main","ts":"2026-06-22T00:50:00Z","input":1000,"output":1,"thinking":0,"cached":800}' \
+ '{"source":"main","ts":"2026-06-21T22:00:00Z","input":1000,"output":1,"thinking":0,"cached":500}' \
+ > "$T/a/logs/token_ledger.jsonl"
+"$PY" "$SCRIPT" "$T/a" --now 2026-06-22T01:00:00Z   # 1h -> 80.0%, 5h -> 65.0%
+rm -rf "$T"
+```
+
+## Related references
+
+- `reference/runtime-self-check/SKILL.md` — §6 live-object lifecycle: the ledger
+  as proof a cache/affinity fix actually took effect after `refresh`.
+- `reference/debug-troubleshoot/SKILL.md` — broader runtime diagnostics when a
+  low/zero hit rate points at a misbehaving session rather than a metric.
+- `reference/architecture/SKILL.md` — where runtime state (including
+  `.lingtai/<agent>/logs/`) lives.

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/scripts/cache_hit_rate.py
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/scripts/cache_hit_rate.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Recent prompt-cache hit rate from LingTai token ledgers (read-only).
+
+Cache hit rate is computed per time window as:
+
+    hit_rate = sum(cached) / sum(input)
+
+over all ledger entries whose ``ts`` falls within the window. Both fields come
+straight from ``logs/token_ledger.jsonl`` (see
+``lingtai_kernel/token_ledger.py``):
+
+    input   total prompt/input tokens for the call (already INCLUDES the
+            cached portion; for the Anthropic adapter this is
+            raw_input + cache_read + cache_write)
+    cached  cache-read input tokens served from the provider prompt cache
+            (a subset of ``input``; cache *writes* are billed under input but
+            are NOT counted as cached by the native adapters)
+
+Because ``cached`` is a subset of ``input``, the ratio is bounded in [0, 1].
+The metric is provider-agnostic: the kernel normalizes every provider's usage
+into the same ``input``/``cached`` fields before the entry is written.
+
+Default windows (lookback from "now", UTC): 1h, 5h, 1d, 3d.
+
+This script is strictly READ-ONLY: it opens ledger files for reading and never
+writes, mutates, or touches runtime state. Standard library only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+LEDGER_NAME = "token_ledger.jsonl"
+
+# (label, timedelta). Order is preserved in output.
+DEFAULT_WINDOWS: list[tuple[str, timedelta]] = [
+    ("1h", timedelta(hours=1)),
+    ("5h", timedelta(hours=5)),
+    ("1d", timedelta(days=1)),
+    ("3d", timedelta(days=3)),
+]
+
+_WINDOW_UNITS = {
+    "s": timedelta(seconds=1),
+    "m": timedelta(minutes=1),
+    "h": timedelta(hours=1),
+    "d": timedelta(days=1),
+    "w": timedelta(weeks=1),
+}
+
+
+def parse_window(token: str) -> tuple[str, timedelta]:
+    """Parse a window spec like ``1h``, ``5h``, ``1d``, ``3d``, ``90m``."""
+    token = token.strip().lower()
+    if len(token) < 2 or token[-1] not in _WINDOW_UNITS:
+        raise argparse.ArgumentTypeError(
+            f"bad window {token!r}: expected <int><s|m|h|d|w>, e.g. 1h 5h 1d 3d"
+        )
+    try:
+        n = int(token[:-1])
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"bad window {token!r}: expected <int><s|m|h|d|w>, e.g. 1h 5h 1d 3d"
+        )
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"window must be positive: {token!r}")
+    return token, _WINDOW_UNITS[token[-1]] * n
+
+
+def parse_ts(value: str) -> datetime | None:
+    """Parse a ledger timestamp into an aware UTC datetime, or None if invalid.
+
+    Ledger timestamps are written as ``%Y-%m-%dT%H:%M:%SZ`` (UTC). We also
+    tolerate an explicit ``+00:00`` offset for forward compatibility.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    v = value.strip()
+    try:
+        if v.endswith("Z"):
+            v = v[:-1] + "+00:00"
+        dt = datetime.fromisoformat(v)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def resolve_ledgers(path: Path) -> tuple[list[Path], str]:
+    """Resolve an input path to the ledger file(s) to read.
+
+    Returns ``(ledger_paths, mode)`` where mode is one of ``file``,
+    ``workdir``, ``root``.
+
+    Resolution rules (chosen to avoid double-counting daemon usage):
+
+    * A file path -> that single ledger.
+    * A directory containing ``logs/token_ledger.jsonl`` -> that one agent/run
+      ledger only. We deliberately do NOT recurse into ``daemons/*/logs`` here,
+      because daemon calls are ALSO tagged into the parent agent ledger
+      (source/em_id/run_id), so the agent ledger already includes them. Reading
+      both would double-count.
+    * Any other directory (a project root, e.g. ``.lingtai/``) -> every direct
+      child ``<child>/logs/token_ledger.jsonl``. Nested ``daemons/`` ledgers are
+      excluded for the same double-count reason.
+    """
+    if path.is_file():
+        return [path], "file"
+    if not path.is_dir():
+        return [], "missing"
+
+    own = path / "logs" / LEDGER_NAME
+    if own.is_file():
+        return [own], "workdir"
+
+    found: list[Path] = []
+    for child in sorted(path.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name == "daemons":
+            continue
+        candidate = child / "logs" / LEDGER_NAME
+        if candidate.is_file():
+            found.append(candidate)
+    return found, "root"
+
+
+def scan_ledger(ledger: Path, source: str | None) -> dict:
+    """Read one ledger, returning entries plus skip diagnostics."""
+    entries: list[tuple[datetime, int, int]] = []
+    bad_json = 0
+    bad_ts = 0
+    bad_fields = 0
+    source_filtered = 0
+    total_lines = 0
+    try:
+        text = ledger.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"error": str(exc), "entries": entries}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        total_lines += 1
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            bad_json += 1
+            continue
+        if source is not None and d.get("source") != source:
+            source_filtered += 1
+            continue
+        dt = parse_ts(d.get("ts"))
+        if dt is None:
+            bad_ts += 1
+            continue
+        inp = d.get("input")
+        cac = d.get("cached")
+        if not isinstance(inp, (int, float)) or not isinstance(cac, (int, float)):
+            bad_fields += 1
+            continue
+        entries.append((dt, int(inp), int(cac)))
+    return {
+        "error": None,
+        "entries": entries,
+        "total_lines": total_lines,
+        "bad_json": bad_json,
+        "bad_ts": bad_ts,
+        "bad_fields": bad_fields,
+        "source_filtered": source_filtered,
+    }
+
+
+def compute_windows(
+    entries: list[tuple[datetime, int, int]],
+    now: datetime,
+    windows: list[tuple[str, timedelta]],
+) -> list[dict]:
+    """Compute per-window cache-hit aggregates."""
+    out = []
+    for label, delta in windows:
+        cutoff = now - delta
+        calls = 0
+        input_sum = 0
+        cached_sum = 0
+        for dt, inp, cac in entries:
+            if dt >= cutoff and dt <= now:
+                calls += 1
+                input_sum += inp
+                cached_sum += cac
+        rate = (cached_sum / input_sum) if input_sum > 0 else None
+        out.append({
+            "window": label,
+            "cutoff": cutoff.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "calls": calls,
+            "input": input_sum,
+            "cached": cached_sum,
+            "hit_rate": rate,
+        })
+    return out
+
+
+def fmt_rate(rate) -> str:
+    return "   n/a" if rate is None else f"{rate * 100:5.1f}%"
+
+
+def render_text(report: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"Cache hit rate  (now={report['now']}, mode={report['mode']})")
+    src = report.get("source")
+    if src:
+        lines.append(f"source filter: {src}")
+    lines.append(f"ledgers read: {len(report['ledgers'])}")
+    for lp in report["ledgers"]:
+        lines.append(f"  - {lp}")
+    lines.append("")
+    header = f"{'window':>7}  {'calls':>7}  {'input':>14}  {'cached':>14}  {'hit_rate':>8}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for w in report["windows"]:
+        lines.append(
+            f"{w['window']:>7}  {w['calls']:>7}  {w['input']:>14,}  "
+            f"{w['cached']:>14,}  {fmt_rate(w['hit_rate']):>8}"
+        )
+    skips = report["skipped"]
+    noted = {k: v for k, v in skips.items() if v}
+    if noted:
+        lines.append("")
+        lines.append("skipped lines: " + ", ".join(f"{k}={v}" for k, v in noted.items()))
+    if report["empty_overall"]:
+        lines.append("")
+        lines.append("NOTE: no valid ledger entries found in any window.")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="cache_hit_rate.py",
+        description="Recent prompt-cache hit rate from LingTai token ledgers "
+                    "(read-only).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # current agent workdir (e.g. .lingtai/codex)\n"
+            "  cache_hit_rate.py .\n\n"
+            "  # a specific agent workdir\n"
+            "  cache_hit_rate.py /path/.lingtai/codex\n\n"
+            "  # a whole project root: per-agent ledgers aggregated\n"
+            "  cache_hit_rate.py /path/.lingtai\n\n"
+            "  # a single ledger file, custom windows, JSON out\n"
+            "  cache_hit_rate.py logs/token_ledger.jsonl --windows 1h 6h 1d --json\n\n"
+            "  # only main-chat turns, deterministic clock for testing\n"
+            "  cache_hit_rate.py . --source main --now 2026-06-22T01:00:00Z\n"
+        ),
+    )
+    p.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Agent workdir, project root, or a token_ledger.jsonl file "
+             "(default: current directory).",
+    )
+    p.add_argument(
+        "--windows",
+        nargs="+",
+        type=parse_window,
+        default=None,
+        metavar="W",
+        help="Lookback windows, e.g. 1h 5h 1d 3d (default), 90m, 1w.",
+    )
+    p.add_argument(
+        "--source",
+        default=None,
+        help="Only count entries with this source tag "
+             "(e.g. main, soul, tc_wake, daemon).",
+    )
+    p.add_argument(
+        "--now",
+        default=None,
+        metavar="ISO",
+        help="Override 'now' (UTC ISO8601, e.g. 2026-06-22T01:00:00Z) for "
+             "deterministic/testing runs. Defaults to the current UTC time.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON report instead of the text table.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.now is not None:
+        now = parse_ts(args.now)
+        if now is None:
+            print(f"error: bad --now value {args.now!r} (want UTC ISO8601 "
+                  f"like 2026-06-22T01:00:00Z)", file=sys.stderr)
+            return 2
+    else:
+        now = datetime.now(timezone.utc)
+
+    windows = args.windows if args.windows else DEFAULT_WINDOWS
+
+    path = Path(args.path).expanduser()
+    ledgers, mode = resolve_ledgers(path)
+    if mode == "missing":
+        print(f"error: path not found: {path}", file=sys.stderr)
+        return 2
+    if not ledgers:
+        print(f"error: no {LEDGER_NAME} found under {path} "
+              f"(looked for <path>/logs/{LEDGER_NAME} and "
+              f"<path>/*/logs/{LEDGER_NAME})", file=sys.stderr)
+        return 1
+
+    all_entries: list[tuple[datetime, int, int]] = []
+    skipped = {"bad_json": 0, "bad_ts": 0, "bad_fields": 0, "source_filtered": 0}
+    read_paths: list[str] = []
+    for ledger in ledgers:
+        res = scan_ledger(ledger, args.source)
+        if res.get("error"):
+            print(f"warning: could not read {ledger}: {res['error']}",
+                  file=sys.stderr)
+            continue
+        read_paths.append(str(ledger))
+        all_entries.extend(res["entries"])
+        for k in skipped:
+            skipped[k] += res.get(k, 0)
+
+    win_results = compute_windows(all_entries, now, windows)
+    report = {
+        "now": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "mode": mode,
+        "source": args.source,
+        "ledgers": read_paths,
+        "windows": win_results,
+        "skipped": skipped,
+        "empty_overall": len(all_entries) == 0,
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a `lingtai-dev-guide` nested reference for measuring recent prompt-cache hit rate from LingTai token ledgers.

- Registers `reference/cache-hit-rate/SKILL.md` in the parent developer-guide router and bumps the guide to `2.5.0`.
- Documents the provider-normalized formula `sum(cached) / sum(input)` for rolling windows such as `1h`, `5h`, `1d`, and `3d`.
- Adds a read-only, standard-library helper script at `reference/cache-hit-rate/scripts/cache_hit_rate.py` that can read an agent workdir, a project `.lingtai` root, or a single `token_ledger.jsonl` file.
- Avoids recursively scanning daemon run directories so daemon calls are not double-counted when they already appear in a parent agent ledger.

## Validation

- `git diff --check`
- Router/frontmatter check for the parent guide entry and the new child reference.
- Script syntax compile via Python `compile(...)`.
- `cache_hit_rate.py --help`
- Synthetic fixture with deterministic `--now`:
  - `1h`: `800 / 1000 = 80%`
  - `5h`: `1300 / 2000 = 65%`
  - `1d`: `1300 / 2000 = 65%`
  - `3d`: `2800 / 6000 = 46.7%`
  - malformed JSON and bad timestamps are skipped and counted.
- Local live smoke against a project `.lingtai` root successfully aggregated three agent ledgers and reported the default four windows.

## Notes

CLI-backed daemon ledger rows may fold cache-creation tokens into the normalized `cached` field, so those sources can make the reported hit rate slightly optimistic. The guide calls out that caveat.
