### PR TITLE
docs: rewrite beginner LingTai work manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+> New to LingTai? Start with the [Beginner work manual](docs/beginner-work-manual.zh.md) or the [single-file illustrated HTML guide](docs/beginner-work-manual-stick-figure.zh.html) to learn the workflow step by step.
+
 On first run LingTai creates `.lingtai/`, provisions its own runtime, walks you through model/preset setup, and starts one resident assistant for the project.
 
 ### First-time install troubleshooting

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ This repo carries two Go binaries:
 
 ## Docs by goal
 
-- **New here?** Run `lingtai-tui`, pick the **Tutorial** recipe, follow the prompts. A Chinese beginner-friendly manual is also available at [`docs/beginner-work-manual.zh.md`](docs/beginner-work-manual.zh.md), with an animated version at [`docs/beginner-work-manual-stick-figure.zh.html`](docs/beginner-work-manual-stick-figure.zh.html).
+- **New here?** Run `lingtai-tui`, pick the **Tutorial** recipe, follow the prompts. A Chinese beginner-friendly manual is also available at [`docs/beginner-work-manual.zh.md`](docs/beginner-work-manual.zh.md), with a standalone single-file illustrated version at [`docs/beginner-work-manual-stick-figure.zh.html`](docs/beginner-work-manual-stick-figure.zh.html).
 - **Set up a channel** — `/mcp` inside the TUI, then the addon's own onboarding resource.
 - **Write a skill** — see `tui/internal/preset/skills/lingtai-dev-guide/` after first launch.
 - **Source layout** — start at [`ANATOMY.md`](ANATOMY.md), then descend into `tui/ANATOMY.md` or `portal/ANATOMY.md`.

--- a/README.wen.md
+++ b/README.wen.md
@@ -56,6 +56,8 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+> 初入 LingTai？先读[小白工作手册](docs/beginner-work-manual.zh.md)（或[单文件 HTML 图解版](docs/beginner-work-manual-stick-figure.zh.html)），再启首个项目。
+
 初启之时，灵台作 `.lingtai/`，备其运行时，引君择模型与配方，并令一常驻器灵守此项目。
 
 ```text

--- a/README.wen.md
+++ b/README.wen.md
@@ -167,7 +167,7 @@ flowchart LR
 
 ## 文档
 
-- 初用者，可先读 [《灵台工作手册（初学者友好版）》](docs/beginner-work-manual.zh.md)，亦可观 [火柴人动画版](docs/beginner-work-manual-stick-figure.zh.html)。
+- 初用者，可先读 [《灵台工作手册（初学者友好版）》](docs/beginner-work-manual.zh.md)，亦可观 [单文件图解版](docs/beginner-work-manual-stick-figure.zh.html)。
 - 接外渠者，于 TUI 中用 `/mcp`，再读相应插件之入门文。
 - 读源码者，自 [`ANATOMY.md`](ANATOMY.md) 入，而后下至 `tui/ANATOMY.md` 或 `portal/ANATOMY.md`。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,6 +51,8 @@ mkdir my-project && cd my-project
 lingtai-tui
 ```
 
+> 第一次用 LingTai？先看[小白工作手册](docs/beginner-work-manual.zh.md)（或[单文件 HTML 图解版](docs/beginner-work-manual-stick-figure.zh.html)），再创建第一个项目。
+
 首次启动时，灵台会创建 `.lingtai/`，准备自己的运行时，引导你配置模型/配方，并为这个项目启动一个常驻智能体。
 
 ```text

--- a/README.zh.md
+++ b/README.zh.md
@@ -402,7 +402,7 @@ Go 写的 TUI **不**承担智能体心智，它启动并监管 Python 内核智
 ## 文档路径
 
 - **第一次用？** 跑 `lingtai-tui`，选 **Tutorial** 配方，跟着走一遍；也可以先读 [《灵台工作手册（初学者友好版）》](docs/beginner-work-manual.zh.md)。
-- **想看可视化解释？** 打开 [火柴人动画版工作手册](docs/beginner-work-manual-stick-figure.zh.html)。
+- **想看可视化解释？** 打开 [单文件图解版工作手册](docs/beginner-work-manual-stick-figure.zh.html)；这个 HTML 不依赖外部资源，可直接双击打开。
 - **配外部渠道** — TUI 里 `/mcp`，再看对应插件自己的入门文档。
 - **写技能** — 首次启动后看 `tui/internal/preset/skills/lingtai-dev-guide/`。
 - **源码结构** — 从 [`ANATOMY.md`](ANATOMY.md) 看起，再下到 `tui/ANATOMY.md` 或 `portal/ANATOMY.md`。

--- a/docs/beginner-work-manual-stick-figure.zh.html
+++ b/docs/beginner-work-manual-stick-figure.zh.html
@@ -3,193 +3,72 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>灵台工作手册｜初中生也能懂的火柴人动画版</title>
+<title>灵台工作手册图解版</title>
 <style>
-:root{
-  --ink:#22312b;--muted:#66756f;--bg:#f7f4ec;--card:#fffdf7;--line:#d9cdb5;
-  --green:#7dab8f;--green2:#2f6f57;--gold:#d4a853;--red:#c96d62;--blue:#6f8fb8;
-  --shadow:0 12px 35px rgba(61,48,28,.12);--radius:22px;
-}
-*{box-sizing:border-box} body{margin:0;background:radial-gradient(circle at top left,#fff8dc 0,#f7f4ec 42%,#eef4ef 100%);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",Arial,sans-serif;line-height:1.75}
-a{color:var(--green2)} .wrap{max-width:1160px;margin:0 auto;padding:28px 18px 70px}.hero{display:grid;grid-template-columns:1.05fr .95fr;gap:24px;align-items:center;padding:30px;border:1px solid var(--line);border-radius:30px;background:linear-gradient(145deg,rgba(255,253,247,.96),rgba(239,247,240,.92));box-shadow:var(--shadow)}
-.badge{display:inline-flex;gap:8px;align-items:center;padding:6px 12px;border:1px solid #c8dbc9;border-radius:999px;background:#f3fbf5;color:var(--green2);font-weight:700;font-size:14px}h1{font-size:clamp(30px,5vw,54px);line-height:1.12;margin:16px 0 12px}.subtitle{font-size:20px;color:#3d5149;margin:0 0 16px}.note{color:var(--muted);font-size:14px}.hero-list{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:18px}.pill{padding:10px 12px;border-radius:14px;background:#fff;border:1px solid #e7dcc8;font-weight:650}.section{margin-top:28px;padding:26px;border:1px solid var(--line);border-radius:var(--radius);background:rgba(255,253,247,.92);box-shadow:var(--shadow)}.section h2{font-size:30px;margin:0 0 14px}.grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}.card{background:#fff;border:1px solid #eadfcd;border-radius:18px;padding:18px}.card h3{margin:0 0 8px;font-size:20px}.big{font-size:22px;font-weight:800;color:var(--green2)}.muted{color:var(--muted)}.steps{counter-reset:s}.step{position:relative;padding:18px 18px 18px 62px;margin:12px 0;border:1px solid #e6d9c2;border-radius:18px;background:#fff}.step:before{counter-increment:s;content:counter(s);position:absolute;left:18px;top:18px;width:32px;height:32px;border-radius:50%;display:grid;place-items:center;background:var(--green);color:white;font-weight:900}.cmd{background:#26332e;color:#eef8ee;padding:14px 16px;border-radius:16px;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;line-height:1.55}.two{display:grid;grid-template-columns:1fr 1fr;gap:16px}.warn{border-left:5px solid var(--gold);background:#fff9e7}.danger{border-left:5px solid var(--red);background:#fff4f3}.ok{border-left:5px solid var(--green);background:#f3fbf5}.tiny{font-size:13px}.toc{display:flex;flex-wrap:wrap;gap:10px;margin-top:14px}.toc a{text-decoration:none;background:#fff;border:1px solid #e4d7c4;padding:7px 10px;border-radius:999px;color:#32463e;font-weight:650}.source{font-size:13px;color:#68746f;border-top:1px dashed #d8ceb9;margin-top:18px;padding-top:12px}
-/* animation */
-.stage{position:relative;min-height:420px;border-radius:26px;background:linear-gradient(#dff2ff 0 45%,#f1ead8 45%);border:1px solid #cbd8cf;overflow:hidden}.sun{position:absolute;right:34px;top:28px;width:58px;height:58px;border-radius:50%;background:#ffd76a;box-shadow:0 0 0 12px rgba(255,215,106,.25);animation:pulse 3s infinite}.ground{position:absolute;left:0;right:0;bottom:0;height:62px;background:#b9d19d}.house{position:absolute;left:50%;top:120px;transform:translateX(-50%);width:245px;height:155px;background:#fff8e8;border:4px solid #5f6d61;border-radius:14px}.house:before{content:"";position:absolute;left:-20px;top:-66px;border-left:142px solid transparent;border-right:142px solid transparent;border-bottom:76px solid #8cb99b}.house-title{position:absolute;left:0;right:0;top:22px;text-align:center;font-weight:900;font-size:28px;color:#2f6f57}.window{position:absolute;width:48px;height:42px;border:3px solid #69756d;background:#dff2ff;top:72px;border-radius:8px}.w1{left:34px}.w2{right:34px}.door{position:absolute;left:103px;bottom:0;width:40px;height:66px;border:3px solid #69756d;border-bottom:0;background:#d4a853;border-radius:12px 12px 0 0}.person{position:absolute;width:70px;height:96px}.person svg{width:100%;height:100%;overflow:visible}.p-human{left:35px;bottom:65px;animation:walkHuman 12s infinite ease-in-out}.p-agent{right:62px;bottom:65px;animation:walkAgent 12s infinite ease-in-out}.bubble{position:absolute;max-width:210px;padding:10px 12px;border:2px solid #52665d;border-radius:18px;background:#fff;box-shadow:0 6px 18px rgba(0,0,0,.08);font-weight:750}.b1{left:20px;top:48px;animation:bubble1 12s infinite}.b2{right:24px;top:55px;animation:bubble2 12s infinite}.file{position:absolute;width:52px;height:64px;background:#fff;border:3px solid #52665d;border-radius:8px;left:105px;bottom:100px;animation:fileFly 12s infinite}.file:after{content:"任务";position:absolute;left:9px;top:20px;font-weight:900;color:#2f6f57}.toolbox{position:absolute;right:86px;top:205px;display:flex;gap:8px;animation:toolsPop 12s infinite}.tool{width:46px;height:46px;border-radius:12px;display:grid;place-items:center;background:#fff;border:3px solid #52665d;font-size:23px}.memory{position:absolute;left:88px;top:218px;display:grid;grid-template-columns:repeat(2,42px);gap:8px;animation:memoryPop 12s infinite}.mem{background:#f3fbf5;border:3px solid #52665d;border-radius:10px;display:grid;place-items:center;font-size:20px}.mini{position:absolute;bottom:73px;left:50%;width:42px;height:58px;opacity:0}.m1{animation:mini1 12s infinite}.m2{animation:mini2 12s infinite}.m3{animation:mini3 12s infinite}.report{position:absolute;right:92px;bottom:135px;width:82px;height:92px;background:#fff;border:3px solid #52665d;border-radius:10px;animation:reportDone 12s infinite}.report:before{content:"报告";position:absolute;left:22px;top:18px;font-size:20px;font-weight:900;color:#2f6f57}.check{position:absolute;right:109px;bottom:206px;font-size:40px;color:var(--green2);animation:checkPop 12s infinite}.caption{position:absolute;left:24px;right:24px;bottom:16px;background:rgba(255,253,247,.9);border:1px solid #ded2bc;border-radius:16px;padding:10px 14px;text-align:center;font-weight:800}.scene-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}.scene{padding:12px;border-radius:16px;border:1px solid #e6d9c2;background:#fff}.scene svg{width:100%;height:110px}.scene b{color:var(--green2)}
-@media (prefers-reduced-motion: reduce){*, *::before, *::after{animation:none!important;transition:none!important}}
-@keyframes pulse{0%,100%{transform:scale(1)}50%{transform:scale(1.08)}}
-@keyframes walkHuman{0%,8%{left:35px}18%,100%{left:88px}}
-@keyframes walkAgent{0%,42%{right:62px}56%,100%{right:120px}}
-@keyframes bubble1{0%,18%{opacity:1;transform:translateY(0)}25%,100%{opacity:.12;transform:translateY(-6px)}}
-@keyframes bubble2{0%,54%{opacity:.12;transform:translateY(5px)}62%,100%{opacity:1;transform:translateY(0)}}
-@keyframes fileFly{0%,18%{opacity:1;transform:translate(0,0) rotate(-3deg)}32%,45%{opacity:1;transform:translate(360px,-110px) rotate(8deg)}52%,100%{opacity:0;transform:translate(460px,-120px)}}
-@keyframes toolsPop{0%,30%{opacity:0;transform:scale(.8)}40%,70%{opacity:1;transform:scale(1)}80%,100%{opacity:.25;transform:scale(.92)}}
-@keyframes memoryPop{0%,25%{opacity:0;transform:scale(.8)}34%,72%{opacity:1;transform:scale(1)}82%,100%{opacity:.28}}
-@keyframes mini1{0%,42%{opacity:0;transform:translate(0,0)}50%,78%{opacity:1;transform:translate(-108px,-36px)}88%,100%{opacity:0;transform:translate(-160px,-70px)}}
-@keyframes mini2{0%,46%{opacity:0;transform:translate(0,0)}54%,80%{opacity:1;transform:translate(0,-58px)}90%,100%{opacity:0;transform:translate(20px,-90px)}}
-@keyframes mini3{0%,50%{opacity:0;transform:translate(0,0)}58%,82%{opacity:1;transform:translate(112px,-35px)}92%,100%{opacity:0;transform:translate(170px,-68px)}}
-@keyframes reportDone{0%,58%{opacity:0;transform:translateY(20px)}68%,100%{opacity:1;transform:translateY(0)}}
-@keyframes checkPop{0%,65%{opacity:0;transform:scale(.4)}72%,100%{opacity:1;transform:scale(1)}}
-@media(max-width:850px){.hero,.two{grid-template-columns:1fr}.grid{grid-template-columns:1fr}.scene-grid{grid-template-columns:1fr 1fr}.hero-list{grid-template-columns:1fr}.stage{min-height:390px}.toolbox{right:25px}.memory{left:24px}.house{width:210px}.house:before{border-left-width:122px;border-right-width:122px}.p-agent{right:18px}.report{right:35px}.note,.source{font-size:14px}}
-@media(max-width:480px){.bubble{max-width:160px;font-size:13px}.b1{left:10px}.b2{right:10px;top:96px}.caption{font-size:13px;padding:8px 10px}.file{animation:fileFlyMobile 12s infinite}@keyframes fileFlyMobile{0%,18%{opacity:1;transform:translate(0,0) rotate(-3deg)}32%,45%{opacity:1;transform:translate(180px,-92px) rotate(8deg)}52%,100%{opacity:0;transform:translate(230px,-105px)}}}
+:root{--bg:#f7f3ea;--ink:#26231e;--muted:#6d6558;--card:#fffaf0;--accent:#7dab8f;--accent2:#d89b5f;--line:#2b2925}
+*{box-sizing:border-box} body{margin:0;background:linear-gradient(180deg,#fbf7ee,#efe7d8);font-family:-apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif;color:var(--ink);line-height:1.7}
+header{padding:42px 20px 20px;text-align:center} h1{margin:0;font-size:clamp(28px,5vw,52px)} .sub{color:var(--muted);font-size:18px;margin-top:10px}
+.wrap{max-width:1080px;margin:0 auto;padding:16px 20px 60px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:18px}.card{background:rgba(255,250,240,.92);border:2px solid #eadcc7;border-radius:22px;padding:20px;box-shadow:0 12px 30px rgba(70,50,20,.08)}
+.card h2{font-size:22px;margin:0 0 10px}.card p{margin:.35em 0}.num{display:inline-flex;width:34px;height:34px;border-radius:50%;background:var(--accent);color:white;align-items:center;justify-content:center;font-weight:700;margin-right:8px}
+pre{white-space:pre-wrap;background:#28231d;color:#fff8e8;border-radius:14px;padding:14px;overflow:auto}.flow{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:center;margin:24px 0}.node{background:white;border:2px solid var(--line);border-radius:18px;padding:12px 16px;min-width:120px;text-align:center;position:relative}.arrow{font-size:28px;color:var(--accent2)}
+.agent{width:120px;height:140px;margin:16px auto;position:relative;animation:breathe 2.8s ease-in-out infinite}.head{width:62px;height:62px;border:3px solid var(--line);border-radius:50%;background:#fff;position:absolute;left:29px;top:0}.body{width:76px;height:58px;border:3px solid var(--line);border-radius:28px 28px 12px 12px;background:#fff;position:absolute;left:22px;top:70px}.eye{width:7px;height:7px;background:var(--line);border-radius:50%;position:absolute;top:25px}.eye.l{left:19px}.eye.r{right:19px}.smile{width:24px;height:12px;border-bottom:3px solid var(--line);border-radius:0 0 20px 20px;position:absolute;left:19px;top:35px}@keyframes breathe{50%{transform:translateY(-8px)}}
+.badge{display:inline-block;background:#e8f3ec;color:#2e6b4d;border-radius:999px;padding:3px 10px;margin:2px;font-size:13px}.warn{background:#fff3dc;border-left:6px solid var(--accent2);padding:12px 14px;border-radius:10px}.ok{background:#eaf6ee;border-left:6px solid var(--accent);padding:12px 14px;border-radius:10px}
+footer{text-align:center;color:var(--muted);padding:20px}.small{font-size:14px;color:var(--muted)}
 </style>
 </head>
 <body>
-<div class="wrap">
-  <section class="hero">
-    <div>
-      <span class="badge">火柴人动画版 · 给第一次见 LingTai 的人</span>
-      <h1>灵台工作手册</h1>
-      <p class="subtitle">你可以把灵台想成一个“长期 AI 助手”。它不只会聊天，还能记住项目、读文件、使用工具、找其他 AI 帮忙；如果外接渠道已配置且可用，通常会把结果发回你发起任务的地方。</p>
-      <div class="toc">
-        <a href="#what">1. 是什么</a><a href="#start">2. 十分钟上手</a><a href="#tools">3. 会什么</a><a href="#memory">4. 记忆</a><a href="#helpers">5. 分神/分身</a><a href="#context">6. 上下文爆炸</a><a href="#slash">7. / 指令</a><a href="#soul">8. 心流</a><a href="#safe">9. 安全与排障</a>
-      </div>
-      <p class="note">如果你看不懂 TUI、MCP、daemon 这些词，没关系。先把灵台理解成“会长期帮你做事的 AI 助手”；专业词后面慢慢认识。整理依据：Lingtai-AI/lingtai README.zh.md、GitHub issue #198，以及当时的 TUI/Portal 与 kernel 版本；具体版本号以最新 README、Releases 与 TUI 内 `/doctor` 为准。</p>
-    </div>
-    <div class="stage" role="img" aria-label="火柴人动画：人把任务交给灵台，灵台调用记忆、工具和分神，最后回复报告。">
-      <div class="sun"></div><div class="ground"></div>
-      <div class="house"><div class="house-title">灵台</div><div class="window w1"></div><div class="window w2"></div><div class="door"></div></div>
-      <div class="bubble b1">帮我盯项目，明早给报告！</div><div class="bubble b2">收到，我会读记忆、用工具、叫帮手。</div>
-      <div class="file"></div>
-      <div class="person p-human"><svg viewBox="0 0 80 110"><circle cx="40" cy="18" r="13" fill="none" stroke="#26332e" stroke-width="5"/><line x1="40" y1="31" x2="40" y2="62" stroke="#26332e" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="42" x2="18" y2="54" stroke="#26332e" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="42" x2="62" y2="54" stroke="#26332e" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="62" x2="24" y2="94" stroke="#26332e" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="62" x2="59" y2="94" stroke="#26332e" stroke-width="5" stroke-linecap="round"/></svg></div>
-      <div class="person p-agent"><svg viewBox="0 0 80 110"><circle cx="40" cy="18" r="13" fill="none" stroke="#2f6f57" stroke-width="5"/><line x1="40" y1="31" x2="40" y2="62" stroke="#2f6f57" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="42" x2="18" y2="54" stroke="#2f6f57" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="42" x2="62" y2="54" stroke="#2f6f57" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="62" x2="24" y2="94" stroke="#2f6f57" stroke-width="5" stroke-linecap="round"/><line x1="40" y1="62" x2="59" y2="94" stroke="#2f6f57" stroke-width="5" stroke-linecap="round"/></svg></div>
-      <div class="toolbox"><div class="tool">📁</div><div class="tool">🔎</div><div class="tool">🛠</div></div>
-      <div class="memory"><div class="mem">简</div><div class="mem">知</div><div class="mem">技</div><div class="mem">邮</div></div>
-      <div class="mini m1"><svg viewBox="0 0 60 80"><circle cx="30" cy="12" r="9" fill="none" stroke="#6f8fb8" stroke-width="4"/><line x1="30" y1="22" x2="30" y2="48" stroke="#6f8fb8" stroke-width="4"/><line x1="30" y1="32" x2="12" y2="42" stroke="#6f8fb8" stroke-width="4"/><line x1="30" y1="32" x2="48" y2="42" stroke="#6f8fb8" stroke-width="4"/><line x1="30" y1="48" x2="18" y2="70" stroke="#6f8fb8" stroke-width="4"/><line x1="30" y1="48" x2="45" y2="70" stroke="#6f8fb8" stroke-width="4"/></svg></div>
-      <div class="mini m2"><svg viewBox="0 0 60 80"><circle cx="30" cy="12" r="9" fill="none" stroke="#d4a853" stroke-width="4"/><line x1="30" y1="22" x2="30" y2="48" stroke="#d4a853" stroke-width="4"/><line x1="30" y1="32" x2="12" y2="42" stroke="#d4a853" stroke-width="4"/><line x1="30" y1="32" x2="48" y2="42" stroke="#d4a853" stroke-width="4"/><line x1="30" y1="48" x2="18" y2="70" stroke="#d4a853" stroke-width="4"/><line x1="30" y1="48" x2="45" y2="70" stroke="#d4a853" stroke-width="4"/></svg></div>
-      <div class="mini m3"><svg viewBox="0 0 60 80"><circle cx="30" cy="12" r="9" fill="none" stroke="#c96d62" stroke-width="4"/><line x1="30" y1="22" x2="30" y2="48" stroke="#c96d62" stroke-width="4"/><line x1="30" y1="32" x2="12" y2="42" stroke="#c96d62" stroke-width="4"/><line x1="30" y1="32" x2="48" y2="42" stroke="#c96d62" stroke-width="4"/><line x1="30" y1="48" x2="18" y2="70" stroke="#c96d62" stroke-width="4"/><line x1="30" y1="48" x2="45" y2="70" stroke="#c96d62" stroke-width="4"/></svg></div>
-      <div class="report"></div><div class="check">✓</div><div class="caption">人发任务 → 灵台醒来 → 读记忆/用工具/叫帮手 → 回到原渠道汇报</div>
-    </div>
-  </section>
-
-  <section class="section" id="what"><h2>1｜灵台到底是什么？</h2>
-    <div class="grid">
-      <div class="card"><div class="big">不是普通聊天框</div><p>普通聊天框像“你问一句，它答一句”。灵台更像一个在项目里长期工作的 AI 组织。</p></div>
-      <div class="card"><div class="big">有自己的家</div><p>每个项目会有 <code>.lingtai/</code>。里面有智能体、信箱、记忆、日志、配置、运行状态和可视化记录。</p></div>
-      <div class="card"><div class="big">能长大</div><p>任务复杂时，它能叫几个“临时小帮手 Daemon”一起查资料，也能培养“长期专门助手 Avatar”。</p></div>
-    </div>
-    <p class="ok card"><b>一句话：</b>灵台不是只会陪你聊天的 AI，而是一个能长期帮你管理项目、记住事情、分配任务的 AI 工作系统。</p>
-  </section>
-
-  <section class="section" id="start"><h2>2｜十分钟上手流程</h2>
-    <div class="step"><b>安装并打开。</b>README 当前推荐 Homebrew；第一次进项目后启动 TUI。如果你没用过命令行，请先找会电脑操作的人帮你完成安装；下面这些命令是输入到“终端”里的。</div>
-    <pre class="cmd">brew install lingtai-ai/lingtai/lingtai-tui
-mkdir my-project && cd my-project
+<header>
+  <div class="agent"><div class="head"><span class="eye l"></span><span class="eye r"></span><span class="smile"></span></div><div class="body"></div></div>
+  <h1>灵台工作手册图解版</h1>
+  <div class="sub">一个文件即可打开；无外链、无依赖。先安装，再启动，再做第一个小任务。</div>
+</header>
+<main class="wrap">
+<section class="card">
+<h2>先看总图</h2>
+<div class="flow"><div class="node">你</div><div class="arrow">→</div><div class="node">lingtai-tui</div><div class="arrow">→</div><div class="node">项目 .lingtai/</div><div class="arrow">→</div><div class="node">agent 工作</div></div>
+<p>灵台不是只会聊天的网页机器人。它是本地工作台：TUI 负责界面，项目目录保存状态，agent 在里面读文件、跑命令、写报告、发消息。</p>
+</section>
+<section class="grid">
+<div class="card"><h2><span class="num">1</span>安装</h2><p>普通用户安装的是 <code>lingtai-tui</code>，不要先去系统 Python 里 <code>pip install lingtai</code>。</p><pre>brew install lingtai-ai/lingtai/lingtai-tui
+lingtai-tui</pre></div>
+<div class="card"><h2><span class="num">2</span>创建项目</h2><p>一个主题建一个项目。项目里会出现 <code>.lingtai/</code>，agent 的信箱、日志、记忆都在这里。</p></div>
+<div class="card"><h2><span class="num">3</span>/setup</h2><p>第一次启动先跑 <code>/setup</code>。不会选就用默认或 Tutorial 配置，先跑通再调细节。</p></div>
+<div class="card"><h2><span class="num">4</span>第一个任务</h2><p>不要先问“你会什么”。直接给一个小任务，例如创建 <code>notes.md</code>。</p></div>
+</section>
+<section class="card">
+<h2>安装最小路径</h2>
+<p class="ok">macOS 最推荐：先确认有 Homebrew，再装 LingTai。</p>
+<pre>brew --version
+brew install lingtai-ai/lingtai/lingtai-tui
+which lingtai-tui
 lingtai-tui</pre>
-    <div class="step"><b>首次配置。</b>跟着 TUI 选模型/配方/语言/工具。第一次不知道选什么，可以先选 Tutorial 或默认引导。</div>
-    <div class="step"><b>发一个小任务。</b>例如：“帮我整理这个项目的文件结构，写一份 5 条以内的总结。”先用小任务确认它能读文件、能回复。</div>
-    <div class="step"><b>学 6 个常用命令。</b><code>/setup</code> 配模型和行为；<code>/kanban</code> 看助手和项目状态；<code>/mcp</code> 配微信/Telegram/邮箱等外接渠道；<code>/skills</code> 看技能；<code>/viz</code> 看组织图；<code>/doctor</code> 排障。</div>
-    <div class="step"><b>开始长期项目。</b>告诉它项目背景、你的偏好、哪些内容要长期记住；重要产物让它写成文件或 HTML。</div>
-    <p class="warn card"><b>小提醒：</b>普通用户请优先按 README 推荐的方法安装或升级。不要随便用 <code>pip install lingtai</code>，它可能不是你真正要升级的部分。大陆网络卡住时，看 README 里的清华镜像 / Gitee tap 说明。Windows 路线仍以最新 README/官网为准。</p>
-  </section>
+<p class="warn">若提示 <code>command not found: brew</code>，先装 Homebrew：<br><code>/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"</code></p>
+</section>
+<section class="grid">
+<div class="card"><h2>大陆网络卡住</h2><p>先试默认安装。若卡在 Homebrew 索引，用清华 TUNA；若卡在 GitHub tap，用 Gitee tap；若 npm 证书报错，先清掉 npm 镜像变量。</p></div>
+<div class="card"><h2>出问题先 doctor</h2><pre>lingtai-tui doctor</pre><p>TUI 里也可用 <code>/doctor</code>。它会检查 TUI、kernel、runtime 的关系。</p></div>
+<div class="card"><h2>看状态</h2><p><span class="badge">/kanban</span><span class="badge">/help</span><span class="badge">/goal</span><span class="badge">/mcp</span><span class="badge">/viz</span></p><p>先记 <code>/kanban</code> 和 <code>/doctor</code> 即可。</p></div>
+</section>
+<section class="card">
+<h2>怎样把任务说清楚</h2>
+<pre>目标：我要做什么
+材料：文件或链接在哪里
+输出：要 Markdown、Word、HTML 还是代码
+红线：不要发布、不要删除、先给我审核
+不确定：先问我</pre>
+<p>说清楚这五项，agent 就少猜很多。</p>
+</section>
 
-  <section class="section" id="tools"><h2>3｜灵台会做什么？</h2>
-    <div class="scene-grid">
-      <div class="scene"><svg viewBox="0 0 180 110"><rect x="35" y="18" width="110" height="74" rx="12" fill="#fff" stroke="#52665d" stroke-width="5"/><path d="M50 38h80M50 55h68M50 72h48" stroke="#7dab8f" stroke-width="6" stroke-linecap="round"/></svg><b>读文件</b><br>整理项目资料、写报告、做表格。</div>
-      <div class="scene"><svg viewBox="0 0 180 110"><circle cx="76" cy="48" r="30" fill="none" stroke="#52665d" stroke-width="7"/><line x1="98" y1="70" x2="132" y2="92" stroke="#52665d" stroke-width="8" stroke-linecap="round"/><path d="M63 48h26M76 35v26" stroke="#d4a853" stroke-width="6"/></svg><b>查网页</b><br>搜索、自动读取网页内容、核对资料来源。</div>
-      <div class="scene"><svg viewBox="0 0 180 110"><rect x="30" y="20" width="120" height="72" rx="12" fill="#eef7ff" stroke="#52665d" stroke-width="5"/><circle cx="70" cy="52" r="14" fill="#d4a853"/><path d="M38 84l34-28 24 19 18-15 36 24" fill="none" stroke="#2f6f57" stroke-width="6"/></svg><b>看图片</b><br>识别截图、图表、海报文字。</div>
-      <div class="scene"><svg viewBox="0 0 180 110"><rect x="32" y="28" width="116" height="58" rx="12" fill="#fff" stroke="#52665d" stroke-width="5"/><path d="M48 48h84M48 66h58" stroke="#c96d62" stroke-width="6"/><path d="M132 18l18 18" stroke="#52665d" stroke-width="6"/></svg><b>用工具</b><br>在你允许时执行电脑命令、运行测试、生成网页，或请写代码工具帮忙。</div>
-    </div>
-    <div class="two" style="margin-top:16px">
-      <div class="card"><h3>外接渠道</h3><p>配置相应 MCP/插件后，同一个长期助手可以从 TUI、微信、Telegram、飞书/Lark、WhatsApp、邮件等入口收到任务。<b>配置正确且渠道可用时，通常回到原渠道。</b></p></div>
-      <div class="card"><h3>可视化</h3><p><code>/viz</code> 或 Portal（图形化展示页）可以看见谁在线、谁给谁发信、组织怎样长大。</p></div>
-    </div>
-  </section>
-
-  <section class="section" id="memory"><h2>4｜灵台怎样“记住事情”？</h2>
-    <div class="grid">
-      <div class="card"><h3>对话</h3><p>像课堂草稿纸，当前有用，太长会清理。</p></div>
-      <div class="card"><h3>当前便签 Pad</h3><p>像任务看板，记录临时笔记、当前计划和下一步。</p></div>
-      <div class="card"><h3>项目知识 Knowledge</h3><p>像项目档案，保存私有事实、路径、长期决策。</p></div>
-      <div class="card"><h3>做事方法 Skills</h3><p>像可复用教程，把做事方法沉淀给以后再用。</p></div>
-      <div class="card"><h3>长期规则 Character</h3><p>像性格和长期规则，告诉它“我是谁、我怎么做事”。</p></div>
-      <div class="card"><h3>整理记忆 Molt / 凝蜕</h3><p>聊天太长、上下文快装不下时，它会把重要内容整理成“给下一轮自己的交接信”，再轻装继续。像收拾书包，不是失忆。</p></div>
-    </div>
-    <p class="ok card"><b>给初学者的用法：</b>重要背景要明确说“请记到长期知识/当前便签里”；复杂任务做完，可以说：“请把这次任务的背景、已完成内容、下一步计划整理成一段，下次我可以直接接着做。”如果你看到它提示“上下文很满/需要凝蜕”，就让它先整理现场再继续。</p>
-  </section>
-
-  <section class="section" id="helpers"><h2>5｜怎样触发分神 / 分身？</h2>
-    <div class="two">
-      <div class="card"><h3>临时小帮手 Daemon / 分神</h3><p>像临时请 3 个同学分头查资料。适合：资料很多、内容很杂、需要交叉校对，但你只想要最后结论的任务。做完就把结论交回来，不长期存在。</p></div>
-      <div class="card"><h3>长期专门助手 Avatar / 分身</h3><p>像培养一个专门同事。适合：长期项目、固定领域、需要记住历史和风格的任务。分身会长期存在，越用越像一个固定岗位。</p></div>
-    </div>
-    <div class="grid" style="margin-top:16px">
-      <div class="card ok"><h3>你可以这样叫分神</h3><p>“这个资料很多，请派 3 个分神：一个查来源，一个看有没有错，一个把结果改成初中生能懂。”</p></div>
-      <div class="card ok"><h3>你可以这样叫分身</h3><p>“这个营养科普项目要长期做，请建一个专门负责证据核验的分身，以后固定找它。”</p></div>
-      <div class="card warn"><h3>什么时候别乱开？</h3><p>很小的事不用分神；需要真实发消息、删文件、发 issue、推代码的事，要先让人确认。分身适合长期岗位，不适合一次性小任务。</p></div>
-    </div>
-    <div class="card" style="margin-top:16px"><h3>编码工具是“手”，灵台是“长期大脑”</h3><p>如果你不写代码，可以先跳过这一段。Claude Code、Codex、OpenCode 等更适合精确改代码；灵台更适合计划、记忆、调度、沟通、长期项目管理。两者可以搭配。</p></div>
-  </section>
-
-
-  <section class="section" id="context"><h2>6｜上下文“爆炸”了怎么办？</h2>
-    <p>上下文可以理解成 AI 这一轮能摊在桌面上的纸。任务越长，纸越多；快放不下时，就要“收桌面”。灵台的办法叫 <b>凝蜕 / molt</b>：先把重点打包，再换一张干净桌子继续。</p>
-    <div class="grid">
-      <div class="card warn"><h3>信号</h3><p>对话很长、它提示 context/molt、开始反复找不到前文、或一个任务做了很多轮还没收束。</p></div>
-      <div class="card ok"><h3>正确做法</h3><p>让它先写交接：“请总结已完成、未完成、关键文件、下一步、要联系谁，再凝蜕/继续。”</p></div>
-      <div class="card danger"><h3>不要这样</h3><p>不要在快满时继续塞大量新任务；不要让它什么都不总结就刷新；不要把“凝蜕”当作失败，它是正常收纳。</p></div>
-    </div>
-    <div class="card" style="margin-top:16px"><b>一句话模板：</b>“先收功：把当前任务、文件路径、结论、坑点、下一步整理好；该记入长期知识/便签的记好；然后再凝蜕继续。”</div>
-  </section>
-
-  <section class="section" id="slash"><h2>7｜常见 / 指令小抄</h2>
-    <p>这些是在 LingTai TUI 里常见的斜杠命令。不同版本可能会增减，最终以 TUI 里实际显示和最新 README 为准。</p>
-    <div class="grid">
-      <div class="card"><h3><code>/setup</code></h3><p>第一次设置或重新检查项目、模型、渠道等基础配置。</p></div>
-      <div class="card"><h3><code>/kanban</code></h3><p>看当前有哪些 agent、任务、状态，像项目看板。</p></div>
-      <div class="card"><h3><code>/mcp</code></h3><p>配置微信、Telegram、飞书、邮箱等外接工具；没配好就不能从这些渠道收发。</p></div>
-      <div class="card"><h3><code>/skills</code></h3><p>查看/管理“做事方法手册”。复杂项目可以把流程写成 skill，避免每次从零开始。</p></div>
-      <div class="card"><h3><code>/viz</code></h3><p>打开可视化网络，看 agent 之间的关系和历史。</p></div>
-      <div class="card"><h3><code>/insights</code></h3><p>看系统整理出的洞察、回顾或运行观察。</p></div>
-      <div class="card"><h3><code>/sleep</code></h3><p>让 agent 休息；它仍可被消息唤醒。</p></div>
-      <div class="card"><h3><code>/refresh</code></h3><p>刷新当前 agent 的身体/配置。适合改配置后重载；不是随便清空一切。</p></div>
-      <div class="card"><h3><code>/doctor</code></h3><p>体检：排查启动、配置、工具、日志等问题。</p></div>
-      <div class="card"><h3><code>/cpr</code></h3><p>复苏卡住或假死的 agent。先诊断，再复苏。</p></div>
-      <div class="card"><h3><code>/clear</code></h3><p>强制重置某个 agent。影响较大，谨慎用。</p></div>
-      <div class="card"><h3><code>/projects</code></h3><p>切换或查看项目网络。</p></div>
-    </div>
-  </section>
-
-  <section class="section" id="soul"><h2>8｜心流是什么？</h2>
-    <p>心流可以理解成“AI 在空闲时的自我复盘”。它会回看最近做过的事，提醒自己哪里可能遗漏、哪里应该沉淀、哪里该继续。它不是人发来的消息，也不是必须照做的命令。</p>
-    <div class="three">
-      <div class="card"><h3>像什么？</h3><p>像一个人做完一天工作后写反思：“今天哪里做得好？哪里可能漏了？下次怎么更稳？”</p></div>
-      <div class="card"><h3>有什么用？</h3><p>帮助 agent 发现盲点：该不该回信、该不该写入知识、该不该做成 skill、是否需要休息或收功。</p></div>
-      <div class="card warn"><h3>注意边界</h3><p>心流只是内心提醒，不代表外界事实。涉及人类新消息、文件变化、网页资料时，仍要通过对应渠道核实。</p></div>
-    </div>
-  </section>
-
-  <section class="section" id="safe"><h2>9｜安全、隐私与排障</h2>
-    <div class="grid">
-      <div class="card danger"><h3>密钥不要外泄</h3><p>API Key、token、密码可以理解成“软件钥匙”，只放受保护配置或 <code>.secrets/</code>。不要贴进公开报告、issue、截图。</p></div>
-      <div class="card warn"><h3>外部动作要确认</h3><p>发消息、提 issue、删文件、推代码都是真实动作。在你确认之前，不要让它自动发送、删除或发布内容。</p></div>
-      <div class="card warn"><h3>专业内容要复核</h3><p>医学、营养、法律、金融等内容，AI 可辅助整理，但最后要人类专家审核。陌生外部邮件也不应自动回复，除非用户确认。</p></div>
-    </div>
-    <h3>常见问题</h3>
-    <div class="two">
-      <div class="card"><b>打不开 / 命令找不到</b><br>检查 Homebrew 的 bin 是否在 PATH；或者按 README 的安装详解重新装。</div>
-      <div class="card"><b>助手不回应</b><br>先等一小会儿：它可能在跑长工具、整理记忆或恢复。然后看 <code>/kanban</code>，再在 TUI 里用 <code>/doctor</code>；技术同学可再查 <code>lingtai-tui list</code> 和日志。</div>
-      <div class="card"><b>升级后没变化</b><br>重启 TUI；在 TUI 里用 <code>/doctor</code> 或在终端运行 <code>lingtai-tui doctor</code>。TUI 程序和 Python 运行时是两层。</div>
-      <div class="card"><b>技能/命令丢了</b><br>试 <code>lingtai-tui bootstrap</code> 或 TUI 里的 <code>/doctor</code>。如果切换模型/预设后微信、Telegram 等工具消失，检查 <code>/setup</code>、<code>/mcp</code> 和当前预设能力。</div>
-    </div>
-  </section>
-
-  <section class="section"><h2>10｜一张小抄：怎么把任务说清楚</h2>
-    <div class="step"><b>说目标：</b>“帮我整理这周的会议记录。”</div>
-    <div class="step"><b>说范围：</b>“只看 <code>meeting-notes</code> 文件夹，不要改原文。”</div>
-    <div class="step"><b>说形式：</b>“输出 5 条重点和 3 个待办事项。”</div>
-    <div class="step"><b>说安全：</b>“不要发给别人，只生成草稿；不要泄露 token 或密码。”</div>
-    <div class="step"><b>说回报方式：</b>“完成后在微信告诉我摘要和文件路径。”</div>
-  </section>
-
-  <section class="section"><h2>来源与本版边界</h2>
-    <ul>
-      <li>GitHub issue：<a href="https://github.com/Lingtai-AI/lingtai/issues/198">Lingtai-AI/lingtai #198 docs: add a beginner-friendly LingTai user manual</a>（open，更新于 2026-05-28）。</li>
-      <li>当前 README.zh.md：Lingtai-AI/lingtai，HEAD <code>9aa992a</code>，提交信息：<code>docs: align localized READMEs with organization framing</code>，时间 2026-06-03。</li>
-      <li>版本号会持续更新：当前的 TUI/Portal 与 <code>lingtai-kernel</code> 版本，请以最新 README、<a href="https://lingtai.ai/releases/">Releases</a> 与 TUI 内 <code>/doctor</code> 为准，本页不再固定具体版本。</li>
-      <li>本页是“给普通用户看的解释版”，不是安装/开发的唯一权威文档。命令只列常用项；完整列表、具体版本号、平台支持和 UI 文案，以最新 README、官网和 TUI 内置 <code>/setup</code>/<code>/mcp</code>/<code>/doctor</code> 为准。</li>
-    </ul>
-    <p class="source">整理时间：2026-06-04。用途：LingTai 初学者工作手册的火柴人动画版；本版补充分神/分身、上下文爆炸、斜杠指令和心流说明。</p>
-  </section>
-</div>
+<section class="grid">
+<div class="card"><h2>上下文满了</h2><p>长任务做久后，让 agent 先收束现场：已完成、未完成、关键文件、下一步。需要时它会凝蜕，像把桌面收干净再继续。</p></div>
+<div class="card"><h2>文件 / knowledge / skill</h2><p>一次性交付放文件；长期事实进 knowledge；以后还会复用的方法写成 skill。不要把所有东西都堆在聊天里。</p></div>
+</section>
+<section class="card">
+<h2>主 agent / daemon / avatar</h2>
+<div class="flow"><div class="node">主 agent<br><span class="small">判断与汇总</span></div><div class="node">daemon<br><span class="small">一次性脏活</span></div><div class="node">avatar<br><span class="small">长期专项</span></div></div>
+<p>小白先不用主动开很多分身。大批量扫描、长测试、严厉审稿时，再让主 agent 派 daemon。</p>
+</section>
+<footer>完整文字版见 <code>docs/beginner-work-manual.zh.md</code>。本图解版为单文件 HTML，可直接双击打开。</footer>
+</main>
 </body>
 </html>

--- a/docs/beginner-work-manual.zh.md
+++ b/docs/beginner-work-manual.zh.md
@@ -1,252 +1,659 @@
-# 灵台工作手册（初学者友好版）
+# 灵台工作手册：从安装到第一个可用任务（初学者版）
 
-> 这是一份给第一次接触 LingTai 的普通用户看的入门手册。它尽量用大白话说明：灵台是什么、如何开始、常用 `/` 指令、怎样叫分神/分身、上下文快满时怎么办、心流是什么，以及安全边界在哪里。
+> 这份手册写给第一次接触 LingTai / 灵台的人。目标只有一个：**照着做，能把灵台装起来、跑起来、知道下一步该点哪里、出了问题该查哪里。**
 >
-> 若安装命令、界面文案或能力列表与当前版本不一致，以最新 README、TUI 内置 `/setup`、`/mcp`、`/doctor` 和实际界面为准。
+> 如果你已经会用命令行，可以直接看第 2 节安装；如果你完全没接触过终端，请从第 1 节开始。
 
-另有一份可直接在浏览器打开的火柴人动画版：[`beginner-work-manual-stick-figure.zh.html`](beginner-work-manual-stick-figure.zh.html)。
+## 0. 先用一句话讲清楚灵台
 
-## 1. 灵台到底是什么？
+灵台不是一个只能在网页里聊天的机器人。它更像一个**本地工作台**：
 
-你可以先把灵台理解成一个**长期 AI 助手工作台**。
+- 你在终端里打开 `lingtai-tui`；
+- TUI 帮你创建一个项目；
+- 项目里会有一个或多个 agent；
+- agent 可以读写本地文件、跑命令、查资料、写技能、发消息；
+- 需要时还能分出临时小助手（daemon）或长期分身（avatar）；
+- 所有状态都落在项目目录的 `.lingtai/` 里，方便检查、迁移和恢复。
 
-普通聊天机器人通常是：你问一句，它答一句。灵台更像一个会长期陪你做项目的小团队：
+可以先记住这张图：
 
-- 它可以读文件、整理资料、写文档、查网页、生成报告；
-- 它可以把项目背景、偏好、资料路径、做事方法沉淀下来，下一次继续用；
-- 它可以临时派出“分神”（daemon）并行查资料、校对、跑脚本；
-- 它也可以培养长期“分身”（avatar），像固定同事一样负责某个方向；
-- 配好外接渠道后，它可以通过 Telegram、微信、飞书、IMAP 邮箱等收发消息；
-- 它不是只停在聊天框里，而是有自己的项目目录、文件、日志、记忆和工具。
+```text
+你
+│
+├─ 终端里的 lingtai-tui       ← 你看到的界面、命令、设置、状态
+│
+└─ 项目目录 .lingtai/          ← agent 的信箱、日志、记忆、配置
+   ├─ 主 agent                 ← 主要和你协作的人
+   ├─ daemon                   ← 临时分神：做一次任务，做完就退
+   ├─ avatar                   ← 长期分身：适合长期专项工作
+   ├─ skills / knowledge       ← 可复用流程与长期知识
+   └─ MCP / IM / email         ← 外部服务与通信入口
+```
 
-适合灵台的场景：长期项目、复杂研究、内容生产、代码与文档协作、多工具协作、需要持续记忆的个人/团队工作流。
+**小白先别急着理解所有名词。** 先完成安装、启动、第一次任务；后面的能力会在需要时再用。
 
-如果你只是偶尔问一句“今天吃什么”，普通 AI 聊天网页可能更轻便；如果你希望 AI 像一个可成长的工作组织，灵台更适合。
+---
 
-## 2. 十分钟上手流程
+## 1. 安装前先确认三件事
 
-### 第一步：安装并启动
+### 1.1 你现在用的是什么系统？
 
-当前 README 推荐的 macOS Homebrew 路径是：
+推荐顺序：
+
+1. **macOS**：最推荐，直接用 Homebrew 安装。
+2. **Linux**：可用 Homebrew for Linux，或从源码安装。
+3. **Windows**：建议先装 WSL2 + Ubuntu，再按 Linux 路线走。
+
+如果你只是想最快体验，优先找一台 macOS。
+
+### 1.2 你需要会什么？
+
+只需要会三件事：
+
+- 打开终端；
+- 复制一段命令进去；
+- 看报错信息，按本手册排查。
+
+不用先学 Python，不用自己装 `pip install lingtai`。普通用户安装 LingTai，**不要把系统 Python 当入口**。
+
+### 1.3 灵台由哪两层组成？
+
+这点很重要，因为很多安装问题都来自“装错层”。
+
+| 层 | 你看到的名字 | 负责什么 | 普通用户怎么装 |
+|---|---|---|---|
+| TUI | `lingtai-tui` | 终端界面、项目向导、命令、可视化入口、升级/doctor | 用 Homebrew 或源码安装 |
+| Kernel | `lingtai` Python 包 | agent 真正运行的内核、工具、上下文、MCP | TUI 自动管理，不要手动装到系统 Python |
+
+一句话：**你安装的是 `lingtai-tui`；Python 内核由 TUI 管。**
+
+---
+
+## 2. macOS 安装：最推荐路线
+
+### 2.1 打开终端
+
+在 macOS 上：
+
+1. 按 `Command + Space`；
+2. 输入“终端”或 `Terminal`；
+3. 回车打开。
+
+后面的命令都复制到终端里执行。
+
+### 2.2 先检查有没有 Homebrew
+
+输入：
+
+```bash
+brew --version
+```
+
+可能出现两种情况：
+
+- 看到 `Homebrew 4.x.x`：说明已经装好了，跳到 2.4。
+- 看到 `command not found: brew`：说明还没装，继续 2.3。
+
+### 2.3 安装 Homebrew
+
+复制执行：
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+安装过程中可能会要求输入电脑密码。输入时终端不会显示星号，这是正常的。
+
+装完后，Homebrew 通常会提示你执行两行 `eval "$(... brew shellenv)"`。如果你没看懂，可以先按下面常见路径试：
+
+Apple Silicon（M1/M2/M3）Mac：
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+Intel Mac：
+
+```bash
+eval "$(/usr/local/bin/brew shellenv)"
+```
+
+再检查：
+
+```bash
+brew --version
+```
+
+能看到版本号，就可以继续。
+
+### 2.4 安装 LingTai TUI
 
 ```bash
 brew install lingtai-ai/lingtai/lingtai-tui
-mkdir my-project && cd my-project
+```
+
+安装完成后，检查命令是否存在：
+
+```bash
+which lingtai-tui
+```
+
+能看到类似下面的路径即可：
+
+```text
+/opt/homebrew/bin/lingtai-tui
+```
+
+然后启动：
+
+```bash
 lingtai-tui
 ```
 
-说明：
+### 2.5 以后怎么升级？
 
-- `brew` 是 macOS 常用软件安装工具；
-- `mkdir my-project && cd my-project` 是新建并进入一个项目文件夹；
-- `lingtai-tui` 会打开终端里的灵台界面；
-- Windows / Linux / 中国大陆网络环境的具体路径可能随版本变化，请以 README 的安装详解为准；
-- 不要把裸 `pip install lingtai` 当作普通用户的标准升级路径。TUI 会管理自己的 Python 运行时；pip 更适合开发、诊断或特殊验证场景。
-
-### 第二步：完成 `/setup`
-
-第一次进入后，按向导完成模型、项目、配方等基础设置。你可以先选最简单的默认路径，不要一开始就追求复杂配置。
-
-### 第三步：说清楚第一个任务
-
-可以这样开头：
-
-> 帮我整理这个项目。请先读 README 和 docs 文件夹，不要修改文件；先告诉我项目是做什么的、有哪些重要文件、下一步建议做什么。
-
-一个好任务通常包含五件事：
-
-1. **目标**：你想要什么结果；
-2. **范围**：看哪些文件/网页，不看哪些；
-3. **形式**：要 Markdown、HTML、表格、清单还是代码；
-4. **安全边界**：不要发消息、不要删文件、不要泄露 token；
-5. **回报方式**：完成后在哪里告诉你、附什么路径或摘要。
-
-## 3. 灵台会做什么？
-
-| 能力 | 初学者理解 | 常见用途 |
-|---|---|---|
-| 文件 | 读、写、改项目里的文本文件 | 整理 README、生成报告、修改配置 |
-| Bash | 在电脑终端执行命令 | 跑测试、查 git 状态、批量处理文件 |
-| Web | 搜索或读取网页 | 查最新文档、资料调研 |
-| Vision | 看图、OCR、理解图片 | 读截图、图表、海报草稿 |
-| Skills | 可复用的做事方法 | 把一套流程沉淀成手册 |
-| Knowledge | 私有长期知识 | 记项目事实、路径、决策 |
-| Pad | 当前便签 | 记正在做什么、下一步是什么 |
-| MCP / Addons | 外接工具 | Telegram、微信、飞书、IMAP 等 |
-| Daemon / 分神 | 临时并行小助手 | 多路查资料、交叉校对、批量扫描 |
-| Avatar / 分身 | 长期专门助手 | 固定负责一个领域或岗位 |
-
-不是每个项目一开始都有所有能力。外接渠道、模型、工具是否可用，取决于你的安装与配置。
-
-## 4. 灵台怎样“记住事情”？
-
-可以把记忆分成几层：
-
-| 层 | 像什么 | 适合放什么 |
-|---|---|---|
-| 对话 | 当前聊天桌面 | 临时讨论、正在推理的过程 |
-| Pad / 当前便签 | 桌面便签 | 当前任务、下一步、重要提醒 |
-| Knowledge / 项目知识 | 项目档案柜 | 项目背景、路径、决策、长期事实 |
-| Skills / 做事方法 | 操作手册 | 可重复使用的流程、检查清单、脚本 |
-| Character / 长期规则 | 助手性格和原则 | 沟通习惯、安全规则、长期偏好 |
-| Molt / 凝蜕 | 收拾书包换新桌面 | 对话太长时，把重点整理给下一轮自己 |
-
-给初学者的实用说法：
-
-> 这件事以后还会用，请记到长期知识里。
->
-> 当前任务的下一步请写到便签里。
->
-> 这套流程以后可能重复，请整理成 skill。
->
-> 现在上下文快满了，请先总结已完成、未完成、关键路径、坑点和下一步，再凝蜕继续。
-
-## 5. 怎样触发分神 / 分身？
-
-### 分神（daemon）：临时小帮手
-
-分神像临时请几个同学分头干活。它适合：
-
-- 资料很多，需要并行阅读；
-- 需要交叉校对，一人看事实、一人看表达、一人看格式；
-- 只需要结论，不需要这个小助手长期存在。
-
-你可以直接对主助手说：
-
-> 这个资料很多，请派 3 个分神：一个查来源是否准确，一个检查初中生能不能看懂，一个检查 HTML/动画展示效果。最后把结论汇总给我。
-
-### 分身（avatar）：长期专门同事
-
-分身像培养一个长期岗位。它适合：
-
-- 一个项目会持续很久；
-- 某个领域需要长期记忆和固定风格；
-- 你希望以后固定找同一个“专家助手”。
-
-你可以说：
-
-> 这个营养科普项目会长期做，请创建一个专门负责证据核验的分身，以后固定让它检查引用和安全边界。
-
-### 什么时候不要乱开？
-
-- 很小的事不用分神，直接让主助手做；
-- 分身适合长期岗位，不适合一次性小任务；
-- 真实发消息、删文件、提交 issue、开 PR、推代码等外部动作，要先确认；
-- 分神/分身越多，越要把任务说清楚，否则会并行制造混乱。
-
-## 6. 上下文“爆炸”了怎么办？
-
-上下文可以理解成 AI 这一轮能摊在桌面上的纸。任务越长，纸越多；快放不下时，就要“收桌面”。灵台的办法叫**凝蜕 / molt**：先把重点打包，再换一张干净桌子继续。
-
-常见信号：
-
-- 对话非常长；
-- 系统提示 context/molt；
-- 助手开始反复找不到前文；
-- 一个任务做了很多轮，还没整理阶段成果。
-
-正确做法：
-
-> 先收功：把当前任务目标、已完成内容、未完成内容、关键文件路径、重要结论、踩坑点、下一步计划整理好；该写入长期知识/当前便签的写好；然后再凝蜕继续。
-
-不要这样做：
-
-- 快满时继续塞大量新任务；
-- 什么都不总结就刷新；
-- 把凝蜕当成失败。它更像正常整理书包。
-
-## 7. 常见 `/` 指令小抄
-
-不同版本的命令可能增减，以下是常见入口。最终以 TUI 实际显示和最新 README 为准。
-
-| 指令 | 做什么 |
-|---|---|
-| `/setup` | 第一次设置或重新检查项目、模型、渠道等基础配置 |
-| `/kanban` | 看当前 agent、任务和状态，像项目看板 |
-| `/mcp` | 配置微信、Telegram、飞书、邮箱等外接工具 |
-| `/skills` | 查看/管理做事方法手册 |
-| `/viz` | 打开可视化网络，看 agent 关系和历史 |
-| `/insights` | 查看系统整理出的洞察或运行观察 |
-| `/sleep` | 让 agent 休息；它仍可被消息唤醒 |
-| `/refresh` | 刷新当前 agent 的身体/配置，适合改配置后重载 |
-| `/doctor` | 体检：排查启动、配置、工具、日志问题 |
-| `/cpr` | 复苏卡住或假死的 agent；先诊断再复苏 |
-| `/clear` | 强制重置某个 agent，影响较大，谨慎用 |
-| `/projects` | 切换或查看项目网络 |
-
-## 8. 心流是什么？
-
-心流可以理解成**AI 在空闲时的自我复盘**。它会回看最近做过的事，提醒自己：
-
-- 有没有漏回消息；
-- 有没有该写入知识/skill 的经验；
-- 当前任务是否需要收束；
-- 有没有安全边界或证据风险；
-- 下一步是不是应该先查证，而不是继续猜。
-
-注意边界：
-
-- 心流不是人发来的消息；
-- 心流不是必须照做的命令；
-- 心流中的外部事实仍要通过对应渠道核实，比如微信、Telegram、文件、网页；
-- 它更像“内心提醒”，帮助 agent 少漏事、少跑偏。
-
-## 9. 安全、隐私与排障
-
-### 密钥不要外泄
-
-API Key、token、密码可以理解成“软件钥匙”。不要把它们写进公开报告、issue、截图、聊天记录或 PR。需要配置时，放到受保护配置或 `.secrets/` 之类的位置，并在报告中只说“已配置/已验证”，不要复述原文。
-
-### 外部动作要确认
-
-发消息、提 issue、开 PR、删文件、推代码、发邮件都是真实动作。除非你明确授权，否则不要让助手自动发布、删除或联系外部对象。
-
-### 专业内容要复核
-
-医学、营养、法律、金融等内容，AI 可以辅助整理，但最后要人类专家审核。不要把 AI 输出当成诊断、处方、法律意见或投资建议。
-
-### 常见问题
-
-| 问题 | 先做什么 |
-|---|---|
-| 打不开 / 命令找不到 | 检查 Homebrew 的 bin 是否在 PATH，或按 README 安装详解重装 |
-| 助手不回应 | 先等一会儿；它可能在跑长工具或整理记忆。再看 `/kanban`、`/doctor` |
-| 升级后没变化 | 重启 TUI；运行 `/doctor` 或 `lingtai-tui doctor` |
-| 外接渠道失效 | 检查 `/mcp`、配置和当前 preset 能力 |
-| 技能/命令像是丢了 | 试 `lingtai-tui bootstrap` 或 `/doctor`，并检查当前 preset |
-| 上下文太长 | 先要求“收功总结”，再凝蜕继续 |
-
-## 10. 一张小抄：怎样把任务说清楚
-
-可以按这个模板发任务：
-
-```text
-目标：帮我整理这周的会议记录。
-范围：只看 meeting-notes 文件夹，不要改原文。
-形式：输出 5 条重点、3 个待办事项、1 个风险提醒。
-安全：不要发给别人，不要泄露 token 或密码。
-回报：完成后在原渠道告诉我摘要和文件路径。
-长期记忆：如果发现以后会重复用的流程，请建议是否写成 skill。
+```bash
+brew update
+brew upgrade lingtai-ai/lingtai/lingtai-tui
 ```
 
-更复杂的任务可以再加：
+升级后要**重启 TUI**。如果你只是升级了却没重启，看起来可能还是旧行为。
 
-```text
-请派 3 个分神交叉检查：
-1. 一个查事实是否准确；
-2. 一个看初中生是否能懂；
-3. 一个检查格式和链接。
-最后由主助手合并成一个版本。
+---
+
+## 3. 中国大陆网络下的安装办法
+
+大陆网络最常见的问题不是 LingTai 本身，而是 Homebrew 拉 GitHub、Go、npm 资源时卡住。按下面顺序试，不要一上来乱改很多变量。
+
+### 3.1 第一选择：先直接装
+
+先试最简单命令：
+
+```bash
+brew install lingtai-ai/lingtai/lingtai-tui
 ```
 
-## 11. 本文边界
+如果能装，就不要再改镜像。
 
-- 本手册是入门解释，不替代最新 README、TUI 内置帮助和开发文档；
-- 命令、安装路径、外接渠道支持范围会随版本变化；
-- 若你在真实项目中使用，请优先让灵台读取当前项目 README、配置和 `/doctor` 结果，而不是只凭这份手册判断。
+### 3.2 如果 Homebrew 更新很慢：先用清华 TUNA 加速 Homebrew 本身
 
-## 来源
+如果卡在 `brew update`、`homebrew-core`、`ghcr.io`，可执行：
 
-- [`README.zh.md`](../README.zh.md)
-- [`Lingtai-AI/lingtai#198`](https://github.com/Lingtai-AI/lingtai/issues/198)
-- 当前 repo 文档与 TUI 常见命令说明
+```bash
+cat >> ~/.zprofile <<'EOF'
+export HOMEBREW_API_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles/api"
+export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles"
+export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/brew.git"
+EOF
+source ~/.zprofile
+brew update
+```
+
+然后再装：
+
+```bash
+brew install lingtai-ai/lingtai/lingtai-tui
+```
+
+### 3.3 如果卡在 GitHub tap：改用 Gitee 镜像 tap
+
+如果报 TLS、GnuTLS、GitHub 拉取失败，可用：
+
+```bash
+brew untap lingtai-ai/lingtai 2>/dev/null || true
+brew tap lingtai-ai/lingtai https://gitee.com/huangzesen1997/homebrew-lingtai.git
+brew install lingtai-ai/lingtai/lingtai-tui
+```
+
+注意：Gitee 是镜像，可能比 GitHub 慢几个小时。如果版本落后，过一会儿再试，或改回 GitHub tap。
+
+### 3.4 如果 Go / npm 编译阶段出问题
+
+默认公式会自动判断是否切换镜像。只有在自动判断不灵时，才手动指定：
+
+```bash
+HOMEBREW_GOPROXY="https://goproxy.cn,direct" \
+HOMEBREW_NPM_CONFIG_REGISTRY="https://registry.npmmirror.com" \
+  brew install lingtai-ai/lingtai/lingtai-tui
+```
+
+如果 npm 镜像证书报错，反而应清掉 npm 镜像：
+
+```bash
+unset HOMEBREW_NPM_CONFIG_REGISTRY
+brew install lingtai-ai/lingtai/lingtai-tui
+```
+
+### 3.5 如果仍然失败
+
+先运行：
+
+```bash
+brew doctor
+brew update
+```
+
+再把报错保存下来。常用信息：
+
+```bash
+brew --version
+brew config
+brew info lingtai-ai/lingtai/lingtai-tui
+```
+
+---
+
+## 4. Linux / Windows 怎么装？
+
+### 4.1 Linux
+
+Linux 也可以用 Homebrew for Linux：
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install lingtai-ai/lingtai/lingtai-tui
+lingtai-tui
+```
+
+如果系统提示缺少编译工具，Ubuntu/Debian 可先装：
+
+```bash
+sudo apt update
+sudo apt install -y build-essential curl git
+```
+
+### 4.2 Windows
+
+Windows 原生终端环境差异很大。推荐路线：
+
+1. 安装 WSL2；
+2. 安装 Ubuntu；
+3. 进入 Ubuntu 终端；
+4. 按 Linux 路线安装。
+
+不建议小白一开始在 Windows 原生 PowerShell 里折腾源码编译。
+
+### 4.3 从源码安装（进阶）
+
+Homebrew 不可用时可从源码装：
+
+```bash
+git clone https://github.com/Lingtai-AI/lingtai.git
+cd lingtai
+./install.sh
+lingtai-tui
+```
+
+源码安装更容易遇到 Go / Node / npm 环境问题。小白优先用 Homebrew。
+
+---
+
+## 5. 第一次启动：按这个顺序走
+
+启动：
+
+```bash
+lingtai-tui
+```
+
+第一次进来，不要急着开很多功能。按顺序做：
+
+### 5.1 创建或选择项目
+
+灵台围绕“项目目录”工作。建议：
+
+- 一个研究/代码/写作主题建一个项目；
+- 不要把所有事都塞进一个项目；
+- 项目目录最好放在你能找到的位置，比如 `~/work/my-lingtai-project`。
+
+### 5.2 跑 `/setup`
+
+TUI 里按提示或输入：
+
+```text
+/setup
+```
+
+你通常会设置：
+
+- 使用什么模型 / preset；
+- agent 的名字；
+- 是否加载某个 recipe；
+- 是否配置外部渠道或密钥。
+
+小白建议：先选默认或 Tutorial 类配置，跑通再改。
+
+### 5.3 给第一个任务
+
+不要一上来问“你能做什么”。直接给一个小任务，例如：
+
+```text
+请在当前项目里创建一个 notes.md，写三条今天要做的事。
+```
+
+或：
+
+```text
+帮我读一下 README.md，告诉我这个项目怎么启动。
+```
+
+这样你会立刻看到它如何读文件、写文件、汇报结果。
+
+### 5.4 看状态
+
+常用：
+
+```text
+/kanban
+```
+
+你可以看到 agent 是否在忙、是否卡住、token / 状态等。
+
+---
+
+## 6. 日常工作时，应该怎么和灵台说话？
+
+### 6.1 最好这样说
+
+```text
+我要做一个申请书。材料在 docs/apply/ 里。请先读模板，再整理我的开源贡献，最后输出一版 Markdown 和 Word 版本。不要提交，先给我审核。
+```
+
+这句话里有五个关键信息：
+
+1. 目标：申请书；
+2. 材料位置：`docs/apply/`；
+3. 步骤：先读模板，再整理，再输出；
+4. 格式：Markdown 和 Word；
+5. 红线：不要提交，先审核。
+
+### 6.2 不建议这样说
+
+```text
+帮我弄一下。
+```
+
+agent 不知道你要弄什么、做到什么程度、能不能改文件、能不能发出去。
+
+### 6.3 一句好用模板
+
+```text
+目标：……
+材料：……
+输出：……
+不要做：……
+如果不确定，先问我。
+```
+
+---
+
+## 7. 什么时候用主 agent、daemon、avatar？
+
+### 7.1 主 agent：负责判断和对话
+
+适合：
+
+- 和你确认目标；
+- 做最终判断；
+- 汇总多个结果；
+- 写给人看的最终回复；
+- 涉及发布、删除、医学/法律/学术强结论等高风险事项。
+
+### 7.2 daemon：临时分神，适合脏活累活
+
+适合：
+
+- 扫很多文件；
+- 查一批资料；
+- 跑测试；
+- 对一个方案做严厉审稿；
+- 让它写报告给主 agent 审。
+
+一句话：**daemon 做一次性任务，做完就退；主 agent 负责验收。**
+
+### 7.3 avatar：长期分身，适合长期专项
+
+适合：
+
+- 一个长期营养学助手；
+- 一个专门维护某仓库的工程 agent；
+- 一个长期跟进某论文方向的研究 agent。
+
+不要为了一个小问题就开 avatar；小任务优先 daemon。
+
+---
+
+## 8. 文件、技能、知识：三种常用“记住”方式
+
+### 8.1 文件
+
+文件是普通项目材料，适合给人看、提交、版本管理。
+
+例：`README.md`、`申请书.docx`、`实验报告.html`。
+
+### 8.2 Knowledge
+
+Knowledge 是某个 agent 的长期私有记忆，适合放项目事实、路径、决策、历史。
+
+例：“这个项目的正式仓库在哪”“某论文曾被谁否决”“某数据不能公开”。
+
+### 8.3 Skills
+
+Skills 是可复用流程，适合沉淀方法。
+
+例：“学术写作防幻觉流程”“三日饮食记录分析流程”“发布前检查清单”。
+
+一句话：
+
+```text
+一次性交付 → 文件
+长期事实 → knowledge
+以后还会复用的方法 → skill
+```
+
+---
+
+## 9. 上下文满了怎么办？
+
+agent 的对话上下文不是无限的。长任务做久后，它需要整理现场。
+
+常见处理：
+
+- 让 agent 把大段工具结果整理成摘要，避免对话里塞满原始日志；
+- 让 agent 做一次“凝蜕”：保存关键状态，再换一个干净上下文继续；
+- 让 agent 把当前任务状态写进内部任务索引；
+- 重要的长期事实，放进 knowledge；
+- 以后还会复用的方法，写成 skill。
+
+这里的“摘要、凝蜕、任务索引”不一定都是你直接输入的命令；你只要用自然语言说“请先收束现场再继续”，agent 会按当前能力处理。
+
+你可以这样说：
+
+```text
+请先收束现场：列出已完成、未完成、关键文件、下一步，然后再继续。
+```
+
+不要害怕凝蜕。好的凝蜕不是失忆，而是“把桌面收拾干净再继续”。
+
+---
+
+## 10. 外部渠道：Telegram / 微信 / 飞书 / 邮箱
+
+灵台可以接外部消息，但不是一开始必须配置。
+
+适合配置外部渠道的情况：
+
+- 你想在手机上给 agent 发消息；
+- 你希望任务完成后它主动通知你；
+- 你不想一直开着 TUI 等回复。
+
+在 TUI 里看：
+
+```text
+/mcp
+```
+
+注意：`/mcp` 主要用来查看连接状态。具体配置要按对应插件说明走，不要把 token 发到公开地方。
+
+---
+
+## 11. 常用 slash 命令小抄
+
+| 命令 | 什么时候用 |
+|---|---|
+| `/setup` | 第一次配置模型、recipe、行为 |
+| `/help` | 查看命令说明 |
+| `/kanban` | 看 agent 是否忙、卡住、休眠 |
+| `/goal` | 设置当前目标，防止任务跑偏 |
+| `/viz` | 看 agent / avatar 网络图 |
+| `/mcp` | 看外部渠道和 MCP 状态 |
+| `/doctor` | 启动、升级、工具异常时排查 |
+| `/clear` | 对话太乱，清理上下文 |
+| `/sleep` | 当前项目暂时不用，让 agent 睡眠待命 |
+| `/suspend all` | 你要离开很久，暂停所有 agent |
+| `/projects` | 切换或查看项目 |
+| `/export` | 导出成果或项目材料 |
+
+不需要一开始全记住。先记：`/setup`、`/kanban`、`/doctor`、`/help`。
+
+---
+
+## 12. 常见问题排查
+
+### 12.1 `lingtai-tui: command not found`
+
+先查 Homebrew 位置：
+
+```bash
+brew --prefix
+```
+
+Apple Silicon 常见路径：`/opt/homebrew`。执行：
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+Intel Mac 常见路径：`/usr/local`。执行：
+
+```bash
+eval "$(/usr/local/bin/brew shellenv)"
+```
+
+再试：
+
+```bash
+which lingtai-tui
+lingtai-tui
+```
+
+### 12.2 TUI 打开了，但 agent 不回复
+
+先跑：
+
+```bash
+lingtai-tui doctor
+```
+
+在 TUI 里也可以用：
+
+```text
+/doctor
+/kanban
+```
+
+如果仍不行，看日志：
+
+```bash
+find .lingtai -name agent.log -maxdepth 3 -print
+```
+
+### 12.3 升级后好像没变化
+
+记住两层：
+
+- Homebrew 升级的是 `lingtai-tui`；
+- TUI 还会管理 Python runtime。
+
+做：
+
+```bash
+brew update
+brew upgrade lingtai-ai/lingtai/lingtai-tui
+lingtai-tui doctor
+```
+
+然后重启 TUI。
+
+### 12.4 技能、命令或工具不见了
+
+先用：
+
+```text
+/doctor
+```
+
+或命令行：
+
+```bash
+lingtai-tui doctor
+```
+
+### 12.5 不要这样修
+
+不要一看到问题就执行：
+
+```bash
+pip install -U lingtai
+```
+
+这通常不会修好 TUI 项目里的 runtime，反而容易让你误以为已经升级。
+
+---
+
+## 13. 一个最小可行工作流
+
+第一次真正用，可以照这个流程：
+
+1. 安装并启动 `lingtai-tui`；
+2. `/setup` 选一个基础配置；
+3. 建一个测试项目；
+4. 让 agent 创建 `notes.md`；
+5. 让 agent 读 `notes.md` 并改一版；
+6. 用 `/kanban` 看状态；
+7. 用 `/doctor` 确认环境健康；
+8. 再开始真正项目。
+
+示例任务：
+
+```text
+请在当前项目创建 notes.md，写下“今日目标、已有材料、下一步”。写完后告诉我文件路径。
+```
+
+如果这一步能成功，你已经跑通了最核心的能力。
+
+---
+
+## 14. 新手最容易踩的坑
+
+1. **把 LingTai 当普通网页聊天机器人。** 它其实是本地项目工作台。
+2. **把所有任务塞进一个项目。** 一个项目一个主题更稳。
+3. **不给材料路径。** agent 找不到材料就会猜。
+4. **不说红线。** 是否能发布、删除、提交 PR，一定要说清楚。
+5. **裸 `pip install lingtai`。** 普通用户不要这样装。
+6. **长任务不让它收束。** 做久了要让它写“已完成/未完成/下一步”。
+7. **外部渠道 token 乱发。** 密钥只放配置，不要贴到公开 issue 或 README。
+
+---
+
+## 15. 这份手册的边界
+
+这份文档只解决“新手如何安装、启动、理解基本工作流”。
+
+更深入的内容请看：
+
+- README：完整安装、架构、排障；
+- `/help`：TUI 命令；
+- `/doctor`：本机环境检查；
+- `ANATOMY.md`：贡献者读源码；
+- 对应 MCP / skill 文档：外部渠道与可复用技能。


### PR DESCRIPTION
## Summary
- Rewrite the Chinese beginner work manual around the current LingTai workflow: install paths, first project setup, agent / daemon / avatar boundaries, memory layers, MCP channels, and troubleshooting.
- Replace the old illustrated HTML with a self-contained single-file version that does not depend on external scripts, CDNs, links, iframes, or imports.
- Update README links to point to the standalone illustrated guide.

## Validation
- `git diff --check`
- Parsed `docs/beginner-work-manual-stick-figure.zh.html` with Python `HTMLParser`
- Grep check for stale wording / external dependency residues: `issue #198`, `初中生`, `火柴人`, `<script src=`, `<link`, `iframe`, `@import`

Docs-only change; no runtime behavior changed.
