### PR TITLE
fix(tui): restore 100 page size and reuse mail renderers

### DIFF
--- a/tui/internal/config/global.go
+++ b/tui/internal/config/global.go
@@ -121,7 +121,7 @@ func LoadTUIConfig(globalDir string) TUIConfig {
 	if tc.Language == "" {
 		tc.Language = "en"
 	}
-	if tc.MailPageSize > 0 && tc.MailPageSize < 200 {
+	if tc.MailPageSize > 0 && tc.MailPageSize < 100 {
 		tc.MailPageSize = 200 // migrate old values below minimum
 	}
 	// Insights defaults to false when absent from JSON.

--- a/tui/internal/config/global_test.go
+++ b/tui/internal/config/global_test.go
@@ -225,12 +225,23 @@ func TestDefaultTUIConfig_MailPageSize(t *testing.T) {
 
 func TestLoadTUIConfig_MigratesLegacySmallMailPageSizeToDefault(t *testing.T) {
 	dir := t.TempDir()
-	payload := []byte(`{"language":"en","mail_page_size":100}`)
+	payload := []byte(`{"language":"en","mail_page_size":50}`)
 	if err := os.WriteFile(filepath.Join(dir, "tui_config.json"), payload, 0o644); err != nil {
 		t.Fatalf("write tui_config.json: %v", err)
 	}
 	if cfg := LoadTUIConfig(dir); cfg.MailPageSize != 200 {
 		t.Fatalf("legacy small mail_page_size loaded as %d, want 200", cfg.MailPageSize)
+	}
+}
+
+func TestLoadTUIConfig_PreservesHundredMailPageSize(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte(`{"language":"en","mail_page_size":100}`)
+	if err := os.WriteFile(filepath.Join(dir, "tui_config.json"), payload, 0o644); err != nil {
+		t.Fatalf("write tui_config.json: %v", err)
+	}
+	if cfg := LoadTUIConfig(dir); cfg.MailPageSize != 100 {
+		t.Fatalf("mail_page_size=100 loaded as %d, want 100", cfg.MailPageSize)
 	}
 }
 

--- a/tui/internal/tui/mail.go
+++ b/tui/internal/tui/mail.go
@@ -985,6 +985,33 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 	toolStyle := lipgloss.NewStyle().Foreground(ColorTool)
 	sepStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
 
+	// glamour.NewTermRenderer is heavyweight (it parses a style and builds an
+	// ANSI renderer), so constructing one per agent/insight message — as this
+	// loop used to — costs O(visible messages) renderer builds every render
+	// pass, the dominant source of mail-view lag at large page sizes. The word
+	// wrap width is the only per-message variable (it depends on the sender-name
+	// prefix length for mail bubbles), so cache one renderer per distinct width
+	// for the duration of this call. A nil entry records a width whose renderer
+	// failed to construct, so callers fall back to the plain-wrap path exactly
+	// as before without retrying the failed build.
+	glamourStyle := ActiveTheme().GlamourStyle
+	renderers := make(map[int]*glamour.TermRenderer)
+	markdownRenderer := func(wrap int) *glamour.TermRenderer {
+		if r, ok := renderers[wrap]; ok {
+			return r
+		}
+		r, err := glamour.NewTermRenderer(
+			glamour.WithStandardStyle(glamourStyle),
+			glamour.WithWordWrap(wrap),
+		)
+		if err != nil {
+			renderers[wrap] = nil
+			return nil
+		}
+		renderers[wrap] = r
+		return r
+	}
+
 	var b strings.Builder
 	var prevVisibleApiGroup *ChatMessage
 
@@ -1184,11 +1211,7 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 			b.WriteString(barStyle.Render("  "+strings.Repeat("─", max(fullBar, 1))) + "\n")
 			b.WriteString("  " + label + "\n")
 			b.WriteString(barStyle.Render("  "+strings.Repeat("─", max(fullBar, 1))) + "\n")
-			r, err := glamour.NewTermRenderer(
-				glamour.WithStandardStyle(ActiveTheme().GlamourStyle),
-				glamour.WithWordWrap(max(wrapWidth-2, 10)),
-			)
-			if err == nil {
+			if r := markdownRenderer(max(wrapWidth-2, 10)); r != nil {
 				rendered, err := r.Render(msg.Body)
 				if err == nil {
 					rendered = strings.Trim(rendered, "\n")
@@ -1242,11 +1265,7 @@ func (m MailModel) renderMessages(msgs []ChatMessage) string {
 			// Render markdown for agent messages, plain wrap for user/system
 			var wrappedBody string
 			if !msg.IsFromMe && msg.From != i18n.T("mail.system_sender") {
-				r, err := glamour.NewTermRenderer(
-					glamour.WithStandardStyle(ActiveTheme().GlamourStyle),
-					glamour.WithWordWrap(bodyWidth),
-				)
-				if err == nil {
+				if r := markdownRenderer(bodyWidth); r != nil {
 					if rendered, rerr := r.Render(msg.Body); rerr == nil {
 						wrappedBody = strings.TrimRight(rendered, "\n")
 					}

--- a/tui/internal/tui/settings.go
+++ b/tui/internal/tui/settings.go
@@ -88,10 +88,10 @@ func NewSettingsModel(globalDir, projectDir, orchDir string, tuiCfg config.TUICo
 		}
 	}
 
-	pageSizeOptions := []string{"200", "500", "1000", "infinite"}
-	pageSizeCurrent := 0 // default to 200
+	pageSizeOptions := []string{"100", "200", "500", "1000", "infinite"}
+	pageSizeCurrent := 1 // default to 200
 	if tuiCfg.MailPageSize <= 0 {
-		pageSizeCurrent = 3 // infinite
+		pageSizeCurrent = 4 // infinite
 	} else {
 		pageSizeStr := fmt.Sprintf("%d", tuiCfg.MailPageSize)
 		for i, p := range pageSizeOptions {

--- a/tui/internal/tui/settings_page_size_test.go
+++ b/tui/internal/tui/settings_page_size_test.go
@@ -21,12 +21,28 @@ func pageSizeField(t *testing.T, m SettingsModel) SettingField {
 func TestSettingsMailPageSizeOptionsAndDefault(t *testing.T) {
 	m := NewSettingsModel(t.TempDir(), t.TempDir(), t.TempDir(), config.DefaultTUIConfig())
 	f := pageSizeField(t, m)
-	wantOptions := []string{"200", "500", "1000", "infinite"}
+	wantOptions := []string{"100", "200", "500", "1000", "infinite"}
 	if !reflect.DeepEqual(f.Options, wantOptions) {
 		t.Fatalf("mail_page_size options = %#v, want %#v", f.Options, wantOptions)
 	}
-	if f.Current != 0 {
-		t.Fatalf("mail_page_size default current = %d (%q), want 0 (%q)", f.Current, f.Options[f.Current], wantOptions[0])
+	if f.Current != 1 {
+		t.Fatalf("mail_page_size default current = %d (%q), want 1 (%q)", f.Current, f.Options[f.Current], wantOptions[1])
+	}
+}
+
+func TestSettingsMailPageSizeHundredOption(t *testing.T) {
+	cfg := config.DefaultTUIConfig()
+	cfg.MailPageSize = 100
+	m := NewSettingsModel(t.TempDir(), t.TempDir(), t.TempDir(), cfg)
+	f := pageSizeField(t, m)
+	if got := f.Options[f.Current]; got != "100" {
+		t.Fatalf("MailPageSize=100 selected %q, want 100", got)
+	}
+
+	m.applyField(&f)
+	loaded := config.LoadTUIConfig(m.globalDir)
+	if loaded.MailPageSize != 100 {
+		t.Fatalf("100 page size persisted as %d, want 100", loaded.MailPageSize)
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore `100` as a Settings → Mail page-size option while keeping the default at `200`
- update config migration so `100` is preserved and only positive values below `100` migrate to the default
- reduce mail-view lag by reusing Glamour markdown renderers within a single `renderMessages` pass, keyed by word-wrap width, instead of constructing a new renderer for every agent/insight message

## Reviewer/opinion notes
- GLM report: `workspace/tui_page_size_perf_20260627/glm_tui_perf_opinion.md`
- Claude report: `workspace/tui_page_size_perf_20260627/claude_tui_perf_opinion.md`
- Both reviewers found the page-size patch OK and identified repeated full render / markdown renderer construction as the likely lag source.
- Claude implementation report: `workspace/tui_page_size_perf_20260627/claude_perf_impl_report.md`

## Tests
- `cd tui && go test ./internal/config -run 'Test(DefaultTUIConfig_MailPageSize|LoadTUIConfig_MigratesLegacySmallMailPageSizeToDefault|LoadTUIConfig_PreservesHundredMailPageSize)'`
- `cd tui && go test ./internal/tui -run 'TestSettingsMailPageSize'`
- `cd tui && go test ./internal/tui -run 'TestSettingsMailPageSize|Test.*Mail|Test.*Render' -count=1`
- `cd tui && go test ./internal/config -run 'MailPageSize' -count=1`
- `cd tui && go test ./internal/tui`
- `git diff --check origin/main..HEAD`

Known environment/pre-existing failure:
- `cd tui && go test ./internal/config ./internal/tui` still fails only in two Homebrew install-method tests (`TestManualTUIUpdateHomebrewRoutesThroughUpdater` and `TestDetectTUIInstallMethodHomebrewFromPathAndEnv/intel_homebrew_env`), same class of unrelated local Homebrew/source-detection failures seen on the previous page-size PR. `./internal/tui` passed.
