### PR TITLE
feat(tui): show YAML front matter in markdown viewer

### DIFF
--- a/tui/internal/tui/mdviewer.go
+++ b/tui/internal/tui/mdviewer.go
@@ -469,9 +469,14 @@ func (m MarkdownViewerModel) renderRight(maxW int) string {
 		return "\n  " + StyleFaint.Render("(no content)")
 	}
 
-	// Strip YAML frontmatter if present
-	if loc := fmRe.FindStringIndex(raw); loc != nil {
-		raw = raw[loc[1]:]
+	// Surface YAML frontmatter (fields like `description`) instead of
+	// discarding it: render the block as a fenced code section above the
+	// body so glamour displays it verbatim and readably, while the body
+	// below renders as normal markdown.
+	if sub := fmRe.FindStringSubmatchIndex(raw); sub != nil {
+		fmBody := strings.TrimRight(raw[sub[2]:sub[3]], "\n")
+		body := raw[sub[1]:]
+		raw = "```yaml\n" + fmBody + "\n```\n\n" + body
 	}
 
 	raw = strings.TrimSpace(raw)

--- a/tui/internal/tui/mdviewer_test.go
+++ b/tui/internal/tui/mdviewer_test.go
@@ -60,19 +60,56 @@ func TestMarkdownViewer_PathEntry(t *testing.T) {
 	}
 }
 
-func TestMarkdownViewer_FrontmatterStripped(t *testing.T) {
+// TestMarkdownViewer_FrontmatterShown verifies that YAML frontmatter is
+// surfaced in the rendered view (as a readable block) rather than discarded,
+// so fields like `description` are visible while the body still renders.
+func TestMarkdownViewer_FrontmatterShown(t *testing.T) {
 	entries := []MarkdownEntry{
-		{Label: "skill", Group: "G", Content: "---\nname: test\n---\n# Real Content"},
+		{Label: "skill", Group: "G", Content: "---\nname: lingtai-demo\ndescription: a one-line summary\n---\n# Real Content\n\nbody text"},
 	}
 	m := NewMarkdownViewer(entries, "Test")
-	m.width = 80
+	m.width = 120
 	m.height = 24
-	right := m.renderRight(60)
+	right := m.renderRight(100)
 	if right == "" {
-		t.Error("renderRight returned empty")
+		t.Fatal("renderRight returned empty")
 	}
-	if strings.Contains(right, "name: test") {
-		t.Error("frontmatter was not stripped")
+	// Frontmatter keys and values are rendered verbatim inside a fenced
+	// code block, so distinctive tokens survive glamour's rendering.
+	for _, want := range []string{"name", "lingtai-demo", "description", "summary"} {
+		if !strings.Contains(right, want) {
+			t.Errorf("expected rendered output to contain frontmatter token %q; got:\n%s", want, right)
+		}
+	}
+	// The markdown body must still render alongside the frontmatter.
+	// glamour styles each heading word separately, so the rendered output
+	// interleaves ANSI sequences between words; assert the words survive
+	// individually rather than as a contiguous "Real Content".
+	for _, want := range []string{"Real", "Content", "body"} {
+		if !strings.Contains(right, want) {
+			t.Errorf("expected body token %q to still render; got:\n%s", want, right)
+		}
+	}
+}
+
+// TestMarkdownViewer_NoFrontmatterUnchanged verifies that documents without
+// frontmatter render exactly as before (no stray code fence is injected).
+func TestMarkdownViewer_NoFrontmatterUnchanged(t *testing.T) {
+	entries := []MarkdownEntry{
+		{Label: "plain", Group: "G", Content: "# Title\n\njust body"},
+	}
+	m := NewMarkdownViewer(entries, "Test")
+	m.width = 120
+	m.height = 24
+	right := m.renderRight(100)
+	if right == "" {
+		t.Fatal("renderRight returned empty")
+	}
+	if strings.Contains(right, "```") || strings.Contains(right, "yaml") {
+		t.Errorf("plain markdown should not gain a frontmatter block; got:\n%s", right)
+	}
+	if !strings.Contains(right, "Title") {
+		t.Errorf("expected body to render; got:\n%s", right)
 	}
 }
 


### PR DESCRIPTION
## What

The TUI markdown viewer (`MarkdownViewerModel`, used by `/skills` detail views, recipe previews, and `/help`) previously **stripped and discarded** the YAML front matter block (`---` ... `---`) at the top of docs and SKILL.md files. As a result, fields like `description`, `name`, and `version` were invisible when reading a doc/skill inside the TUI.

This PR surfaces the front matter instead of discarding it.

## How

In `renderRight` (`tui/internal/tui/mdviewer.go`), instead of cutting the front matter out, wrap it in a fenced ` ```yaml ` code block and prepend it to the body. glamour then renders it verbatim and readably, and the rest of the document continues to render as normal markdown.

- Uses `fmRe.FindStringSubmatchIndex` to keep the captured front matter body (the existing `fmRe` regex already isolates it).
- Documents **without** front matter are completely unaffected — no code fence is injected.

Example: a SKILL.md with

```
---
name: lingtai-demo
description: a one-line summary
---
# Real Content
```

now shows the `name`/`description` fields in a code block above the rendered `Real Content` heading, rather than hiding them.

## Tests

- Replaced `TestMarkdownViewer_FrontmatterStripped` (which asserted the old discard behavior) with `TestMarkdownViewer_FrontmatterShown` — asserts both the front matter keys/values **and** the body render.
- Added `TestMarkdownViewer_NoFrontmatterUnchanged` — asserts plain markdown gains no stray code fence.
- `go test ./internal/tui/` (full package) passes; `go vet` and `go build ./...` clean.

## Scope / caveats

- Diff is intentionally minimal: only `mdviewer.go` and `mdviewer_test.go`.
- `tui/internal/tui/ANATOMY.md` cites `mdviewer.go:40-518` with only a generic description ("Generic markdown display with sidebar navigation"); that range was already stale (file is ~690 lines) and the prose doesn't mention front-matter handling, so no anatomy update is included in this narrow PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)