### PR TITLE
docs: integrate release-window lessons into dev guide

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -8,7 +8,7 @@ description: >
   publication-bound release workflow, run a runtime self-check, get a PR
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
-version: 2.5.0
+version: 2.5.1
 ---
 
 # LingTai Developer Guide
@@ -77,9 +77,10 @@ drill-down files, not standalone top-level skills.
   location: reference/release-workflow/SKILL.md
   description: |
     Full command-level release checklist for paired TUI/Portal + kernel releases:
-    scope/candidate heads, clean worktrees, validation gates, GitHub/PyPI/Homebrew
-    publishing, the required self-contained HTML release log, and website
-    release-log/blog drafting with the reusable release blog template.
+    scope/candidate heads, clean worktrees, the parent/daemon division of labor
+    for large windows, release-window pitfalls, validation gates,
+    GitHub/PyPI/Homebrew publishing, the required self-contained HTML release log,
+    and website release-log/blog drafting with the reusable release blog template.
 - name: dev-guide-debug-troubleshoot
   location: reference/debug-troubleshoot/SKILL.md
   description: |

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
@@ -6,7 +6,7 @@ description: >
   GitHub/PyPI/Homebrew publishing boundaries, the required self-contained HTML
   release log, website release-log/blog drafting, and the reusable release blog
   template.
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Release Workflow
@@ -101,6 +101,79 @@ Rules:
 - If you must amend code during release validation, commit it before tagging.
 - Before push/tag/publish, show the human the final candidate refs when approval
   wording is ambiguous.
+
+## 2.5 Parent / daemon division of labor for large release windows
+
+A consequential release window is large and mostly mechanical. Split it so the
+parent (this agent) keeps judgment and authority while claude-p daemons absorb
+the bulk work in parallel.
+
+The parent retains, and does not delegate:
+
+- maintainer authorization boundaries and every external side effect (push, tag,
+  GitHub release, PyPI upload, website deploy, Homebrew tap commit);
+- the final candidate refs and the go/no-go decision;
+- public-facing reports and the human-facing release report;
+- spot-checks of daemon output before trusting it (see the daemon-resume pitfall
+  in §2.6).
+
+Daemons handle the bulky, mechanical blocks, each writing raw outputs to a dated
+report directory so the parent can audit:
+
+- validation gates (TUI/portal/kernel tests, builds, twine/diff checks);
+- scope and contributor audits (commits, PRs, issues across the window);
+- release-notes and HTML-release-log drafting;
+- website release-blog drafting;
+- the Homebrew formula/SHA audit;
+- broad read-only scans (security, stale-doc, repo sweeps).
+
+Constraints for delegated work:
+
+- Give each daemon a clean worktree and a dated report dir
+  (`reports/<task>-YYYYMMDD/`); have it write reports/raw outputs there, not into
+  the conversation only.
+- For read-only audits, include an explicit safety prompt: do **not** write
+  Claude memory, `MEMORY.md`, `~/.claude/`, or global config; touch only the
+  assigned worktree and report dir; keep secrets out of outputs.
+- A daemon proposes; the parent disposes. Treat daemon results as drafts to
+  verify, not as authorized actions already taken.
+
+## 2.6 Release-window pitfalls
+
+Lessons that have cost real time. Read before running long gates or publishing
+any public log.
+
+- **Async shell may be `/bin/sh`, not bash.** A non-interactive default shell can
+  be POSIX `sh`, where Bash process substitution (`cmd > >(tee log)`) is a syntax
+  error and long gate pipelines fail silently or partially. Run long gates inside
+  a daemon, or write an explicit `bash -lc '...'` script, instead of relying on
+  the ambient shell.
+- **A daemon can exit while a background child keeps running.** If a daemon
+  spawns a background process and then returns, its reported output may be
+  incomplete. Do not trust a daemon's summary as final: inspect its report dir,
+  and resume or redo the step deterministically before relying on it.
+- **Public logs cite final merge/tag SHAs, not local validation commits.** When
+  you validate on a pre-squash branch or scratch commit, that SHA is not what
+  ships. Public release logs and HTML logs must cite the final merged/tagged
+  commits. If you validated on a pre-squash tree, prove tree equivalence
+  (e.g. `git diff <validated>..<final>` is empty) and still publish the final
+  refs.
+- **Homebrew may auto-update after the tag.** A GitHub workflow often bumps the
+  tap automatically once the TUI tag is pushed. Before any manual tap edit,
+  verify the bot's commit and SHA landed; do not race it with a hand edit.
+- **Contributor audits cover the whole window and non-code participation.** Do
+  not scope to merged commits / PR authors only. Include closed and rejected
+  issues, issue and PR comments and reviews, and humans who shaped scope or review
+  without authoring code. See §7.3 for the inclusion rule.
+- **Inspect the live `lingtai-web` structure before any website edit.** Never
+  assume blog or release-data paths from memory; the site layout changes (see
+  §7.1).
+- **Keep PR/release explainers local unless intentionally committed.** Draft
+  reports, HTML logs, and explainers live under `reports/` and are not pushed
+  unless the human asked for them to be committed.
+- **External side effects require channel-readable authorization.** An imperative
+  the human can point to on the channel — not an inference — gates every push,
+  tag, release, upload, deploy, or tap commit.
 
 ## 3. TUI/Portal gates
 


### PR DESCRIPTION
## Summary
- add the 2026-06-26 release-window lessons to the canonical `lingtai-dev-guide` release workflow reference
- document the parent/daemon split for large releases: parent keeps authorization/final refs/side effects/public reporting, while claude-p daemons handle bulky gates, audits, drafts, website/Homebrew checks, and read-only scans
- document concrete pitfalls: `/bin/sh` async shell vs Bash process substitution, incomplete daemon/background-child output, final tag SHA vs pre-squash validation refs, Homebrew auto-update verification, full-window contributor audits including closed/rejected issues and comments, live `lingtai-web` structure checks, local-only explainers, and channel-readable authorization for side effects
- bump `lingtai-dev-guide` root to v2.5.1 and nested `release-workflow` reference to v1.2.0

## Validation
- `git diff --check HEAD~1 HEAD`
- frontmatter shape check for root + nested release-workflow skill
- kernel skill validator frontmatter passes; its directory-structure failures are pre-existing false positives on `origin/main` (`scripts/assets` prose match and nested-reference path resolution), with no new file-reference patterns introduced by this PR

## Notes
- docs-only; no release gates run
- primary local checkout was dirty, so this was prepared in a clean worktree from `origin/main`
