### PR TITLE
feat(swiss-knife): add tool-call trend reports

### DIFF
--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -7,7 +7,7 @@ description: >
   image understanding (describe/OCR/critique); listen for local audio
   transcription and music analysis; academic-research for fetching papers,
   citation networks, and LaTeX writing; dj for journal-inspired music
-  generation; token-usage for token/cost reports; html-report for standalone
+  generation; token-usage for token/cost and tool-call/API-call trend reports; html-report for standalone
   browser deliverables; xiaomi-mimo for Xiaomi MiMo provider discovery;
   zhipu-coding-plan for Z.AI / BigModel coding-plan capabilities; headless-bot
   for provisioning fresh LingTai bot projects such as Telegram bots from
@@ -76,8 +76,8 @@ nested_references:
   - name: token-usage
     location: reference/token-usage/SKILL.md
     description: >
-      Nested swiss-knife reference for network-wide token and cost reports. Read
-      this when the human asks about token usage, budget, model costs, or spending
+      Nested swiss-knife reference for network-wide token, cost, cache, and tool-call/API-call trend reports. Read
+      this when the human asks about token usage, budget, model costs, spending, cache behavior, or tools per API call
       across agent ledgers.
   - name: html-report
     location: reference/html-report/SKILL.md
@@ -132,7 +132,7 @@ nested_references:
 | Transcribe speech/voice notes or analyze music locally (no API key) | `reference/listen/SKILL.md` |
 | Fetch papers, trace citations, run scholar analysis, or write LaTeX | `reference/academic-research/SKILL.md` |
 | Compose music from a project journal, session mood, or requested genre | `reference/dj/SKILL.md` |
-| Report token usage or model costs | `reference/token-usage/SKILL.md` |
+| Report token usage, model costs, cache rates, or tool-call/API-call trends | `reference/token-usage/SKILL.md` |
 | Produce standalone HTML reports/dashboards/memos | `reference/html-report/SKILL.md` |
 | Discover/configure Xiaomi MiMo provider/model access | `reference/xiaomi-mimo/SKILL.md`; for `mimocode` shell execution, load `bash-manual` → `reference/bash-mimocode/SKILL.md` |
 | Discover/configure Zhipu / Z.AI coding-plan capabilities | `reference/zhipu-coding-plan/SKILL.md`; for shell CLI harness execution, load `bash-manual` first |

--- a/tui/internal/preset/skills/swiss-knife/reference/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/token-usage/SKILL.md
@@ -1,33 +1,57 @@
 ---
 name: token-usage
 description: >
-  Nested swiss-knife reference for token usage and cost reports. Network-wide token usage and cost calculator using litellm's model pricing database.
-  Reads token_ledger.jsonl from all agents, matches models to litellm pricing, and
-  produces a per-agent and grand-total cost report. Supports any model litellm knows
-  about (2700+ models) plus custom pricing overrides. Use when the human asks about
-  token usage, cost, budget, or spending.
-version: 2.0.0
-tags: [python, cost, tokens, litellm, budget]
+  Nested swiss-knife reference for token usage, cost, cache, and tool-call/API-call reports.
+  Use for model cost reports, cache rates, budget/burn analysis, and tools-per-API-call trends across LingTai logs.
+version: 2.1.0
+tags: [python, cost, tokens, litellm, budget, tools, agents]
 ---
 
-# Token Usage & Cost Calculator v2
+# Token Usage, Cost, and Agentic-Intensity Reports v2
 
-Network-wide token cost analysis powered by [litellm](https://github.com/BerriAI/litellm)'s model pricing database (2700+ models).
+Network-wide token cost analysis powered by [litellm](https://github.com/BerriAI/litellm)'s model pricing database (2700+ models), plus runtime-event trend analysis for tool calls per API call.
 
 ## Quick Usage
 
-Run the bundled script:
+Run the bundled cost script:
 
 ```bash
 ~/.lingtai-tui/runtime/venv/bin/python3 ~/.lingtai-tui/utilities/swiss-knife/reference/token-usage/scripts/cost_report.py /path/to/.lingtai
 ```
 
-Optional flags:
+Cost-report optional flags:
 - `--json` — output as JSON instead of table
 - `--by-model` — group by model instead of by agent
 - `--since YYYY-MM-DD` — only count entries after this date
 - `--top N` — show only top N agents (default: all)
 - `--custom-pricing FILE` — load custom pricing overrides from JSON
+
+
+
+### Tool-call/API-call trend
+
+Use this when the human asks for “tool calls per API call”, “tools per API call”, “agentic intensity”, or how tool-heavy the local LingTai network has been over time. The script reads LingTai `logs/events.jsonl` files, not `token_ledger.jsonl`, because it needs runtime event IDs.
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python3 ~/.lingtai-tui/utilities/swiss-knife/reference/token-usage/scripts/tool_calls_per_api_call_trend.py \
+  /path/to/project/.lingtai \
+  --days 5 \
+  --timezone America/Los_Angeles \
+  --model gpt-5.5
+```
+
+Optional flags:
+- `--out-prefix PREFIX` — write `PREFIX.md`, `PREFIX.json`, and `PREFIX.csv`
+- `--model MODEL` — also emit a model-specific table for an exact model name; repeatable
+- `--include-daemons` — include daemon event logs instead of excluding them
+
+Metric definitions:
+- **API calls:** unique successful LLM response events (`type == "llm_response"`), deduplicated by `(events log path, api_call_id)`.
+- **Tool calls:** unique model-requested top-level tool calls (`type == "tool_call_received"`), deduplicated by `(events log path, api_call_id, tool_call_id)` and assigned to the local-day bin of the producing API response.
+- **Tool calls per API call:** `tool_calls / api_calls`.
+- **Tool-using API-call rate:** fraction of API calls that produced at least one tool call.
+
+Treat the metric as behavioral intensity, not token volume: a higher value means each model API call is asking the runtime to do more tool work on average.
 
 ## How It Works
 
@@ -37,6 +61,8 @@ Optional flags:
 4. Falls back to custom pricing if the model isn't in either source
 5. Calculates per-agent and grand-total costs
 6. Reports cache hit rate, burn rate, and per-model breakdown
+
+For tool-call/API-call trend reports, the separate `tool_calls_per_api_call_trend.py` script scans `logs/events.jsonl`, counts `llm_response` and `tool_call_received` events, and writes Markdown/JSON/CSV daily trend artifacts.
 
 ## Pricing Sources
 
@@ -79,17 +105,19 @@ Each agent's `logs/token_ledger.jsonl` has one JSON object per LLM call:
 
 ## Dependencies
 
-- `litellm` — required. Check with `python3 -c "import litellm"`. If missing, ask the human before installing:
+- `cost_report.py` requires `litellm`. Check with `python3 -c "import litellm"`. If missing, ask the human before installing:
 
   > token-usage needs `litellm` (~5MB) for model pricing. Install it? (`pip install litellm`)
 
   Install only after they say yes.
+- `tool_calls_per_api_call_trend.py` uses only the Python standard library.
 - Python 3.9+
 
 ## Tips
 
 - Check after spawning multiple avatars — they each burn their own system prompt
 - Cache hit rate is the key efficiency metric — aim for >90%
+- Tool calls per API call is a useful agentic-intensity metric: values above 1 mean the average model response asks for more than one tool call
 - Daemon tokens are tracked in `daemons/<run_id>/logs/token_ledger.jsonl`
 - For per-session breakdown, use `--since` to filter by date
 

--- a/tui/internal/preset/skills/swiss-knife/reference/token-usage/scripts/tool_calls_per_api_call_trend.py
+++ b/tui/internal/preset/skills/swiss-knife/reference/token-usage/scripts/tool_calls_per_api_call_trend.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Compute LingTai tool calls per LLM API call over recent local-day bins.
+
+The metric is intentionally based on LingTai runtime events rather than token
+volume:
+
+- API calls: successful LLM responses (`type == "llm_response"`), deduplicated
+  by `(events log path, api_call_id)`.
+- Tool calls: top-level model-requested tool calls (`type == "tool_call_received"`),
+  deduplicated by `(events log path, api_call_id, tool_call_id)` and assigned to
+  the local-day bin of the API response that produced them.
+- Tool calls/API call: `tool_calls / api_calls`.
+- Tool-using API-call rate: API calls with at least one tool call / API calls.
+
+Pass one or more roots to scan. A root may be a project directory, a `.lingtai`
+directory, an agent directory, or a single `events.jsonl` file. Daemon logs are
+excluded by default to match parent-agent usage-report workflows.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import DefaultDict, Dict, Iterable, List, Optional, Set, Tuple
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Python <3.9 fallback
+    ZoneInfo = None  # type: ignore[assignment]
+
+EXCLUDE_PARTS = {"daemons", "node_modules", ".git", "__pycache__"}
+
+
+@dataclass(frozen=True)
+class ApiKey:
+    log_path: str
+    api_call_id: str
+
+
+@dataclass
+class ApiInfo:
+    ts: float
+    day: str
+    source: str
+    model: Optional[str] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    thinking_tokens: int = 0
+    cached_tokens: int = 0
+
+
+def parse_tz(name: str):
+    if name.upper() == "UTC":
+        return timezone.utc
+    if ZoneInfo is None:
+        raise SystemExit("--timezone requires Python 3.9+ zoneinfo unless using UTC")
+    try:
+        return ZoneInfo(name)
+    except Exception as exc:  # pragma: no cover - depends on host tzdata
+        raise SystemExit(f"invalid --timezone {name!r}: {exc}") from exc
+
+
+def norm_ts(value) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            return None
+    return None
+
+
+def iter_event_logs(roots: Iterable[Path], since_ts: float, include_daemons: bool) -> Iterable[Path]:
+    seen: Set[Path] = set()
+    excludes = EXCLUDE_PARTS if not include_daemons else {p for p in EXCLUDE_PARTS if p != "daemons"}
+    for root in roots:
+        root = root.expanduser()
+        candidates: Iterable[Path]
+        if root.is_file() and root.name == "events.jsonl":
+            candidates = [root]
+        elif root.is_dir():
+            candidates = root.rglob("events.jsonl")
+        else:
+            continue
+        for path in candidates:
+            if path in seen:
+                continue
+            seen.add(path)
+            if any(part in excludes for part in path.parts):
+                continue
+            try:
+                if path.stat().st_mtime < since_ts - 86400:
+                    continue
+            except OSError:
+                continue
+            yield path
+
+
+def source_label(events_path: Path) -> str:
+    parts = events_path.parts
+    if ".lingtai" in parts:
+        idx = parts.index(".lingtai")
+        agent = parts[idx + 1] if idx + 1 < len(parts) else "unknown-agent"
+        project = parts[idx - 1] if idx - 1 >= 0 else "unknown-project"
+        return f"{project}/{agent}"
+    if len(parts) >= 3:
+        return "/".join(parts[-4:-2]) or str(events_path.parent)
+    return str(events_path.parent)
+
+
+def new_bucket() -> dict:
+    return {
+        "api_calls": 0,
+        "tool_calls": 0,
+        "tool_using_api_calls": 0,
+        "input_tokens": 0,
+        "cached_tokens": 0,
+        "output_tokens": 0,
+        "thinking_tokens": 0,
+    }
+
+
+def add_api(bucket: dict, info: ApiInfo, tool_count: int) -> None:
+    bucket["api_calls"] += 1
+    bucket["tool_calls"] += tool_count
+    bucket["tool_using_api_calls"] += 1 if tool_count else 0
+    bucket["input_tokens"] += info.input_tokens
+    bucket["cached_tokens"] += info.cached_tokens
+    bucket["output_tokens"] += info.output_tokens
+    bucket["thinking_tokens"] += info.thinking_tokens
+
+
+def finalize_bucket(bucket: dict) -> dict:
+    out = dict(bucket)
+    api_calls = bucket["api_calls"]
+    input_tokens = bucket["input_tokens"]
+    out["tool_calls_per_api_call"] = bucket["tool_calls"] / api_calls if api_calls else None
+    out["tool_using_api_call_rate"] = bucket["tool_using_api_calls"] / api_calls if api_calls else None
+    out["total_tokens"] = bucket["input_tokens"] + bucket["output_tokens"] + bucket["thinking_tokens"]
+    out["cache_rate"] = bucket["cached_tokens"] / input_tokens if input_tokens else None
+    return out
+
+
+def day_for(ts: float, tz) -> str:
+    return datetime.fromtimestamp(ts, timezone.utc).astimezone(tz).date().isoformat()
+
+
+def compute(roots: List[Path], days: int, timezone_name: str, models: List[str], include_daemons: bool) -> dict:
+    tz = parse_tz(timezone_name)
+    now = datetime.now(timezone.utc)
+    now_local = now.astimezone(tz)
+    start_date = now_local.date() - timedelta(days=days - 1)
+    since_local = datetime.combine(start_date, datetime.min.time(), tzinfo=tz)
+    since = since_local.astimezone(timezone.utc)
+    since_ts = since.timestamp()
+    now_ts = now.timestamp()
+
+    model_filters = [m.lower() for m in models]
+    api_models: Dict[ApiKey, str] = {}
+    api_infos: Dict[ApiKey, ApiInfo] = {}
+    tool_counts_by_api: Counter[ApiKey] = Counter()
+    seen_tool_events: Set[Tuple[str, str, str]] = set()
+    files_scanned = 0
+    candidate_lines_seen = 0
+
+    for events_path in iter_event_logs(roots, since_ts, include_daemons):
+        files_scanned += 1
+        path_s = str(events_path)
+        label = source_label(events_path)
+        try:
+            with events_path.open(encoding="utf-8", errors="ignore") as handle:
+                for line in handle:
+                    if "api_call_id" not in line:
+                        continue
+                    if not ("llm_call" in line or "llm_response" in line or "tool_call_received" in line):
+                        continue
+                    candidate_lines_seen += 1
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    typ = rec.get("type")
+                    ts = norm_ts(rec.get("ts"))
+                    api_id = rec.get("api_call_id")
+                    if ts is None or not api_id:
+                        continue
+                    # Keep model/tool records just outside the window in case they bracket a response.
+                    if ts < since_ts - 3600 or ts > now_ts + 3600:
+                        continue
+                    key = ApiKey(path_s, str(api_id))
+                    if typ == "llm_call":
+                        model = rec.get("model")
+                        if model is not None:
+                            api_models[key] = str(model)
+                    elif typ == "llm_response":
+                        if not (since_ts <= ts <= now_ts):
+                            continue
+                        prior = api_infos.get(key)
+                        if prior is None or ts >= prior.ts:
+                            api_infos[key] = ApiInfo(
+                                ts=ts,
+                                day=day_for(ts, tz),
+                                source=label,
+                                model=api_models.get(key),
+                                input_tokens=int(rec.get("input_tokens") or 0),
+                                output_tokens=int(rec.get("output_tokens") or 0),
+                                thinking_tokens=int(rec.get("thinking_tokens") or 0),
+                                cached_tokens=int(rec.get("cached_tokens") or 0),
+                            )
+                    elif typ == "tool_call_received":
+                        tool_id = rec.get("tool_call_id") or rec.get("tool_trace_id") or ""
+                        unique = (path_s, str(api_id), str(tool_id))
+                        if unique in seen_tool_events:
+                            continue
+                        seen_tool_events.add(unique)
+                        tool_counts_by_api[key] += 1
+        except OSError:
+            continue
+
+    for key, model in api_models.items():
+        if key in api_infos and not api_infos[key].model:
+            api_infos[key].model = model
+
+    by_day_all: DefaultDict[str, dict] = defaultdict(new_bucket)
+    by_source_all: DefaultDict[str, dict] = defaultdict(new_bucket)
+    by_day_by_model: Dict[str, DefaultDict[str, dict]] = {m: defaultdict(new_bucket) for m in model_filters}
+    by_source_by_model: Dict[str, DefaultDict[str, dict]] = {m: defaultdict(new_bucket) for m in model_filters}
+
+    for key, info in api_infos.items():
+        tool_count = int(tool_counts_by_api.get(key, 0))
+        add_api(by_day_all[info.day], info, tool_count)
+        add_api(by_source_all[info.source], info, tool_count)
+        model = (info.model or "").lower()
+        for wanted in model_filters:
+            if model == wanted:
+                add_api(by_day_by_model[wanted][info.day], info, tool_count)
+                add_api(by_source_by_model[wanted][info.source], info, tool_count)
+
+    days_list = [(start_date + timedelta(days=i)).isoformat() for i in range(days)]
+    result = {
+        "generated_at_utc": now.isoformat(),
+        "generated_at_local": now_local.isoformat(),
+        "timezone": timezone_name,
+        "since_utc": since.isoformat(),
+        "since_local": since_local.isoformat(),
+        "days": days,
+        "roots": [str(r.expanduser()) for r in roots],
+        "exclude_daemons": not include_daemons,
+        "models": models,
+        "files_scanned": files_scanned,
+        "candidate_event_lines_seen": candidate_lines_seen,
+        "definition": {
+            "api_calls": "unique llm_response events by (events log path, api_call_id)",
+            "tool_calls": "unique tool_call_received events by (events log path, api_call_id, tool_call_id), assigned to the producing API response day",
+            "tool_calls_per_api_call": "tool_calls / api_calls",
+            "tool_using_api_call_rate": "API calls with at least one tool_call_received / API calls",
+        },
+        "by_day_all_models": {day: finalize_bucket(by_day_all[day]) for day in days_list},
+        "by_source_all_models": {k: finalize_bucket(v) for k, v in sorted(by_source_all.items(), key=lambda kv: kv[1]["tool_calls"], reverse=True)},
+        "by_day_by_model": {
+            wanted: {day: finalize_bucket(by_day_by_model[wanted][day]) for day in days_list}
+            for wanted in model_filters
+        },
+        "by_source_by_model": {
+            wanted: {k: finalize_bucket(v) for k, v in sorted(by_source_by_model[wanted].items(), key=lambda kv: kv[1]["tool_calls"], reverse=True)}
+            for wanted in model_filters
+        },
+    }
+    return result
+
+
+def fmt_ratio(value) -> str:
+    return "n/a" if value is None else f"{value:.3f}"
+
+
+def fmt_pct(value) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def write_outputs(result: dict, prefix: Path) -> None:
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    prefix.with_suffix(".json").write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    with prefix.with_suffix(".csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow([
+            "scope",
+            "name",
+            "api_calls",
+            "tool_calls",
+            "tool_calls_per_api_call",
+            "tool_using_api_call_rate",
+            "input_tokens",
+            "cached_tokens",
+            "cache_rate",
+            "output_tokens",
+            "thinking_tokens",
+            "total_tokens",
+        ])
+        tables = [("day_all_models", result["by_day_all_models"]), ("source_all_models", result["by_source_all_models"])]
+        for model, rows in result["by_day_by_model"].items():
+            tables.append((f"day_model:{model}", rows))
+        for model, rows in result["by_source_by_model"].items():
+            tables.append((f"source_model:{model}", rows))
+        for scope, rows in tables:
+            for name, bucket in rows.items():
+                writer.writerow([
+                    scope,
+                    name,
+                    bucket["api_calls"],
+                    bucket["tool_calls"],
+                    bucket["tool_calls_per_api_call"],
+                    bucket["tool_using_api_call_rate"],
+                    bucket["input_tokens"],
+                    bucket["cached_tokens"],
+                    bucket["cache_rate"],
+                    bucket["output_tokens"],
+                    bucket["thinking_tokens"],
+                    bucket["total_tokens"],
+                ])
+
+    md: List[str] = [
+        "# Tool calls per API call trend",
+        "",
+        f"- Generated: `{result['generated_at_local']}` local / `{result['generated_at_utc']}` UTC",
+        f"- Window start: `{result['since_local']}` local / `{result['since_utc']}` UTC",
+        f"- Roots: `{', '.join(result['roots'])}`",
+        f"- Excludes daemon logs: `{result['exclude_daemons']}`",
+        f"- Event logs scanned: `{result['files_scanned']}`",
+        "",
+        "Metric: `tool_calls_per_api_call = unique tool_call_received events / unique llm_response API calls`, binned by local calendar day. `tool_using_api_call_rate` is the fraction of API calls that produced at least one tool call.",
+        "",
+        "## Daily trend — all models",
+        "",
+        "| date | API calls | tool calls | tools/API call | tool-using API calls | total tokens | cache rate |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for day, bucket in result["by_day_all_models"].items():
+        md.append(
+            f"| {day} | {bucket['api_calls']:,} | {bucket['tool_calls']:,} | "
+            f"{fmt_ratio(bucket['tool_calls_per_api_call'])} | {fmt_pct(bucket['tool_using_api_call_rate'])} | "
+            f"{bucket['total_tokens']:,} | {fmt_pct(bucket['cache_rate'])} |"
+        )
+    for model, rows in result["by_day_by_model"].items():
+        md.extend([
+            "",
+            f"## Daily trend — model `{model}`",
+            "",
+            "| date | API calls | tool calls | tools/API call | tool-using API calls | total tokens | cache rate |",
+            "|---|---:|---:|---:|---:|---:|---:|",
+        ])
+        for day, bucket in rows.items():
+            md.append(
+                f"| {day} | {bucket['api_calls']:,} | {bucket['tool_calls']:,} | "
+                f"{fmt_ratio(bucket['tool_calls_per_api_call'])} | {fmt_pct(bucket['tool_using_api_call_rate'])} | "
+                f"{bucket['total_tokens']:,} | {fmt_pct(bucket['cache_rate'])} |"
+            )
+    md.extend([
+        "",
+        "## Top sources by tool calls — all models",
+        "",
+        "| source | API calls | tool calls | tools/API call | tool-using API calls |",
+        "|---|---:|---:|---:|---:|",
+    ])
+    for source, bucket in list(result["by_source_all_models"].items())[:20]:
+        md.append(
+            f"| {source} | {bucket['api_calls']:,} | {bucket['tool_calls']:,} | "
+            f"{fmt_ratio(bucket['tool_calls_per_api_call'])} | {fmt_pct(bucket['tool_using_api_call_rate'])} |"
+        )
+    md.extend(["", "## Artifacts", f"- JSON: `{prefix.with_suffix('.json')}`", f"- CSV: `{prefix.with_suffix('.csv')}`"])
+    prefix.with_suffix(".md").write_text("\n".join(md) + "\n", encoding="utf-8")
+
+
+def default_prefix(days: int) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path.cwd() / f"tool_calls_per_api_call_{days}d_{stamp}"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Compute LingTai tool calls per API call over local-day bins.")
+    parser.add_argument("roots", nargs="+", help="Roots to scan: project dir, .lingtai dir, agent dir, or events.jsonl file.")
+    parser.add_argument("--days", type=int, default=5, help="Number of local calendar days to include, including today (default: 5).")
+    parser.add_argument("--timezone", default="UTC", help="IANA timezone for day bins (default: UTC; e.g. America/Los_Angeles).")
+    parser.add_argument("--model", action="append", default=[], help="Also emit a model-specific table for an exact model name; repeatable.")
+    parser.add_argument("--include-daemons", action="store_true", help="Include daemon logs instead of excluding them.")
+    parser.add_argument("--out-prefix", default="", help="Output path prefix for .md/.json/.csv artifacts (default: ./tool_calls_per_api_call_<days>d_<timestamp>).")
+    args = parser.parse_args(argv)
+    if args.days < 1:
+        parser.error("--days must be >= 1")
+    roots = [Path(root) for root in args.roots]
+    result = compute(roots, args.days, args.timezone, args.model, args.include_daemons)
+    prefix = Path(args.out_prefix).expanduser() if args.out_prefix else default_prefix(args.days)
+    write_outputs(result, prefix)
+    print(json.dumps({
+        "prefix": str(prefix),
+        "artifacts": [str(prefix.with_suffix(ext)) for ext in (".md", ".json", ".csv")],
+        "generated_at_local": result["generated_at_local"],
+        "by_day_all_models": result["by_day_all_models"],
+        "by_day_by_model": result["by_day_by_model"],
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tui/internal/preset/swiss_knife_populate_test.go
+++ b/tui/internal/preset/swiss_knife_populate_test.go
@@ -35,6 +35,7 @@ func TestPopulateBundledLibrary_SwissKnifeNestedReferences(t *testing.T) {
 		"reference/dj/SKILL.md",
 		"reference/token-usage/SKILL.md",
 		"reference/token-usage/scripts/cost_report.py",
+		"reference/token-usage/scripts/tool_calls_per_api_call_trend.py",
 		"reference/token-usage/scripts/custom_pricing.json",
 		"reference/html-report/SKILL.md",
 		"reference/html-report/assets/template.html",

--- a/tui/internal/tui/skill_files_test.go
+++ b/tui/internal/tui/skill_files_test.go
@@ -129,6 +129,7 @@ func TestBuildSkillFolderEntries_SwissKnifeNestedReferences(t *testing.T) {
 		"find-something-to-do/SKILL.md",
 		"token-usage/SKILL.md",
 		"token-usage/scripts/cost_report.py",
+		"token-usage/scripts/tool_calls_per_api_call_trend.py",
 	} {
 		e, ok := labels[want]
 		if !ok {


### PR DESCRIPTION
## Summary
- extend the swiss-knife `token-usage` nested reference with a portable `tool_calls_per_api_call_trend.py` script
- document the `tool_calls / llm_response API calls` metric, tool-using API-call rate, examples, and dependencies
- update swiss-knife router wording and embedded skill-file tests so the new script ships with the TUI utility library

## Validation
- `python3 -m py_compile tui/internal/preset/skills/swiss-knife/reference/token-usage/scripts/tool_calls_per_api_call_trend.py`
- synthetic fixture smoke test: 2 API calls, 2 tool calls, tools/API = 1.0, tool-using API-call rate = 0.5
- `python3 <skills-validator> tui/internal/preset/skills/swiss-knife/reference/token-usage`
- `python3 <skills-validator> tui/internal/preset/skills/swiss-knife`
- `git diff --check`
- `cd tui && go test ./internal/preset -run SwissKnife`
- `cd tui && go test ./internal/tui -run SwissKnife`

## Notes
- The new script is stdlib-only; `litellm` remains required only for the existing cost-report script.
- Local review explainer: `/Users/huangzesen/work/projects/marco-velli-heliophysics-related/pr_reports/swiss_knife_token_usage_tool_calls_pr_20260623.html`
- Post-merge follow-up requested by Jason: rebuild `lingtai-tui` and re-bootstrap so the updated swiss-knife subskill appears in the local agent library.
