### PR TITLE
perf(tui): defer session rebuild off launch path

### DIFF
--- a/tui/internal/fs/session.go
+++ b/tui/internal/fs/session.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -55,7 +56,17 @@ type NotificationMetaContext struct {
 
 // SessionCache is an append-only cache backed by session.jsonl.
 // It incrementally tails three data sources and appends new entries.
+//
+// Concurrency: the launch path defers the authoritative RebuildFromSources
+// into a Bubble Tea Cmd goroutine while the periodic mail tick keeps calling
+// Refresh on the main goroutine (see internal/tui/mail.go). Both mutate the
+// same *SessionCache, so every public entry point that touches mutable state
+// (RebuildFromSources, Refresh, IngestMail, Entries, Len) holds mu. The
+// unexported helpers (ingestMail, IngestEvents, IngestInquiries, append,
+// rewriteFile) assume the caller already holds mu and never lock themselves —
+// that keeps the lock non-reentrant and avoids deadlock.
 type SessionCache struct {
+	mu          sync.Mutex     // guards all fields below; see type doc for the locking discipline
 	path        string         // human/logs/session.jsonl
 	entries     []SessionEntry // in-memory mirror of all entries
 	lastMailTs  string         // highest mail ReceivedAt ingested (watermark for live-session dedup)
@@ -100,6 +111,9 @@ func NewSessionCache(humanDir string, projectPath string) *SessionCache {
 // sorts them chronologically, writes session.jsonl, and sets offsets to EOF
 // so subsequent Refresh calls only append new entries.
 func (sc *SessionCache) RebuildFromSources(cache MailCache, humanAddr, orchDir, orchName string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
 	// Clear any prior state and suppress file writes during ingest
 	// (we'll write the sorted result in one shot at the end).
 	sc.entries = nil
@@ -109,8 +123,9 @@ func (sc *SessionCache) RebuildFromSources(cache MailCache, humanAddr, orchDir, 
 	sc.soulVoices = make(map[string][]soulVoiceRecord)
 	sc.rebuilding = true
 
-	// Ingest everything from offset 0.
-	sc.IngestMail(cache, humanAddr, orchDir, orchName)
+	// Ingest everything from offset 0. Uses the unlocked helpers — we already
+	// hold sc.mu and the helpers must not re-lock (non-reentrant mutex).
+	sc.ingestMail(cache, humanAddr, orchDir, orchName)
 	sc.IngestEvents(orchDir)
 	sc.IngestInquiries(orchDir)
 
@@ -188,13 +203,23 @@ func (sc *SessionCache) append(entries ...SessionEntry) {
 	}
 }
 
-// Entries returns all entries in the cache.
+// Entries returns a snapshot copy of all entries in the cache. The copy is
+// deliberate: callers (e.g. buildMessages) iterate the result after this
+// returns, possibly while a concurrent RebuildFromSources mutates the backing
+// slice. Returning the live slice would race; the copy is shallow (entry
+// strings share storage) so it is cheap relative to the rebuild it guards.
 func (sc *SessionCache) Entries() []SessionEntry {
-	return sc.entries
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	out := make([]SessionEntry, len(sc.entries))
+	copy(out, sc.entries)
+	return out
 }
 
 // Len returns the total number of entries.
 func (sc *SessionCache) Len() int {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
 	return len(sc.entries)
 }
 
@@ -205,7 +230,17 @@ func (sc *SessionCache) Len() int {
 // IngestMail appends new mail messages to the session log.
 // humanAddr is the human's mail address (to determine IsFromMe).
 // orchName is the orchestrator's display name.
+//
+// Public entry point: acquires the cache lock. RebuildFromSources/Refresh,
+// which already hold the lock, call the unlocked ingestMail directly.
 func (sc *SessionCache) IngestMail(cache MailCache, humanAddr, orchDir, orchName string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.ingestMail(cache, humanAddr, orchDir, orchName)
+}
+
+// ingestMail is the unlocked body of IngestMail. The caller must hold sc.mu.
+func (sc *SessionCache) ingestMail(cache MailCache, humanAddr, orchDir, orchName string) {
 	var newEntries []SessionEntry
 	for _, msg := range cache.Messages {
 		// Skip mail at or below the watermark — already ingested either in this
@@ -281,6 +316,9 @@ func splitLast(s, sep string) string {
 // fresh consultation_fire entries can be inflated with voice text on
 // the same poll. Inflates the bodies of any soul_flow entries (new or
 // already-cached) that came back as the fallback summary.
+//
+// Lock: the caller must hold sc.mu. This is only reached from the locked
+// RebuildFromSources/Refresh paths; it does not lock itself (non-reentrant).
 func (sc *SessionCache) IngestEvents(orchDir string) {
 	if orchDir == "" {
 		return
@@ -892,6 +930,8 @@ func formatToolResultValue(value interface{}) string {
 
 // IngestInquiries tails the orchestrator's soul_inquiry.jsonl from the last-read
 // offset. Only human and insight-sourced inquiries are ingested.
+//
+// Lock: the caller must hold sc.mu (reached only from RebuildFromSources/Refresh).
 func (sc *SessionCache) IngestInquiries(orchDir string) {
 	if orchDir == "" {
 		return
@@ -935,7 +975,10 @@ func parseInquiry(line []byte) *SessionEntry {
 
 // Refresh polls all three data sources and appends new entries to the session log.
 func (sc *SessionCache) Refresh(cache MailCache, humanAddr, orchDir, orchName string) {
-	sc.IngestMail(cache, humanAddr, orchDir, orchName)
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	// Unlocked helpers — we already hold sc.mu (non-reentrant).
+	sc.ingestMail(cache, humanAddr, orchDir, orchName)
 	sc.IngestEvents(orchDir)
 	sc.IngestInquiries(orchDir)
 }

--- a/tui/internal/fs/session_race_test.go
+++ b/tui/internal/fs/session_race_test.go
@@ -1,0 +1,97 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestSessionCacheConcurrentRebuildAndRefresh is the regression test for the
+// launch-perf concurrency blocker (GLM review B1): deferring the authoritative
+// RebuildFromSources into a Bubble Tea Cmd goroutine made it race with the
+// periodic mail tick, which keeps calling Refresh + Entries on the main
+// goroutine. Both mutate the same *SessionCache (entries slice, offsets,
+// rebuilding flag, and session.jsonl on disk) with no synchronization in the
+// pre-fix code.
+//
+// This test reproduces that exact overlap: one goroutine repeatedly runs
+// RebuildFromSources (the deferred launch work) while another repeatedly runs
+// Refresh / Entries / Len (the tick path), against a content-heavy orchestrator
+// log so the rebuild has real work to do. Run with `-race`; before the mutex
+// fix the race detector fires on sc.entries / sc.eventsOff / the rebuilding
+// flag. After the fix it must pass cleanly and never panic.
+func TestSessionCacheConcurrentRebuildAndRefresh(t *testing.T) {
+	tmp := t.TempDir()
+	humanDir := filepath.Join(tmp, "human")
+	orchDir := filepath.Join(tmp, "orch")
+	logsDir := filepath.Join(orchDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Content-heavy events.jsonl — this is the scenario the patch targets, where
+	// RebuildFromSources takes long enough that ticks overlap it.
+	var b strings.Builder
+	for i := 0; i < 4000; i++ {
+		fmt.Fprintf(&b, `{"ts":%d,"type":"text_output","text":"line %d with some body content to parse"}`+"\n", 1781300000+i, i)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sc := NewSessionCache(humanDir, tmp)
+	cache := NewMailCache(humanDir).Refresh()
+
+	var wg sync.WaitGroup
+
+	// Goroutine 1: the deferred authoritative rebuild, run repeatedly to keep it
+	// overlapping the refresh loop (mirrors initialRebuild on the Cmd goroutine).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			sc.RebuildFromSources(cache, "human", orchDir, "orch")
+		}
+	}()
+
+	// Goroutine 2: the tick path — Refresh then read Entries/Len, the exact
+	// buildMessages sequence that runs on Bubble Tea's main goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			sc.Refresh(cache, "human", orchDir, "orch")
+			entries := sc.Entries()
+			for range entries {
+				// Touch the snapshot the way buildMessages iterates it; this is
+				// where a non-copying Entries() would race the rebuild's mutation.
+			}
+			_ = sc.Len()
+		}
+	}()
+
+	wg.Wait()
+
+	// After all the churn the cache must still reflect the full event history
+	// (every entry ingested at least once), and the on-disk file must be
+	// well-formed — not truncated mid-write by a concurrent rewrite/append.
+	if got := sc.Len(); got != 4000 {
+		t.Fatalf("after concurrent rebuild/refresh: expected 4000 entries, got %d", got)
+	}
+	data, err := os.ReadFile(filepath.Join(humanDir, "logs", "session.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := 0
+	for _, c := range data {
+		if c == '\n' {
+			lines++
+		}
+	}
+	if lines != 4000 {
+		t.Fatalf("session.jsonl: expected 4000 lines, got %d (concurrent truncate/append corruption?)", lines)
+	}
+}

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -188,13 +188,35 @@ func NewMailModel(humanDir, humanAddr, baseDir, orchDir, orchName string, pageSi
 		dismissedInsights: make(map[string]bool),
 		sessionCache:      fs.NewSessionCache(humanDir, filepath.Dir(baseDir)),
 	}
-	// Refresh mail cache before session rebuild so mail entries are included.
-	m.cache = m.cache.Refresh()
-	// Always rebuild session.jsonl from authoritative sources on launch. This is
-	// cheap (ms-scale) and avoids the entire class of dedup bugs that come from
-	// trying to patch an existing file across restarts.
-	m.sessionCache.RebuildFromSources(m.cache, humanAddr, orchDir, m.orchDisplayName())
+	// NOTE: the mail-cache refresh and the authoritative session rebuild are
+	// intentionally NOT done here. NewMailModel runs on the synchronous launch
+	// path (NewApp, before tea.Program.Run), so doing the rebuild here parses
+	// the entire events.jsonl / soul_inquiry.jsonl / soul_flow.jsonl history
+	// before the first frame can render — seconds of frozen terminal on
+	// content-heavy projects. The rebuild is deferred to initialRebuild(), a
+	// command run by Init(), so the first frame paints immediately (empty) and
+	// the history fills in a beat later. See initialRebuild for the rationale.
 	return m
+}
+
+// initialRebuild performs the one-time authoritative session rebuild off the
+// synchronous launch path. It refreshes the mail cache, then rebuilds
+// session.jsonl from all sources (mail + events.jsonl + soul_inquiry.jsonl +
+// soul_flow.jsonl), merging and sorting chronologically. This is the heavy work
+// that used to run in NewMailModel; running it as a tea.Cmd keeps the first
+// frame instant. It returns a mailRefreshMsg so the standard refresh handler
+// builds the view from the now-populated cache. sessionCache is a pointer, so
+// the rebuild mutates the model's shared cache; the returned cache is installed
+// by the mailRefreshMsg handler.
+func (m MailModel) initialRebuild() tea.Msg {
+	// Refresh mail cache before session rebuild so mail entries are included.
+	cache := m.cache.Refresh()
+	// Always rebuild session.jsonl from authoritative sources on launch. This
+	// avoids the entire class of dedup bugs that come from trying to patch an
+	// existing file across restarts.
+	m.sessionCache.RebuildFromSources(cache, m.humanAddr, m.orchestrator, m.orchDisplayName())
+	m.cache = cache
+	return m.refreshMail()
 }
 
 func adaptiveInputMaxHeight(windowHeight int) int {
@@ -540,7 +562,12 @@ func sessionEntryToChatMessage(e fs.SessionEntry, humanAddr string) ChatMessage 
 func (m MailModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.input.Init(),
-		m.refreshMail,
+		// initialRebuild does the one-time authoritative session rebuild off the
+		// synchronous launch path (see initialRebuild and NewMailModel). It
+		// returns a mailRefreshMsg, so the standard refresh handler builds the
+		// view once history is loaded. The periodic tick below then keeps it
+		// current via the incremental Refresh path.
+		m.initialRebuild,
 		tickEvery(m.pollRate),
 		pulseTick(),
 	)

--- a/tui/internal/tui/mail_launch_defer_test.go
+++ b/tui/internal/tui/mail_launch_defer_test.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestNewMailModelDefersSessionRebuild guards the launch-performance contract:
+// NewMailModel must NOT read and parse the full events.jsonl / soul_inquiry.jsonl
+// / soul_flow.jsonl history synchronously inside the constructor. That work runs
+// on the synchronous launch path (NewApp -> before tea.Program.Run), so on
+// content-heavy projects it blocks the first frame for as long as it takes to
+// parse the entire log. The rebuild is deferred to a command driven by Init().
+//
+// The observable contract: immediately after construction the session cache is
+// empty (no historical ingest has happened yet).
+func TestNewMailModelDefersSessionRebuild(t *testing.T) {
+	humanDir := t.TempDir()
+	orchDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(orchDir, "logs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	events := strings.Join([]string{
+		`{"ts":1781300000,"type":"llm_call","api_call_id":"api_one"}`,
+		`{"ts":1781300001,"type":"text_output","text":"answer"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(orchDir, "logs", "events.jsonl"), []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewMailModel(humanDir, "human", t.TempDir(), orchDir, "agent", unlimitedPageSize, "", "en", false, 0)
+	if got := m.sessionCache.Len(); got != 0 {
+		t.Fatalf("NewMailModel ingested %d session entries synchronously; expected 0 (rebuild must be deferred to Init)", got)
+	}
+}
+
+// TestMailInitRunsRebuild verifies that Init()'s command performs the deferred
+// rebuild and that feeding its message into Update populates the message stream.
+// This is the other half of the deferral: the work still happens, just off the
+// synchronous launch path.
+func TestMailInitRunsRebuild(t *testing.T) {
+	humanDir := t.TempDir()
+	orchDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(orchDir, "logs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	events := strings.Join([]string{
+		`{"ts":1781300000,"type":"llm_response","api_call_id":"api_one"}`,
+		`{"ts":1781300001,"type":"text_output","text":"deferred answer"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(orchDir, "logs", "events.jsonl"), []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewMailModel(humanDir, "human", t.TempDir(), orchDir, "agent", unlimitedPageSize, "", "en", false, 0)
+	m.verbose = verboseThinking
+
+	// Run the initial rebuild command (the deferred heavy work).
+	msg := m.initialRebuild()
+	if msg == nil {
+		t.Fatal("initialRebuild returned nil msg")
+	}
+	if got := m.sessionCache.Len(); got == 0 {
+		t.Fatalf("initialRebuild did not populate the session cache; got %d entries", got)
+	}
+
+	// Feed the resulting message through Update — the view should now build.
+	updated, _ := m.Update(msg)
+	found := false
+	for _, cm := range updated.messages {
+		if cm.Type == "text_output" && strings.Contains(cm.Body, "deferred answer") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the deferred answer in built messages after Init rebuild; got %d messages", len(updated.messages))
+	}
+}
+
+// TestMailInitIncludesRebuildCmd verifies Init() actually schedules the rebuild.
+func TestMailInitIncludesRebuildCmd(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMailModel(dir, "human@local", dir, dir, "orch", 20, dir, "en", false, 0)
+	if cmd := m.Init(); cmd == nil {
+		t.Fatal("MailModel.Init returned nil cmd; expected at least the rebuild + refresh batch")
+	}
+	_ = tea.Batch // keep the bubbletea import meaningful even if Batch isn't referenced directly
+}


### PR DESCRIPTION
## Summary

- defer the authoritative mail/session rebuild out of the synchronous `NewMailModel` launch path and into an initial Bubble Tea command
- make `fs.SessionCache` concurrency-safe now that the first rebuild can run concurrently with mail ticks/refreshes
- add launch-path and race-regression tests for the deferred rebuild path

## Why

On content-heavy projects, `lingtai-tui` could spend launch time in `NewMailModel` rebuilding session/mail history from full event and soul logs before the first frame could render. This keeps the authoritative rebuild, but schedules it after startup via `Init()` so the first frame is no longer blocked by a full historical parse.

The first review found that moving the rebuild into a Bubble Tea command could race with periodic refresh paths. The follow-up commit adds locking and snapshot semantics to `SessionCache`, plus a race test covering concurrent rebuild/refresh.

## Validation

- `git diff --check origin/main...HEAD`
- gofmt check on changed files
- `go vet ./internal/fs ./internal/tui`
- `go test ./internal/tui ./internal/fs -count=1`
- `go test -race ./internal/fs -run TestSessionCacheConcurrentRebuildAndRefresh -count=1`
- `go test -race ./internal/tui -run 'Mail|Session|Launch|Rebuild' -count=1`
- `cd tui && go test ./... -count=1`

Independent GLM review was rerun after the race fix and approved the final branch.

## Notes

The mail/session view may briefly render before the deferred history refresh completes. That is the intended tradeoff for keeping the launch path responsive while preserving the authoritative rebuild immediately after startup.
