### PR TITLE
docs: clarify patch-to-self refresh workflow

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -34,6 +34,11 @@ stays short on purpose; the detailed procedures live under `reference/<topic>/`.
   TUI-created project venv; do not present bare `pip install/upgrade lingtai` as
   the standard user path. Use manual pip/venv commands only for developer,
   diagnostic, or verification contexts.
+- **Patch-to-self refresh rule:** a merged PR or rebuilt checkout is not live in
+  the agent until the runtime-imported source/package is updated, the agent is
+  refreshed, and a live in-situ probe confirms the new behaviour. For kernel
+  fixes, always identify the actual import path and git HEAD first; do not
+  assume the repo you edited is the one this agent imports.
 
 ## Nested reference catalog
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
@@ -252,7 +252,11 @@ With the TUI's runtime venv:
     -p ~/.lingtai-tui/runtime/venv
 ```
 
-Changes to the kernel source are reflected immediately in the running agent — no rebuild needed (editable install).
+Kernel source changes need no binary rebuild in editable mode, but they are live
+only in the checkout/package the agent actually imports. After a merge in another
+worktree, first identify the runtime import path and git HEAD, fast-forward or
+editable-reinstall that source if needed, then `refresh` and verify with an
+in-situ probe. See `reference/runtime-self-check/SKILL.md` for the checklist.
 
 ### Auto-upgrader gotcha
 

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -24,6 +24,48 @@ the post-refresh "which runtime am I executing?" probe. Use it after a
 MCP/addon config change — and any time a fix "should be live" but behaviour
 disagrees.
 
+## Patch-to-self checklist — merged PR ≠ live runtime
+
+When you want to test a kernel/TUI fix on the agent you are currently speaking
+through, do **all** of these steps. This is the in-situ path; skipping step 1 is
+how agents repeatedly refresh stale code and conclude the fix failed.
+
+1. **Find the runtime import path.** Use the runtime venv Python, not `python` on
+   PATH, and print `lingtai` / `lingtai_kernel` `__file__`, package metadata, and
+   the nearest git checkout.
+2. **Compare HEADs.** If the running agent imports `/B/lingtai-kernel` but your
+   PR was merged in `/A/lingtai-kernel`, update `/B` (`git fetch origin main &&
+   git pull --ff-only origin main`) or reinstall the intended checkout into the
+   runtime venv. Do not edit protected dirty checkouts; stop and report if
+   fast-forward is not clean.
+3. **Refresh only after the imported source/package is right.** `refresh`
+   reloads from the configured runtime environment; it does not fetch or
+   fast-forward a source tree for you.
+4. **Do an in-situ probe.** Verify the live behaviour or metadata changed on the
+   current agent itself — for example a tool result `_meta`, a token-ledger
+   field, or another direct observable. Source greps and import probes are
+   necessary but not sufficient.
+5. **Report evidence.** Include runtime Python, import path, old/new HEAD, action
+   taken (fast-forward/editable reinstall/rebuild), refresh result, and the live
+   probe.
+
+Minimal kernel probe:
+
+```bash
+VENV_PY="$HOME/.lingtai-tui/runtime/venv/bin/python"
+"$VENV_PY" - <<'PY'
+import inspect, importlib.metadata as md
+import lingtai_kernel
+print('python:', __import__('sys').executable)
+print('lingtai_kernel:', lingtai_kernel.__file__)
+try:
+    print('dist:', md.version('lingtai-kernel'))
+    print('direct_url:', md.distribution('lingtai-kernel').read_text('direct_url.json') or '<none>')
+except Exception as e:
+    print('dist metadata:', repr(e))
+PY
+```
+
 ## Core principle
 
 This is a **read-only diagnostic**. Probe, confirm, and report. The only write
@@ -158,6 +200,9 @@ preset/path mismatches, see `reference/debug-troubleshoot/SKILL.md`.
 
 After a `refresh`, walk this list before trusting new behaviour:
 
+- [ ] Patch-to-self: if testing a merged PR on this agent, the imported
+  source/package was updated before refresh, and an in-situ live probe confirms
+  the new behaviour.
 - [ ] §1 import probe: `lingtai.__file__` resolves where you expect (editable vs wheel).
 - [ ] §1 git HEAD of the imported checkout matches the intended commit; tree state noted.
 - [ ] §2 active binary resolves to the expected path; version string matches dev/brew expectation.


### PR DESCRIPTION
## Summary
- add a prominent `Patch-to-self refresh rule` to the LingTai dev guide root
- add a runtime self-check checklist for making a merged patch reach the current agent before testing it
- correct the contributing guide’s kernel editable-install wording so agents verify the actual import path/HEAD before `refresh`

## Validation
- `git diff --check`
- phrase validation for `Patch-to-self` / `in-situ probe` coverage

## Notes
Local explainer: `/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1/reports/dev-guide-runtime-refresh-20260624.html`
