### PR TITLE
feat(tui): live agent activity indicator on the mail view footer

### DIFF
--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -145,6 +145,7 @@ type MailModel struct {
 	wasActive         bool             // true if previous refresh was ACTIVE
 	quoteIdx          int              // which quote to show (advances on each ACTIVE transition)
 	pulseTick         int              // pulse animation counter while ACTIVE
+	activeSince       time.Time        // when the agent last entered ACTIVE (zero when not active)
 	inquiryState      string           // "", "sent", "taken" — tracks /btw lifecycle
 	insightPending    bool             // true when waiting for 5s insight delay
 	insightAt         time.Time        // when to fire the auto-insight
@@ -654,10 +655,14 @@ func (m MailModel) Update(msg tea.Msg) (MailModel, tea.Cmd) {
 		isActive := strings.EqualFold(m.orchState, "ACTIVE")
 		isIdle := strings.EqualFold(m.orchState, "IDLE")
 		if isActive && !m.wasActive {
-			// Just became active — advance to next quote, reset pulse
+			// Just became active — advance to next quote, reset pulse, start timer
 			m.quoteIdx++
 			m.pulseTick = 0
 			m.insightPending = false
+			m.activeSince = time.Now()
+		} else if !isActive {
+			// Not active — stop the elapsed timer so the badge drops it
+			m.activeSince = time.Time{}
 		}
 		insightDone := fileExists(filepath.Join(m.baseDir, ".tui-asset", ".insight.done"))
 		if isIdle && m.wasActive && !m.insightPending && !insightDone && m.insightsEnabled {
@@ -1207,6 +1212,38 @@ func (m MailModel) humanName() string {
 	return i18n.T("mail.you")
 }
 
+// stateGlyph returns the leading glyph for the agent-state badge. ACTIVE uses
+// the rotating spinner frame so the badge visibly animates in normal mode;
+// every other state gets a distinct static glyph (color carries the rest of
+// the distinction via StateColor).
+func (m MailModel) stateGlyph() string {
+	switch strings.ToUpper(m.orchState) {
+	case "ACTIVE":
+		return spinnerFrames[m.pulseTick%len(spinnerFrames)]
+	case "ASLEEP":
+		return "◌"
+	case "SUSPENDED":
+		return "○"
+	case "REFRESHING":
+		return "⟳"
+	default: // IDLE, STUCK, unknown
+		return "◉"
+	}
+}
+
+// activeElapsed returns a short " 12s" / " 3m" suffix while the agent is ACTIVE,
+// or "" otherwise — the "how long has it been working" signal.
+func (m MailModel) activeElapsed() string {
+	if !strings.EqualFold(m.orchState, "ACTIVE") || m.activeSince.IsZero() {
+		return ""
+	}
+	d := time.Since(m.activeSince)
+	if d < time.Minute {
+		return fmt.Sprintf(" %ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf(" %dm", int(d.Minutes()))
+}
+
 func (m MailModel) networkActivityBadge() string {
 	if m.networkActivity.Status == "" {
 		return ""
@@ -1303,7 +1340,11 @@ func (m MailModel) View() string {
 	stateLabel := i18n.T("state." + stateKey)
 	stateStyle := lipgloss.NewStyle().Foreground(StateColor(strings.ToUpper(stateKey)))
 	orchNameStyle := lipgloss.NewStyle().Foreground(ColorText).Bold(true)
-	titleRightBase := orchNameStyle.Render(m.orchDisplayName()) + " " + stateStyle.Render("◉ "+stateLabel)
+	// Activity indicator: an animated glyph per state (spinner while ACTIVE) plus
+	// a live elapsed timer. This makes normal mode show that the agent is alive
+	// and working without needing Ctrl+O. It lives in the always-visible header
+	// and is independent of the verbose level.
+	titleRightBase := orchNameStyle.Render(m.orchDisplayName()) + " " + stateStyle.Render(m.stateGlyph()+" "+stateLabel+m.activeElapsed())
 
 	// Thinking indicator: fixed quote per ACTIVE session, pulsing color + spinners
 	titleCenter := ""

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -1340,11 +1340,7 @@ func (m MailModel) View() string {
 	stateLabel := i18n.T("state." + stateKey)
 	stateStyle := lipgloss.NewStyle().Foreground(StateColor(strings.ToUpper(stateKey)))
 	orchNameStyle := lipgloss.NewStyle().Foreground(ColorText).Bold(true)
-	// Activity indicator: an animated glyph per state (spinner while ACTIVE) plus
-	// a live elapsed timer. This makes normal mode show that the agent is alive
-	// and working without needing Ctrl+O. It lives in the always-visible header
-	// and is independent of the verbose level.
-	titleRightBase := orchNameStyle.Render(m.orchDisplayName()) + " " + stateStyle.Render(m.stateGlyph()+" "+stateLabel+m.activeElapsed())
+	titleRightBase := orchNameStyle.Render(m.orchDisplayName()) + " " + stateStyle.Render("◉ "+stateLabel)
 
 	// Thinking indicator: fixed quote per ACTIVE session, pulsing color + spinners
 	titleCenter := ""
@@ -1393,8 +1389,13 @@ func (m MailModel) View() string {
 	}
 	header := titleLine + "\n" + strings.Repeat("\u2500", m.width)
 
-	// Build footer — "Email To: AgentName ─────────"
-	toLabel := StyleFaint.Render("Email To: ") + lipgloss.NewStyle().Foreground(ColorAgent).Render(m.orchDisplayName()) + " "
+	// Build footer — "Email To: AgentName  ◉ <state> <elapsed> ─────────"
+	// The activity indicator lives here, in the interaction line, so the human
+	// sees the agent's live state (animated spinner + elapsed while ACTIVE) right
+	// where their attention already is. Reuses the header's stateStyle/stateLabel
+	// and is independent of the verbose level.
+	indicator := stateStyle.Render(m.stateGlyph() + " " + stateLabel + m.activeElapsed())
+	toLabel := StyleFaint.Render("Email To: ") + lipgloss.NewStyle().Foreground(ColorAgent).Render(m.orchDisplayName()) + "  " + indicator + " "
 	sepWidth := m.width - lipgloss.Width(toLabel)
 	if sepWidth < 0 {
 		sepWidth = 0

--- a/tui/internal/tui/mail_activity_footer_test.go
+++ b/tui/internal/tui/mail_activity_footer_test.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/anthropics/lingtai-tui/i18n"
+)
+
+// emailToLine returns the ANSI-stripped "Email To:" footer line from a full
+// View(), or "" if absent. The activity indicator lives on this line, so tests
+// isolate it from the header (which has its own separate state badge / center
+// spinner). Stripping ANSI keeps assertions free of color-code digits.
+func emailToLine(view string) string {
+	for _, line := range strings.Split(ansi.Strip(view), "\n") {
+		if strings.Contains(line, "Email To:") {
+			return line
+		}
+	}
+	return ""
+}
+
+// TestFooterShowsActivityIndicatorWhenActive verifies the live indicator is
+// rendered on the "Email To:" interaction line — the ACTIVE spinner glyph and
+// the localized state label — so the human sees agent activity where their
+// attention already is, without entering verbose mode.
+func TestFooterShowsActivityIndicatorWhenActive(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMailModel(dir, "human", dir, dir, "orch", 20, dir, "en", false, 0)
+	m = sizeMail(t, m)
+
+	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true})
+
+	footer := emailToLine(m.View())
+	if footer == "" {
+		t.Fatal("no Email To: footer line in view")
+	}
+	if !strings.Contains(footer, spinnerFrames[0]) {
+		t.Errorf("Email To: line should carry the ACTIVE spinner glyph %q; got %q", spinnerFrames[0], footer)
+	}
+	if label := i18n.T("state.active"); !strings.Contains(footer, label) {
+		t.Errorf("Email To: line should carry the state label %q; got %q", label, footer)
+	}
+}
+
+// TestFooterIndicatorIdleHasNoTimer verifies that when the agent is IDLE the
+// footer shows the static glyph + label but no elapsed timer (no digits).
+func TestFooterIndicatorIdleHasNoTimer(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMailModel(dir, "human", dir, dir, "orch", 20, dir, "en", false, 0)
+	m = sizeMail(t, m)
+
+	m, _ = m.Update(mailRefreshMsg{state: "idle", alive: true})
+
+	footer := emailToLine(m.View())
+	if footer == "" {
+		t.Fatal("no Email To: footer line in view")
+	}
+	if !strings.Contains(footer, "◉") {
+		t.Errorf("idle Email To: line should carry the static ◉ glyph; got %q", footer)
+	}
+	// The idle label ("idle") and agent name ("orch") have no digits, so any
+	// digit on the ANSI-stripped line would signal a stray elapsed timer.
+	if strings.ContainsAny(footer, "0123456789") {
+		t.Errorf("idle Email To: line should not contain an elapsed timer; got %q", footer)
+	}
+}

--- a/tui/internal/tui/mail_activity_indicator_test.go
+++ b/tui/internal/tui/mail_activity_indicator_test.go
@@ -1,0 +1,99 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestStateGlyph verifies each agent state maps to its expected badge glyph,
+// case-insensitively. ACTIVE uses the animated spinner frame; the rest are
+// distinct static glyphs (with color carrying IDLE vs STUCK).
+func TestStateGlyph(t *testing.T) {
+	cases := []struct {
+		state string
+		want  string
+	}{
+		{"ACTIVE", spinnerFrames[0]},
+		{"active", spinnerFrames[0]}, // case-insensitive
+		{"IDLE", "◉"},
+		{"idle", "◉"},
+		{"STUCK", "◉"}, // color (ColorStuck) carries the distinction
+		{"ASLEEP", "◌"},
+		{"SUSPENDED", "○"},
+		{"REFRESHING", "⟳"},
+		{"refreshing", "⟳"},
+		{"", "◉"},
+		{"bogus", "◉"},
+	}
+	for _, c := range cases {
+		m := MailModel{orchState: c.state, pulseTick: 0}
+		if got := m.stateGlyph(); got != c.want {
+			t.Errorf("stateGlyph(%q) = %q, want %q", c.state, got, c.want)
+		}
+	}
+}
+
+// TestStateGlyphActiveAnimates verifies the ACTIVE spinner advances with
+// pulseTick (modulo the frame count) so the badge visibly animates.
+func TestStateGlyphActiveAnimates(t *testing.T) {
+	for i := 0; i < len(spinnerFrames)*2+1; i++ {
+		m := MailModel{orchState: "ACTIVE", pulseTick: i}
+		want := spinnerFrames[i%len(spinnerFrames)]
+		if got := m.stateGlyph(); got != want {
+			t.Errorf("pulseTick=%d: stateGlyph() = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestActiveElapsed verifies the elapsed suffix renders only while ACTIVE with
+// a non-zero start time, formatted as seconds under a minute and minutes above.
+// Offsets are mid-interval to avoid second/minute boundary flake.
+func TestActiveElapsed(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name  string
+		state string
+		since time.Time
+		want  string
+	}{
+		{"not active drops timer", "idle", now.Add(-30 * time.Second), ""},
+		{"active but zero start", "active", time.Time{}, ""},
+		{"active seconds", "active", now.Add(-12500 * time.Millisecond), " 12s"},
+		{"active minutes", "active", now.Add(-210 * time.Second), " 3m"},
+	}
+	for _, c := range cases {
+		m := MailModel{orchState: c.state, activeSince: c.since}
+		if got := m.activeElapsed(); got != c.want {
+			t.Errorf("%s: activeElapsed() = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestActiveSinceLifecycle verifies the activeSince timestamp is set on entry to
+// ACTIVE, preserved while staying ACTIVE, and cleared on any non-ACTIVE refresh
+// (including the synthesized suspended/refreshing states, which arrive as
+// non-ACTIVE through the same mailRefreshMsg path).
+func TestActiveSinceLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMailModel(dir, "human", dir, dir, "orch", 20, dir, "en", false, 0)
+	m = sizeMail(t, m)
+
+	// Enter ACTIVE → timer starts.
+	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true})
+	if m.activeSince.IsZero() {
+		t.Fatal("activeSince should be set on entering ACTIVE")
+	}
+	first := m.activeSince
+
+	// Stay ACTIVE → timestamp preserved (not reset each refresh).
+	m, _ = m.Update(mailRefreshMsg{state: "active", alive: true})
+	if !m.activeSince.Equal(first) {
+		t.Errorf("activeSince should be preserved while staying ACTIVE; was %v, now %v", first, m.activeSince)
+	}
+
+	// Leave ACTIVE → timer cleared so the badge drops the elapsed suffix.
+	m, _ = m.Update(mailRefreshMsg{state: "idle", alive: true})
+	if !m.activeSince.IsZero() {
+		t.Error("activeSince should be cleared when leaving ACTIVE")
+	}
+}


### PR DESCRIPTION
## Problem

In the mail view's **normal mode** (verbose off), there is no sign the agent is working between sends. Reasoning/diary/tool entries are gated behind `Ctrl+O`, so while the agent thinks the screen looks frozen — a common "is it broken?" moment, especially for first-time users.

## What this does

Adds a **live, state-aware activity indicator** on the `Email To: <agent>` footer line — directly above the input box, where attention already is during a conversation. It is independent of the verbose level, so it shows in normal mode without `Ctrl+O`.

Two commits, kept separate on purpose:

1. **add live agent activity indicator** — introduces the indicator (state glyph + elapsed timer + `activeSince` lifecycle + `stateGlyph`/`activeElapsed` helpers), initially rendered in the header state badge.
2. **move the indicator to the `Email To:` footer line** — relocates it to the interaction line and reverts the header badge to its original static form.

## Behavior

On the `Email To:` line, after the agent name:

| State | Glyph | Timer |
|---|---|---|
| ACTIVE | rotating spinner (`✶✸✹✺`, 250ms) | live `12s` / `3m` |
| IDLE | `◉` | — |
| STUCK | `◉` (stuck color) | — |
| ASLEEP | `◌` | — |
| SUSPENDED | `○` | — |
| REFRESHING | `⟳` | — |

Color follows the existing `StateColor`. The footer reuses the header's already-computed `stateStyle`/`stateLabel`; the elapsed suffix widens the line as it ticks, but the separator width is clamped at zero so layout never breaks.

## Testing

- New unit tests: `stateGlyph` mapping (case-insensitive, all states), spinner animation across `pulseTick`, `activeElapsed` formatting/guards, the `activeSince` set/preserve/clear lifecycle through `mailRefreshMsg`, and footer-render assertions (ANSI-stripped) for ACTIVE (glyph + label) and IDLE (no timer).
- `go build ./...`, `go vet ./...`, `go test ./...` all green.

## Scope / not included

- The **send → ACTIVE** gap (agent still waking on the next heartbeat) still shows the static idle badge; a "sent · waiting" cue is a separate follow-up.
- A live **reasoning-step stream** (what the agent is doing) is intentionally out of scope here — diary/`text_output` are the agent's private space, so a human-facing version belongs with the curated status-event work (#146 / #208).
- No i18n keys added (the elapsed suffix is procedural-numeric, matching existing `formatStaminaShort`); no migration; portal untouched.
