### PR TITLE
docs(dev-guide): verify TUI rebuild actually lands on PATH

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -9,7 +9,7 @@ description: >
   evidence safely with secrets redacted. Includes verifying that long-lived
   runtime objects (services/adapters/caches) were actually rebuilt after a
   refresh, not just that new source is imported.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Runtime Self-Check
@@ -168,6 +168,49 @@ If `/opt/homebrew/bin/lingtai-{tui,portal}` are dev-mode symlinks into the
 checkout, each `make build` is picked up immediately — no `brew reinstall`. If
 they are real binaries, re-link them (see the setup reference) before expecting
 rebuilds to take effect.
+
+### Verify the rebuild actually landed on PATH (don't trust `make dev`/`--version` alone)
+
+`make dev` succeeding and `lingtai-tui --version` printing a fresh-looking
+`-N-gSHORTSHA` do **not** prove the binary your shell runs is the one you just
+built. On a machine with many worktrees, `/opt/homebrew/bin/lingtai-{tui,portal}`
+often symlink into *some other* worktree's `tui/bin/lingtai-tui`, so building in
+your worktree leaves PATH pointing at a stale binary — and `--version` can read
+the same string from either build. Confirm the link target, the source commit,
+and the binary mtime explicitly:
+
+```bash
+# What does PATH actually resolve to, and where does the symlink point?
+which lingtai-tui
+readlink "$(which lingtai-tui)"          # the immediate symlink target
+readlink -f "$(which lingtai-tui)"       # fully resolved path — which worktree's bin?
+readlink -f "$(which lingtai)"           # same check for the `lingtai` launcher
+
+# Is that the worktree you just built in? Compare to your build output path:
+ls -l "$REPO/tui/bin/lingtai-tui"        # mtime should be seconds-fresh after make
+stat -f '%m %N' "$(readlink -f "$(which lingtai-tui)")"   # mtime of the on-PATH binary
+
+# Source commit the on-PATH binary was built from (must match $REPO's HEAD):
+lingtai-tui --version                    # vX.Y.Z-N-gSHORTSHA — compare SHA to:
+git -C "$REPO" rev-parse --short HEAD
+```
+
+If `readlink -f` resolves into a *different* worktree than `$REPO`, your build
+did not reach PATH. Either re-link `/opt/homebrew/bin/lingtai-{tui,portal}` to
+`$REPO/tui/bin/lingtai-tui` (and the portal equivalent), or build in the
+worktree that the symlink already targets — then re-run the checks above and
+confirm SHA, mtime, and resolved path all agree before trusting the binary.
+
+**Worktree caveat — never strand the PATH symlink.** When you rebuild from a
+clean worktree *because the primary checkout is dirty*, the `/opt` symlink may
+already point into yet another worktree (the one whose binary is currently
+live). Before removing or re-linking anything: (a) run `readlink -f` on both
+`/opt/homebrew/bin/lingtai-tui` and `…/lingtai` to learn which worktree they
+target; (b) ensure `/opt` points at *your* rebuilt `tui/bin/lingtai-tui`, or
+clearly report that it still points elsewhere; and (c) **do not `git worktree
+remove` a worktree that the PATH symlink targets** — that leaves a dangling
+`/opt` link and a broken `lingtai-tui` on PATH. Clean up such a worktree only
+after re-linking `/opt` to a surviving build.
 
 ## 4. MCP / addon source and tool-surface check
 


### PR DESCRIPTION
## What

Adds a focused **"Verify the rebuild actually landed on PATH"** subsection to the `lingtai-dev-guide` runtime-self-check reference (section 3, *Rebuild the active TUI from a clean release worktree*). Docs-only; one file.

## Why

Discovered today: after `make dev` / `make build`, the command succeeding and `lingtai-tui --version` printing a fresh-looking `-N-gSHORTSHA` do **not** prove the binary your shell runs is the one you just built. On this machine, `/opt/homebrew/bin/lingtai-tui` and `/opt/homebrew/bin/lingtai` currently symlink into the `tui-mdviewer-frontmatter-20260624` worktree's `tui/bin/lingtai-tui` — so a `make build` in a *different* worktree leaves PATH pointing at a stale binary, and `--version` can read a matching string from either build.

## What the new subsection says

- Don't trust `make dev` output or `--version` alone.
- Check the actual link target and resolution: `readlink` and `readlink -f` on **both** `lingtai-tui` and the `lingtai` launcher — which worktree's `bin` does PATH resolve to?
- Compare the built binary's source SHA (`lingtai-tui --version`) to `$REPO` HEAD (`git rev-parse --short HEAD`).
- Compare the on-PATH binary's mtime to your fresh build output (`ls -l` / `stat`).
- **Worktree caveat:** when rebuilding from a clean worktree because the primary checkout is dirty, ensure `/opt` points at *your* rebuilt `tui/bin/lingtai-tui` (or clearly report it points elsewhere), and **never `git worktree remove` a worktree that the PATH symlink targets** — that strands `/opt` and breaks `lingtai-tui` on PATH.

Bumps `dev-guide-runtime-self-check` frontmatter version `1.1.0 → 1.2.0`, matching the existing per-reference versioning convention.

## Validation

- `git diff --check` clean (no whitespace errors).
- Frontmatter + markdown heading structure intact; new content is a `###` subsection under the existing section 3.
- Edited the **repository source** under `tui/internal/preset/skills/...`, not only the generated installed copy.
- Built on a clean worktree from `origin/main`; the dirty primary checkout and the live TUI-binary worktree were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)