### PR TITLE
Lower default TUI context limit from 300k to 250k

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1399,7 +1399,7 @@ func DefaultAgentOpts() AgentOpts {
 	return AgentOpts{
 		Language:       "en",
 		Stamina:        36000,
-		ContextLimit:   300000,
+		ContextLimit:   250000,
 		SoulDelay:      99999,
 		MaxRpm:         60,
 		MaxAedAttempts: DefaultMaxAedAttempts,

--- a/tui/internal/preset/preset_context_limit_test.go
+++ b/tui/internal/preset/preset_context_limit_test.go
@@ -1,0 +1,68 @@
+package preset
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDefaultAgentOpts_ContextLimit pins the TUI first-run/setup default token
+// (context) upper limit, so newly generated init.json manifests use the
+// intended budget. This is the canonical default; the firstrun wizard's
+// zero/invalid-input fallbacks mirror it.
+func TestDefaultAgentOpts_ContextLimit(t *testing.T) {
+	if got := DefaultAgentOpts().ContextLimit; got != 250000 {
+		t.Errorf("DefaultAgentOpts().ContextLimit = %d, want 250000", got)
+	}
+}
+
+// TestGenerateInitJSON_WritesContextLimit verifies the default flows into the
+// generated manifest as 250000, and — crucially — that an explicit user
+// override is preserved verbatim rather than being clamped back to the default.
+func TestGenerateInitJSON_WritesContextLimit(t *testing.T) {
+	withTempPresets(t, func() {
+		tmpDir := t.TempDir()
+		lingtaiDir := filepath.Join(tmpDir, ".lingtai")
+		os.MkdirAll(lingtaiDir, 0o755)
+		globalDir := filepath.Join(tmpDir, ".lingtai-global")
+		Bootstrap(globalDir)
+
+		readManifest := func(agent string) map[string]interface{} {
+			t.Helper()
+			initPath := filepath.Join(lingtaiDir, agent, "init.json")
+			data, err := os.ReadFile(initPath)
+			if err != nil {
+				t.Fatalf("read init.json: %v", err)
+			}
+			var initJSON map[string]interface{}
+			if err := json.Unmarshal(data, &initJSON); err != nil {
+				t.Fatalf("parse init.json: %v", err)
+			}
+			m, ok := initJSON["manifest"].(map[string]interface{})
+			if !ok {
+				t.Fatal("manifest not a map")
+			}
+			return m
+		}
+
+		// Default flows through to the manifest as 250000.
+		if err := GenerateInitJSONWithOpts(DefaultPreset(), "alice", "alice", lingtaiDir, globalDir, DefaultAgentOpts()); err != nil {
+			t.Fatalf("GenerateInitJSONWithOpts: %v", err)
+		}
+		// JSON numbers decode as float64.
+		if v, ok := readManifest("alice")["context_limit"].(float64); !ok || int(v) != 250000 {
+			t.Errorf("alice context_limit = %v (ok=%v), want 250000", readManifest("alice")["context_limit"], ok)
+		}
+
+		// Explicit override is preserved, not reset to the default.
+		opts := DefaultAgentOpts()
+		opts.ContextLimit = 1000000
+		if err := GenerateInitJSONWithOpts(DefaultPreset(), "bob", "bob", lingtaiDir, globalDir, opts); err != nil {
+			t.Fatalf("GenerateInitJSONWithOpts: %v", err)
+		}
+		if v, ok := readManifest("bob")["context_limit"].(float64); !ok || int(v) != 1000000 {
+			t.Errorf("bob context_limit = %v (ok=%v), want preserved 1000000", readManifest("bob")["context_limit"], ok)
+		}
+	})
+}

--- a/tui/internal/tui/firstrun.go
+++ b/tui/internal/tui/firstrun.go
@@ -1819,7 +1819,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 					}
 					ctxLimit, _ := strconv.Atoi(m.ctxLimitInput.Value())
 					if ctxLimit <= 0 {
-						ctxLimit = 300000
+						ctxLimit = 250000
 					}
 					soulDelay, _ := strconv.ParseFloat(m.soulDelayInput.Value(), 64)
 					if soulDelay <= 0 {
@@ -1875,7 +1875,7 @@ func (m FirstRunModel) Update(msg tea.Msg) (FirstRunModel, tea.Cmd) {
 				}
 				ctxLimit, err := strconv.Atoi(m.ctxLimitInput.Value())
 				if err != nil || ctxLimit <= 0 {
-					ctxLimit = 300000
+					ctxLimit = 250000
 				}
 				soulDelay, err := strconv.ParseFloat(m.soulDelayInput.Value(), 64)
 				if err != nil || soulDelay <= 0 {
@@ -3668,7 +3668,7 @@ func (m *FirstRunModel) enterAgentNameDir(p preset.Preset) {
 
 	// Numeric defaults — overridden by saved init.json values in setup mode below.
 	m.staminaInput.SetValue("36000")
-	m.ctxLimitInput.SetValue("300000")
+	m.ctxLimitInput.SetValue("250000")
 	m.soulDelayInput.SetValue("99999")
 	m.maxRpmInput.SetValue("60")
 	m.maxAedInput.SetValue(strconv.Itoa(preset.DefaultMaxAedAttempts))


### PR DESCRIPTION
## Summary

Per Jason's request (`TUI默认的token上限从300k改到250k`), lower the TUI's **default** token/context upper limit for newly created agents from **300000 → 250000**.

This is a defaults-only change. Explicit operator overrides are untouched — a value typed in the first-run/setup wizard, or one already present in `init.json`, still flows through verbatim.

## What changed

Four mirrored default/fallback sites in `tui/`:

| Site | File | Role |
|---|---|---|
| `DefaultAgentOpts().ContextLimit` | `tui/internal/preset/preset.go` | the canonical default |
| setup-mode "keep current" fallback | `tui/internal/tui/firstrun.go` | used when input ≤ 0 |
| create/save fallback | `tui/internal/tui/firstrun.go` | used when input invalid/≤ 0 |
| prefilled input value | `tui/internal/tui/firstrun.go` | `ctxLimitInput.SetValue` |

**Deliberately untouched:** the m039 migration and legacy-normalization logic (and their tests) use `300000` as fixture data to verify root→`llm.context_limit` copying and canonical-value preservation. Those are unrelated to the default and were left alone.

## Tests

Adds `tui/internal/preset/preset_context_limit_test.go`:
- pins `DefaultAgentOpts().ContextLimit == 250000`
- proves the default flows into generated `init.json` as `250000`
- proves an explicit `1000000` override is preserved through `GenerateInitJSONWithOpts` (not reset to the default)

## Validation

- `gofmt -l` — clean on all touched files
- `go test ./internal/preset/ ./internal/tui/ ./internal/migrate/` — all pass
- `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)