### PR TITLE
tui/mail: absolutely center thinking header quote

### DIFF
--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -141,7 +141,7 @@ type MailModel struct {
 	lastInputLines    int
 	lastPaletteLines  int
 	lastBannerLines   int
-	lastTelemetryRow  bool // whether the home telemetry row was reserved last sync
+	lastTelemetryRow  bool             // whether the home telemetry row was reserved last sync
 	pendingMessage    string           // full text from editor, sent on Enter
 	globalDir         string           // ~/.lingtai-tui/
 	wasActive         bool             // true if previous refresh was ACTIVE
@@ -1379,6 +1379,45 @@ func (m MailModel) viewEditorWarn() string {
 	return b.String()
 }
 
+// composeCenteredHeader lays out a three-part header line — left block anchored
+// at column 0, right block flush with the terminal's right edge, and the center
+// block placed at the *absolute* terminal midpoint (start column
+// (width-centerW)/2) rather than centered in the leftover gap between left and
+// right. All widths are display widths (lipgloss.Width) so ANSI styling and
+// multibyte runes are handled correctly.
+//
+// When absolute centering would overlap the left or right block (or the
+// terminal is too narrow), it falls back to centering the block in the leftover
+// gap, and finally to a single-space compact layout, so the line is always
+// non-empty and never drops a block.
+func composeCenteredHeader(left, center, right string, width int) string {
+	leftW := lipgloss.Width(left)
+	centerW := lipgloss.Width(center)
+	rightW := lipgloss.Width(right)
+
+	// Absolute centering: place the center block so its midpoint sits at the
+	// terminal midpoint. Require at least one space of separation on each side
+	// of the center block to keep the blocks visually distinct.
+	start := (width - centerW) / 2
+	if start >= leftW+1 && start+centerW <= width-rightW-1 {
+		leftGap := start - leftW
+		rightGap := width - rightW - (start + centerW)
+		return left + strings.Repeat(" ", leftGap) + center + strings.Repeat(" ", rightGap) + right
+	}
+
+	// Fallback: center the block in whatever gap remains between the anchored
+	// left and right blocks.
+	gapTotal := width - leftW - centerW - rightW - 1
+	if gapTotal > 0 {
+		leftGap := gapTotal / 2
+		rightGap := gapTotal - leftGap
+		return left + strings.Repeat(" ", leftGap) + center + strings.Repeat(" ", rightGap) + right
+	}
+
+	// Too narrow for any gap: compact single-space layout, no overlap math.
+	return left + " " + center + " " + right
+}
+
 func (m MailModel) View() string {
 	if m.showEditorWarn {
 		return m.viewEditorWarn()
@@ -1426,18 +1465,9 @@ func (m MailModel) View() string {
 
 	leftW := lipgloss.Width(titleLeft)
 	rightW := lipgloss.Width(titleRight)
-	centerW := lipgloss.Width(titleCenter)
 	var titleLine string
 	if titleCenter != "" {
-		// Three-part layout: left ... center ... right
-		gapTotal := m.width - leftW - centerW - rightW - 1
-		if gapTotal > 0 {
-			leftGap := gapTotal / 2
-			rightGap := gapTotal - leftGap
-			titleLine = titleLeft + strings.Repeat(" ", leftGap) + titleCenter + strings.Repeat(" ", rightGap) + titleRight
-		} else {
-			titleLine = titleLeft + " " + titleCenter + " " + titleRight
-		}
+		titleLine = composeCenteredHeader(titleLeft, titleCenter, titleRight, m.width)
 	} else {
 		padding := m.width - leftW - rightW - 1
 		if padding > 0 {

--- a/tui/internal/tui/mail_header_center_test.go
+++ b/tui/internal/tui/mail_header_center_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// centerStart returns the column index of the first rune of center within line
+// (both ANSI-stripped), or -1 if center is not found.
+func centerStart(line, center string) int {
+	plain := ansi.Strip(line)
+	c := ansi.Strip(center)
+	idx := strings.Index(plain, c)
+	if idx < 0 {
+		return -1
+	}
+	// Index is a byte offset; convert to a rune/cell column. The header is
+	// ASCII-padded on the left, but the brand/center may contain multibyte
+	// runes, so measure display width up to the match.
+	return lipgloss.Width(plain[:idx])
+}
+
+// TestComposeCenteredHeaderAbsoluteMidpoint proves that, given ample width, the
+// center block is placed at the absolute terminal center: its midpoint equals
+// the terminal midpoint (within one cell for parity), independent of the left
+// and right block widths.
+func TestComposeCenteredHeaderAbsoluteMidpoint(t *testing.T) {
+	left := "  LingTai"
+	center := "✹ 菩提本无树 ✹"
+	right := "orch ◉ active"
+	width := 80
+
+	line := composeCenteredHeader(left, center, right, width)
+
+	start := centerStart(line, center)
+	if start < 0 {
+		t.Fatalf("center block not found in line: %q", ansi.Strip(line))
+	}
+	centerW := lipgloss.Width(center)
+	gotMid := start + centerW/2
+	wantMid := width / 2
+	if diff := gotMid - wantMid; diff < -1 || diff > 1 {
+		t.Errorf("center midpoint = %d, want terminal midpoint %d (start=%d centerW=%d)", gotMid, wantMid, start, centerW)
+	}
+}
+
+// TestComposeCenteredHeaderAnchorsLeftAndRight verifies the left block stays at
+// column 0 and the right block ends flush with the terminal width.
+func TestComposeCenteredHeaderAnchorsLeftAndRight(t *testing.T) {
+	left := "  LingTai"
+	center := "✹ hi ✹"
+	right := "orch ◉ active"
+	width := 80
+
+	line := composeCenteredHeader(left, center, right, width)
+	plain := ansi.Strip(line)
+
+	if !strings.HasPrefix(plain, ansi.Strip(left)) {
+		t.Errorf("line should start with left block %q; got %q", left, plain)
+	}
+	if !strings.HasSuffix(plain, ansi.Strip(right)) {
+		t.Errorf("line should end with right block %q; got %q", right, plain)
+	}
+}
+
+// TestComposeCenteredHeaderNarrowFallback verifies that when the three blocks
+// cannot be laid out without overlap, the helper still returns a non-empty line
+// containing all three blocks (graceful compact fallback, no panic).
+func TestComposeCenteredHeaderNarrowFallback(t *testing.T) {
+	left := "  LingTai brand block"
+	center := "✹ 菩提本无树 ✹"
+	right := "orchestrator ◉ active network[3]"
+	width := 40 // too narrow for absolute centering
+
+	line := composeCenteredHeader(left, center, right, width)
+	plain := ansi.Strip(line)
+
+	if plain == "" {
+		t.Fatal("narrow fallback produced an empty line")
+	}
+	for _, block := range []string{left, center, right} {
+		if !strings.Contains(plain, ansi.Strip(block)) {
+			t.Errorf("narrow fallback line missing block %q; got %q", block, plain)
+		}
+	}
+}
+
+// TestComposeCenteredHeaderNoOverlap verifies the center block never overlaps
+// the left or right blocks when absolute centering is used.
+func TestComposeCenteredHeaderNoOverlap(t *testing.T) {
+	left := "  LingTai"
+	center := "✹ 菩提本无树 ✹"
+	right := "orch ◉ active"
+	width := 80
+
+	line := composeCenteredHeader(left, center, right, width)
+	start := centerStart(line, center)
+	if start < 0 {
+		t.Fatalf("center block not found: %q", ansi.Strip(line))
+	}
+	leftW := lipgloss.Width(left)
+	rightW := lipgloss.Width(right)
+	centerW := lipgloss.Width(center)
+	if start < leftW {
+		t.Errorf("center starts at %d, overlaps left block of width %d", start, leftW)
+	}
+	if end := start + centerW; end > width-rightW {
+		t.Errorf("center ends at %d, overlaps right block (width-rightW=%d)", end, width-rightW)
+	}
+}


### PR DESCRIPTION
## Summary
- add a focused `composeCenteredHeader` helper for the ACTIVE/thinking top mail header
- place the quote/spinner block at the absolute terminal midpoint while keeping the left brand and right agent/state blocks anchored
- fall back to the old gap-centered/compact layout when the terminal is too narrow or blocks would overlap
- add focused layout tests for midpoint centering, left/right anchoring, narrow fallback, and non-overlap

## Notes
- no copy/i18n changes
- gofmt also aligned one pre-existing comment in `mail.go` because this PR touches that file

## Validation
- `cd tui && go test -count=1 ./internal/tui`
- `cd tui && PYTHONDONTWRITEBYTECODE=1 go test ./...`
- `cd tui && go build ./...`
- `git diff --check`
