### PR TITLE
tui/doctor: clarify diagnostic section layout

### DIFF
--- a/tui/internal/tui/doctor.go
+++ b/tui/internal/tui/doctor.go
@@ -283,7 +283,10 @@ func (m DoctorModel) View() string {
 	} else {
 		titleRow = title + "  " + escHint
 	}
-	header := titleRow + "\n" + strings.Repeat("─", m.width) + "\n"
+	// Render the rule faint so the bright title row and the accent-marked
+	// section headers below it carry the visual weight, not the divider.
+	rule := StyleFaint.Render(strings.Repeat("─", m.width))
+	header := titleRow + "\n" + rule + "\n"
 
 	// Export hint: a prominent, always-visible banner under the header announcing
 	// the save-report capability — shown while checks are still running as well as
@@ -325,7 +328,7 @@ func (m DoctorModel) View() string {
 	if m.ready && !m.viewport.AtBottom() {
 		hint += " " + RuneBullet + " ↑↓ " + i18n.T("doctor.scroll")
 	}
-	footer := strings.Repeat("─", m.width) + "\n"
+	footer := rule + "\n"
 	// Prominent privacy reminder: whenever a completed run can be (or has been)
 	// saved, spell out that the bundle is local + redacted and should be reviewed
 	// before sharing. Sits on its own accented line above the hint so it reads as
@@ -338,10 +341,25 @@ func (m DoctorModel) View() string {
 	return header + exportHint + "\n" + PaintViewportBG(body, m.width) + "\n" + footer
 }
 
+// doctorSectionMarker is the accent-colored anchor printed before each section
+// label. It gives the runtime / kernel / LLM / per-agent group headers a
+// consistent left edge so the eye can catch block boundaries while scrolling,
+// instead of the headers reading as just-another-bold-line among the indented
+// ✓/✗ status output below them.
+const doctorSectionMarker = "▸ "
+
+// renderSectionHeader formats a section label as an accent marker followed by
+// the bold title. Extracted so the marker styling is exercisable in tests
+// without re-rendering the whole viewport.
+func renderSectionHeader(label string) string {
+	return StyleAccent.Render(doctorSectionMarker) + StyleTitle.Render(label)
+}
+
 // renderBody formats the diagnostic lines into the scrollable region. Section
-// headers are un-indented and bold with a leading blank line so the runtime /
-// kernel / LLM / per-agent groups read as distinct blocks; status, warning,
-// and hint lines keep the two-space indent that nests them under their section.
+// headers carry an accent marker and bold label with a leading blank line so
+// the runtime / kernel / LLM / per-agent groups read as distinct blocks;
+// status, warning, and hint lines keep the two-space indent that nests them
+// under their section.
 func (m DoctorModel) renderBody() string {
 	var b strings.Builder
 	for i, line := range m.lines {
@@ -350,7 +368,7 @@ func (m DoctorModel) renderBody() string {
 			if i > 0 {
 				b.WriteString("\n")
 			}
-			b.WriteString(StyleTitle.Render(line.Text) + "\n")
+			b.WriteString(renderSectionHeader(line.Text) + "\n")
 		case line.Hint:
 			b.WriteString("  " + StyleAccent.Render(line.Text) + "\n")
 		case line.Warn:

--- a/tui/internal/tui/doctor_view_test.go
+++ b/tui/internal/tui/doctor_view_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // makeManyLines builds a DoctorModel whose diagnostic output is taller than the
@@ -85,5 +86,42 @@ func TestDoctorViewRendersSectionHeaders(t *testing.T) {
 	out := m.View()
 	if !strings.Contains(out, "RUNTIME") {
 		t.Fatal("section header text should appear in the rendered view")
+	}
+}
+
+func TestRenderSectionHeaderAnchorsLabel(t *testing.T) {
+	// Section headers carry the accent marker so group boundaries are scannable;
+	// the label itself must survive verbatim. Strip ANSI so the assertion holds
+	// regardless of the active theme's color codes.
+	out := ansi.Strip(renderSectionHeader("LLM connectivity"))
+	if !strings.HasPrefix(out, doctorSectionMarker) {
+		t.Fatalf("section header should begin with the marker %q, got %q", doctorSectionMarker, out)
+	}
+	if !strings.Contains(out, "LLM connectivity") {
+		t.Fatalf("section header should preserve its label, got %q", out)
+	}
+}
+
+func TestRenderBodyMarksOnlySectionLines(t *testing.T) {
+	// Only Section lines get the marker; status/hint lines stay indented and
+	// unmarked so the marker reliably signals a group boundary.
+	m := NewDoctorModel("/tmp/orch", "/tmp/global")
+	m.lines = []doctorLine{
+		{Text: "Runtime & assets", Section: true},
+		{Text: "✓ ready", OK: true},
+		{Text: "→ do the thing", Hint: true},
+	}
+	lines := strings.Split(ansi.Strip(m.renderBody()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 rendered lines, got %d: %#v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], doctorSectionMarker) {
+		t.Fatalf("section line should be marked, got %q", lines[0])
+	}
+	if strings.Contains(lines[1], doctorSectionMarker) || strings.Contains(lines[2], doctorSectionMarker) {
+		t.Fatalf("non-section lines must not carry the section marker: %#v", lines[1:])
+	}
+	if !strings.HasPrefix(lines[1], "  ") || !strings.HasPrefix(lines[2], "  ") {
+		t.Fatalf("status/hint lines should stay indented: %#v", lines[1:])
 	}
 }


### PR DESCRIPTION
## Summary
- add an accent marker before each `/doctor` diagnostic section header so group boundaries are easier to scan while scrolling
- render the header/footer divider rules faint so the title and section headings carry the visual weight
- add focused rendering tests for the section marker behavior

## Notes
- independent PR branched from current `origin/main`
- intentionally does not include #449 save-report changes or privacy reminder
- no behavior changes, feature changes, or new i18n strings

## Validation
- `cd tui && go test -count=1 ./internal/tui`
- `cd tui && PYTHONDONTWRITEBYTECODE=1 go test ./...`
- `cd tui && go build ./...`
- `git diff --check`
