### PR TITLE
fix(tui): mark context rebuilds in kanban ledger

### DIFF
--- a/tui/i18n/en.json
+++ b/tui/i18n/en.json
@@ -357,6 +357,8 @@
   "props.detail_recent_main": "Recent calls — agent (last 100)",
   "props.detail_recent_daemons": "Recent calls — daemons (last 100)",
   "props.detail_recent_empty": "No agent calls recorded yet.",
+  "props.detail_recent_rebuild": "context rebuilt",
+  "props.detail_recent_molt": "molt",
   "props.detail_recent_daemons_empty": "No daemon calls recorded yet.",
   "props.detail_mcp": "MCP servers",
   "props.detail_daemons": "Daemons",

--- a/tui/i18n/wen.json
+++ b/tui/i18n/wen.json
@@ -352,6 +352,8 @@
   "props.detail_recent_main": "近召 — 本体（末百）",
   "props.detail_recent_daemons": "近召 — 神识（末百）",
   "props.detail_recent_empty": "本体未尝有召。",
+  "props.detail_recent_rebuild": "灵台重铸",
+  "props.detail_recent_molt": "凝蜕",
   "props.detail_recent_daemons_empty": "神识未尝有召。",
   "props.detail_mcp": "MCP 之器",
   "props.detail_daemons": "神识",

--- a/tui/i18n/zh.json
+++ b/tui/i18n/zh.json
@@ -352,6 +352,8 @@
   "props.detail_recent_main": "近期调用 — 主体（最近 100）",
   "props.detail_recent_daemons": "近期调用 — 神识（最近 100）",
   "props.detail_recent_empty": "尚未记录主体调用。",
+  "props.detail_recent_rebuild": "上下文重建",
+  "props.detail_recent_molt": "凝蜕",
   "props.detail_recent_daemons_empty": "尚未记录神识调用。",
   "props.detail_mcp": "MCP 服务器",
   "props.detail_daemons": "神识",

--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -25,6 +25,8 @@ The TUI's read-only window into an agent working directory (`<project>/.lingtai/
 | `SumTokenLedgerByProvider` | `tui/internal/fs/agent.go:582` | groups main-agent ledger entries by derived provider name + recent N entries, skipping daemon-mirrored rows so `/kanban` main detail stays separate from daemon detail |
 | `SumMoltSessionTokenLedger` | `tui/internal/fs/agent.go:622` | uses `logs/log.sqlite` `psyche_molt` boundaries when available (JSONL fallback), then sums cached non-daemon token-ledger windows for `/kanban` Ctrl+D current and last session API/cache stats, including Codex `codex_request_mode` counts (`ws_full` / `ws_incremental`) |
 | `SumSessionTokenLedgerBetween` | `tui/internal/fs/agent.go:696` | reusable `[since, before)` ledger-window summation helper used by molt-session stats and since-cutoff callers |
+| **rebuild_marker.go** | | |
+| `RecentRebuildTimes(agentDir, limit)` | `tui/internal/fs/rebuild_marker.go` | best-effort newest-first `psyche_molt` (context-rebuild) timestamps for `/kanban` Ctrl+D ledger separators; prefers `logs/log.sqlite` LIMIT query (`sqlitelog.QueryRecentMoltTimes`), falls back to tailing the last `tailScanLines` (1000) lines of `logs/events.jsonl`; missing/malformed logs yield no markers |
 | **jsonl.go** | | |
 | `forEachJSONLLine(path, fn)` | `tui/internal/fs/jsonl.go:16` | streams JSONL files one line at a time without `ReadFile`/`strings.Split`, avoiding duplicate buffers and Scanner token limits for ledger/history hot paths |
 | **daemon_ledger.go** | | |

--- a/tui/internal/fs/agent.go
+++ b/tui/internal/fs/agent.go
@@ -559,17 +559,18 @@ func storeTokenLedgerTotals(path string, info os.FileInfo, totals TokenTotals) {
 // agent calls from historical daemon rows that were mirrored into parent
 // ledgers.
 type LedgerEntry struct {
-	TS                string `json:"ts"`
-	Input             int64  `json:"input"`
-	Output            int64  `json:"output"`
-	Thinking          int64  `json:"thinking"`
-	Cached            int64  `json:"cached"`
-	Model             string `json:"model,omitempty"`
-	Endpoint          string `json:"endpoint,omitempty"`
-	Source            string `json:"source,omitempty"`
-	EmID              string `json:"em_id,omitempty"`
-	RunID             string `json:"run_id,omitempty"`
-	CodexTransferMode string `json:"codex_transfer_mode,omitempty"`
+	TS                 string `json:"ts"`
+	Input              int64  `json:"input"`
+	Output             int64  `json:"output"`
+	Thinking           int64  `json:"thinking"`
+	Cached             int64  `json:"cached"`
+	Model              string `json:"model,omitempty"`
+	Endpoint           string `json:"endpoint,omitempty"`
+	Source             string `json:"source,omitempty"`
+	EmID               string `json:"em_id,omitempty"`
+	RunID              string `json:"run_id,omitempty"`
+	CodexTransferMode  string `json:"codex_transfer_mode,omitempty"`
+	CodexWSDeltaReason string `json:"codex_ws_delta_reason,omitempty"`
 }
 
 // SumTokenLedgerByProvider reads a token_ledger.jsonl, groups main-agent

--- a/tui/internal/fs/rebuild_marker.go
+++ b/tui/internal/fs/rebuild_marker.go
@@ -1,0 +1,119 @@
+package fs
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/anthropics/lingtai-tui/internal/sqlitelog"
+)
+
+// tailReadChunk is the size of each backward read when tailing events.jsonl.
+const tailReadChunk = 64 * 1024
+
+// tailScanLines bounds how many trailing lines of events.jsonl the JSONL
+// fallback inspects. Full-file scans of events.jsonl can be slow on
+// long-lived agents, so the fallback only tails the most recent lines.
+const tailScanLines = 1000
+
+// RecentRebuildTimes returns the timestamps of recent context-rebuild
+// (psyche_molt) events for an agent, newest first, capped at limit. It is
+// best-effort and never errors: the primary source is the agent's
+// logs/log.sqlite sidecar via a targeted LIMIT query (no full scan); if that
+// is missing or fails, it falls back to tailing the last tailScanLines lines
+// of logs/events.jsonl. Missing or malformed logs simply yield no markers,
+// so callers can render no separator.
+func RecentRebuildTimes(agentDir string, limit int) []time.Time {
+	if limit <= 0 {
+		limit = 10
+	}
+	if times, err := sqlitelog.QueryRecentMoltTimes(agentDir, limit); err == nil {
+		return times
+	}
+	return tailMoltTimes(filepath.Join(agentDir, "logs", "events.jsonl"), tailScanLines, limit)
+}
+
+// tailMoltTimes inspects only the last maxLines lines of an events.jsonl file
+// for psyche_molt rows and returns their timestamps newest-first, capped at
+// limit. It reads backward from EOF in fixed chunks until it has gathered
+// enough trailing lines (or hit the start of the file), so a huge line in the
+// file prefix never affects it and the prefix is never scanned. Malformed
+// lines are skipped; a missing file yields nil.
+func tailMoltTimes(eventsPath string, maxLines, limit int) []time.Time {
+	if maxLines <= 0 {
+		return nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	f, err := os.Open(eventsPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil
+	}
+	size := info.Size()
+
+	// Read backward from EOF until we have maxLines newlines (one more than
+	// the number of trailing lines we want, to anchor the oldest line's start)
+	// or reach the file start. We only keep a bounded suffix buffer.
+	var suffix []byte
+	pos := size
+	newlines := 0
+	for pos > 0 && newlines <= maxLines {
+		readSize := int64(tailReadChunk)
+		if readSize > pos {
+			readSize = pos
+		}
+		pos -= readSize
+		buf := make([]byte, readSize)
+		if _, err := f.ReadAt(buf, pos); err != nil && err != io.EOF {
+			return nil
+		}
+		suffix = append(buf, suffix...)
+		newlines += bytes.Count(buf, []byte{'\n'})
+	}
+
+	// Keep only the last maxLines lines of the gathered suffix. Ignore
+	// trailing newline terminators so a normally newline-ended file still
+	// contributes exactly maxLines data lines instead of maxLines-1.
+	suffix = bytes.TrimRight(suffix, "\n")
+	if len(suffix) == 0 {
+		return nil
+	}
+	lines := bytes.Split(suffix, []byte{'\n'})
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+
+	var times []time.Time
+	// Walk the tail newest-first so the returned slice is newest-first.
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+		var evt struct {
+			Type string  `json:"type"`
+			TS   float64 `json:"ts"`
+		}
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		if evt.Type != "psyche_molt" || evt.TS <= 0 {
+			continue
+		}
+		times = append(times, unixFloatTime(evt.TS))
+		if limit > 0 && len(times) >= limit {
+			break
+		}
+	}
+	return times
+}

--- a/tui/internal/fs/rebuild_marker_test.go
+++ b/tui/internal/fs/rebuild_marker_test.go
@@ -1,0 +1,160 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecentRebuildTimesJSONLFallback(t *testing.T) {
+	agentDir := t.TempDir()
+	logsDir := filepath.Join(agentDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		`{"type":"text_input","ts":1000.0}`,
+		`{"type":"psyche_molt","ts":1100.0}`,
+		`{"type":"tool_call","ts":1200.0}`,
+		`{"type":"psyche_molt","ts":1300.5}`,
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"),
+		[]byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No log.sqlite present, so the reader falls back to the JSONL tail.
+	times := RecentRebuildTimes(agentDir, 10)
+	if len(times) != 2 {
+		t.Fatalf("expected 2 rebuild times, got %d", len(times))
+	}
+	if times[0].Unix() != 1300 || times[1].Unix() != 1100 {
+		t.Fatalf("expected newest-first (1300,1100), got %d,%d", times[0].Unix(), times[1].Unix())
+	}
+}
+
+func TestRecentRebuildTimesJSONLTailOnly(t *testing.T) {
+	agentDir := t.TempDir()
+	logsDir := filepath.Join(agentDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A molt event far above the tail window must NOT be seen; only the
+	// recent tail is inspected, per the no-full-scan constraint.
+	var b strings.Builder
+	b.WriteString(`{"type":"psyche_molt","ts":1.0}` + "\n") // line 1 — outside the tail
+	for i := 0; i < tailScanLines+50; i++ {
+		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
+	}
+	b.WriteString(`{"type":"psyche_molt","ts":99999.0}` + "\n") // near end — inside the tail
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	times := RecentRebuildTimes(agentDir, 10)
+	if len(times) != 1 {
+		t.Fatalf("expected only the in-tail molt, got %d", len(times))
+	}
+	if times[0].Unix() != 99999 {
+		t.Fatalf("expected the recent molt (99999), got %d", times[0].Unix())
+	}
+}
+
+func TestRecentRebuildTimesJSONLTailIncludesOldestLineInWindow(t *testing.T) {
+	agentDir := t.TempDir()
+	logsDir := filepath.Join(agentDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Exactly tailScanLines data lines plus a trailing newline. The first line
+	// is still inside the tail window and must not be dropped because Split
+	// sees a trailing empty segment.
+	var b strings.Builder
+	b.WriteString(`{"type":"psyche_molt","ts":777.0}` + "\n")
+	for i := 1; i < tailScanLines; i++ {
+		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	times := RecentRebuildTimes(agentDir, 10)
+	if len(times) != 1 {
+		t.Fatalf("expected the oldest in-window molt, got %d", len(times))
+	}
+	if times[0].Unix() != 777 {
+		t.Fatalf("expected in-window molt (777), got %d", times[0].Unix())
+	}
+}
+
+func TestRecentRebuildTimesHugePrefixLineDoesNotBlockTail(t *testing.T) {
+	agentDir := t.TempDir()
+	logsDir := filepath.Join(agentDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A >1MiB prefix line, far outside the last-1000-line window. A naive
+	// bufio.Scanner with a 1MiB token cap chokes on this line and stops,
+	// hiding the recent molt. The true tail reader must seek past it.
+	var b strings.Builder
+	huge := strings.Repeat("x", 2*1024*1024)
+	fmt.Fprintf(&b, `{"type":"text_input","ts":1.0,"junk":"%s"}`+"\n", huge)
+	for i := 0; i < tailScanLines+50; i++ {
+		fmt.Fprintf(&b, `{"type":"tool_call","ts":%d.0}`+"\n", 1000+i)
+	}
+	b.WriteString(`{"type":"psyche_molt","ts":88888.0}` + "\n") // in the tail
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	times := RecentRebuildTimes(agentDir, 10)
+	if len(times) != 1 {
+		t.Fatalf("expected the in-tail molt despite huge prefix line, got %d", len(times))
+	}
+	if times[0].Unix() != 88888 {
+		t.Fatalf("expected the recent molt (88888), got %d", times[0].Unix())
+	}
+}
+
+func TestRecentRebuildTimesMissingLogsIsEmpty(t *testing.T) {
+	times := RecentRebuildTimes(t.TempDir(), 10)
+	if len(times) != 0 {
+		t.Fatalf("expected no markers for missing logs, got %d", len(times))
+	}
+}
+
+func TestRecentRebuildTimesPrefersSQLite(t *testing.T) {
+	sqliteBin, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("sqlite3 not available")
+	}
+	agentDir := t.TempDir()
+	logsDir := filepath.Join(agentDir, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// JSONL has a molt the sqlite sidecar does not — proves sqlite wins when present.
+	if err := os.WriteFile(filepath.Join(logsDir, "events.jsonl"),
+		[]byte(`{"type":"psyche_molt","ts":1.0}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	createSQL := `
+		CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, ts REAL NOT NULL, type TEXT NOT NULL, fields_json TEXT NOT NULL DEFAULT '{}');
+		INSERT INTO events (ts, type) VALUES (5000.0, 'psyche_molt');
+	`
+	cmd := exec.Command(sqliteBin, filepath.Join(logsDir, "log.sqlite"), createSQL)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 setup failed: %v\n%s", err, out)
+	}
+
+	times := RecentRebuildTimes(agentDir, 10)
+	if len(times) != 1 {
+		t.Fatalf("expected 1 rebuild time from sqlite, got %d", len(times))
+	}
+	if times[0].Unix() != 5000 {
+		t.Fatalf("expected sqlite molt (5000), got %d", times[0].Unix())
+	}
+}

--- a/tui/internal/sqlitelog/molt.go
+++ b/tui/internal/sqlitelog/molt.go
@@ -56,6 +56,51 @@ func QueryMoltSessionWindows(agentDir string) (currentSince, lastSince, lastBefo
 	return currentSince, lastSince, lastBefore, true, nil
 }
 
+// QueryRecentMoltTimes fetches the most recent psyche_molt (context rebuild)
+// timestamps from the sqlite sidecar, newest first, capped at limit. It is a
+// targeted, LIMIT-bounded query — never a full table scan. Used to mark
+// context-rebuild boundaries in the /kanban Ctrl+D ledger. Degrades like the
+// other queries here: a missing database or binary returns a descriptive
+// error and a nil slice, and the caller falls back to JSONL or draws nothing.
+func QueryRecentMoltTimes(agentDir string, limit int) ([]time.Time, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	db := DBPath(agentDir)
+	if _, err := os.Stat(db); err != nil {
+		return nil, fmt.Errorf("sqlite sidecar not found: %s", db)
+	}
+	bin, err := findSQLite3()
+	if err != nil {
+		return nil, err
+	}
+
+	sql := fmt.Sprintf(`SELECT ts FROM events WHERE type='psyche_molt' ORDER BY ts DESC LIMIT %d`, limit)
+	out, err := exec.Command(bin, "-separator", "\x1f", db, sql).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if msg := strings.TrimSpace(string(ee.Stderr)); msg != "" {
+				return nil, fmt.Errorf("sqlite3: %s", msg)
+			}
+		}
+		return nil, fmt.Errorf("sqlite3 query failed: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+	var times []time.Time
+	for _, line := range strings.Split(raw, "\n") {
+		ts, err := strconv.ParseFloat(strings.TrimSpace(line), 64)
+		if err != nil || ts <= 0 {
+			continue
+		}
+		times = append(times, unixFloatTimeUTC(ts))
+	}
+	return times, nil
+}
+
 func unixFloatTimeUTC(ts float64) time.Time {
 	sec := int64(ts)
 	nsec := int64((ts - float64(sec)) * 1e9)

--- a/tui/internal/sqlitelog/molt_recent_test.go
+++ b/tui/internal/sqlitelog/molt_recent_test.go
@@ -1,0 +1,63 @@
+package sqlitelog
+
+import "testing"
+
+func TestQueryRecentMoltTimesNewestFirst(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1000.0,'psyche_molt','{}');`,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1001.0,'tool_call','{}');`,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1002.5,'psyche_molt','{}');`,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1500.25,'psyche_molt','{}');`,
+	)
+	times, err := QueryRecentMoltTimes(agentDir, 10)
+	if err != nil {
+		t.Fatalf("QueryRecentMoltTimes: %v", err)
+	}
+	if len(times) != 3 {
+		t.Fatalf("expected 3 molt times, got %d", len(times))
+	}
+	wantUnix := []int64{1500, 1002, 1000}
+	for i, w := range wantUnix {
+		if got := times[i].Unix(); got != w {
+			t.Fatalf("times[%d].Unix() = %d, want %d", i, got, w)
+		}
+	}
+}
+
+func TestQueryRecentMoltTimesRespectsLimit(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1000.0,'psyche_molt','{}');`,
+		`INSERT INTO events(ts,type,fields_json) VALUES(2000.0,'psyche_molt','{}');`,
+		`INSERT INTO events(ts,type,fields_json) VALUES(3000.0,'psyche_molt','{}');`,
+	)
+	times, err := QueryRecentMoltTimes(agentDir, 2)
+	if err != nil {
+		t.Fatalf("QueryRecentMoltTimes: %v", err)
+	}
+	if len(times) != 2 {
+		t.Fatalf("expected limit of 2, got %d", len(times))
+	}
+	if times[0].Unix() != 3000 || times[1].Unix() != 2000 {
+		t.Fatalf("expected newest two (3000,2000), got %d,%d", times[0].Unix(), times[1].Unix())
+	}
+}
+
+func TestQueryRecentMoltTimesEmpty(t *testing.T) {
+	agentDir := makeTestDB(t,
+		`INSERT INTO events(ts,type,fields_json) VALUES(1000.0,'tool_call','{}');`,
+	)
+	times, err := QueryRecentMoltTimes(agentDir, 10)
+	if err != nil {
+		t.Fatalf("QueryRecentMoltTimes empty: %v", err)
+	}
+	if len(times) != 0 {
+		t.Fatalf("expected no molt times, got %d", len(times))
+	}
+}
+
+func TestQueryRecentMoltTimesMissingDB(t *testing.T) {
+	_, err := QueryRecentMoltTimes(t.TempDir(), 10)
+	if err == nil {
+		t.Fatal("expected error for missing sqlite sidecar")
+	}
+}

--- a/tui/internal/tui/props.go
+++ b/tui/internal/tui/props.go
@@ -65,6 +65,7 @@ type PropsModel struct {
 	detailContextStats        fs.ContextStats
 	detailDaemonCounts        fs.DaemonCounts
 	detailMCPNames            []string
+	detailRebuilds            []time.Time // psyche_molt times, newest first; rendered as molt separators
 }
 
 // detailRecentCalls is the number of recent token-ledger calls shown in each
@@ -251,6 +252,9 @@ func (m *PropsModel) loadDetail() {
 	// network. Missing ledgers render an empty lane.
 	m.detailDaemonRecent = fs.DaemonRecentLedger(m.selectedDir, detailRecentCalls)
 	m.detailContextStats = fs.ReadContextStats(m.selectedDir)
+	// Context-rebuild boundaries to mark in the main-agent ledger lane.
+	// Best-effort: empty when no rebuild markers are available.
+	m.detailRebuilds = fs.RecentRebuildTimes(m.selectedDir, detailRecentCalls)
 
 	// MCP names from init.json's mcp block.
 	m.detailMCPNames = nil
@@ -979,6 +983,83 @@ func (m PropsModel) renderRecentCallLanes() []string {
 	return lines
 }
 
+const (
+	ledgerSeparatorReconstructLabel = "props.detail_recent_rebuild"
+	ledgerSeparatorMoltLabel        = "props.detail_recent_molt"
+)
+
+// ledgerSeparatorLabelKeys maps each ledger row index (in a newest-first
+// entries slice) to the dotted separator label(s) that should be drawn after
+// that row. Codex token-ledger rows mark the first call after a reconstruct
+// with codex_ws_delta_reason="epoch_reset"; that row is itself the low-cache
+// reconstruct call, so the visual boundary belongs immediately after it,
+// before the next-older pre-reconstruct row. Molt timestamps are separate
+// boundaries and get their own label.
+func ledgerSeparatorLabelKeys(entries []fs.LedgerEntry, moltTimes []time.Time) map[int][]string {
+	out := map[int][]string{}
+	if len(entries) < 2 {
+		return out
+	}
+	for i := 0; i+1 < len(entries); i++ {
+		if isReconstructLedgerEntry(entries[i]) {
+			addLedgerSeparatorLabel(out, i, ledgerSeparatorReconstructLabel)
+		}
+	}
+	if len(moltTimes) == 0 {
+		return out
+	}
+	parsed := make([]time.Time, len(entries))
+	ok := make([]bool, len(entries))
+	for i, e := range entries {
+		if t, err := time.Parse(time.RFC3339, e.TS); err == nil {
+			parsed[i] = t
+			ok[i] = true
+		}
+	}
+	for _, r := range moltTimes {
+		for i := 0; i+1 < len(entries); i++ {
+			if !ok[i] || !ok[i+1] {
+				continue
+			}
+			// newest-first: parsed[i] is at/after the molt, parsed[i+1] before it.
+			if !parsed[i].Before(r) && parsed[i+1].Before(r) {
+				addLedgerSeparatorLabel(out, i, ledgerSeparatorMoltLabel)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func addLedgerSeparatorLabel(out map[int][]string, idx int, labelKey string) {
+	for _, existing := range out[idx] {
+		if existing == labelKey {
+			return
+		}
+	}
+	out[idx] = append(out[idx], labelKey)
+}
+
+// rebuildSeparatorIndexes is kept as a small test/helper compatibility wrapper
+// for callers that only care whether any separator exists after a row.
+func rebuildSeparatorIndexes(entries []fs.LedgerEntry, rebuilds []time.Time) map[int]bool {
+	labels := ledgerSeparatorLabelKeys(entries, rebuilds)
+	out := make(map[int]bool, len(labels))
+	for idx := range labels {
+		out[idx] = true
+	}
+	return out
+}
+
+func isReconstructLedgerEntry(entry fs.LedgerEntry) bool {
+	switch strings.ToLower(strings.TrimSpace(entry.CodexWSDeltaReason)) {
+	case "epoch_reset", "reconstruct", "reconstructed", "context_rebuild", "context_reconstructed":
+		return true
+	default:
+		return false
+	}
+}
+
 // renderMainCallRows renders the selected agent's recent per-call ledger
 // entries (newest first). Rows deliberately avoid truncating model/endpoint
 // fields so detail mode can preserve raw diagnostic evidence.
@@ -991,11 +1072,16 @@ func (m PropsModel) renderMainCallRows() []string {
 		return []string{"  " + subtleStyle.Render(i18n.T("props.detail_recent_empty"))}
 	}
 
-	lines := []string{
-		"  " + labelStyle.Render(fmt.Sprintf("%-24s  %-10s  %-24s  %10s  %10s  %10s  %10s  %10s  %7s  %s",
-			"time", "provider", "model", "input", "output", "thinking", "cached", "miss", "cache%", "endpoint")),
-	}
-	for _, e := range m.detailRecent {
+	headerLine := fmt.Sprintf("  %-24s  %-10s  %-24s  %10s  %10s  %10s  %10s  %10s  %7s  %s",
+		"time", "provider", "model", "input", "output", "thinking", "cached", "miss", "cache%", "endpoint")
+	lines := []string{"  " + labelStyle.Render(headerLine)}
+
+	// Rows that start a reconstructed context, or that straddle a fallback
+	// rebuild timestamp, get a faint dotted separator drawn after them.
+	separators := ledgerSeparatorLabelKeys(m.detailRecent, m.detailRebuilds)
+	sepWidth := lipgloss.Width(headerLine)
+
+	for i, e := range m.detailRecent {
 		provider := fs.DeriveLedgerProvider(e.Endpoint, e.Model)
 		model := e.Model
 		if model == "" {
@@ -1018,8 +1104,29 @@ func (m PropsModel) renderMainCallRows() []string {
 			endpoint,
 		)
 		lines = append(lines, valueStyle.Render(line))
+		for _, labelKey := range separators[i] {
+			lines = append(lines, rebuildSeparatorLine(sepWidth, labelKey))
+		}
 	}
 	return lines
+}
+
+// rebuildSeparatorLine renders the faint dotted boundary marking a context
+// rebuild between two adjacent ledger calls.
+func rebuildSeparatorLine(width int, labelKey string) string {
+	if width < 8 {
+		width = 8
+	}
+	faint := lipgloss.NewStyle().Foreground(ColorTextFaint)
+	if labelKey == "" {
+		labelKey = ledgerSeparatorReconstructLabel
+	}
+	label := i18n.T(labelKey)
+	dots := width - lipgloss.Width(label) - 1
+	if dots < 3 {
+		return "  " + faint.Render(strings.Repeat("┈", width))
+	}
+	return "  " + faint.Render(strings.Repeat("┈", dots)+" "+label)
 }
 
 // renderDaemonCallRows renders all daemon per-call ledger entries (newest

--- a/tui/internal/tui/rebuild_separator_test.go
+++ b/tui/internal/tui/rebuild_separator_test.go
@@ -1,0 +1,199 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anthropics/lingtai-tui/internal/fs"
+)
+
+func ts(unix int64) string {
+	return time.Unix(unix, 0).UTC().Format(time.RFC3339)
+}
+
+// Ledger rows are newest-first. A rebuild between two adjacent calls means a
+// separator is drawn after the newer (earlier-in-slice) row.
+
+func TestLedgerSeparatorLabelKeysDistinguishesReconstructAndMolt(t *testing.T) {
+	entries := []fs.LedgerEntry{
+		{TS: ts(3000), CodexWSDeltaReason: "epoch_reset"},
+		{TS: ts(2000)},
+		{TS: ts(1000)},
+	}
+	labels := ledgerSeparatorLabelKeys(entries, []time.Time{time.Unix(1500, 0).UTC()})
+	if got := labels[0]; len(got) != 1 || got[0] != ledgerSeparatorReconstructLabel {
+		t.Fatalf("expected reconstruct label after index 0, got %v", got)
+	}
+	if got := labels[1]; len(got) != 1 || got[0] != ledgerSeparatorMoltLabel {
+		t.Fatalf("expected molt label after index 1, got %v", got)
+	}
+}
+
+func TestRenderMainCallRowsInsertsMoltSeparatorLabel(t *testing.T) {
+	m := PropsModel{
+		detailRecent: []fs.LedgerEntry{
+			{TS: ts(3000), Model: "m", Endpoint: "e"},
+			{TS: ts(1000), Model: "m", Endpoint: "e"},
+		},
+		detailRebuilds: []time.Time{time.Unix(2000, 0).UTC()},
+	}
+	rows := m.renderMainCallRows()
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows (header, row, molt separator, row), got %d:\n%s",
+			len(rows), strings.Join(rows, "\n"))
+	}
+	if !strings.Contains(rows[2], "┈") || !strings.Contains(rows[2], "molt") {
+		t.Fatalf("expected dotted molt separator, got %q", rows[2])
+	}
+}
+
+func TestRebuildSeparatorIndexesUsesCodexEpochResetRow(t *testing.T) {
+	entries := []fs.LedgerEntry{
+		{TS: ts(3000), CodexWSDeltaReason: "ok"},
+		{TS: ts(2000), CodexWSDeltaReason: "epoch_reset"},
+		{TS: ts(1000), CodexWSDeltaReason: "ok"},
+	}
+	got := rebuildSeparatorIndexes(entries, nil)
+	if len(got) != 1 || !got[1] {
+		t.Fatalf("expected separator after epoch_reset row index 1, got %v", got)
+	}
+}
+
+func TestRenderMainCallRowsInsertsSeparatorFromEpochReset(t *testing.T) {
+	m := PropsModel{
+		detailRecent: []fs.LedgerEntry{
+			{TS: ts(3000), Model: "m", Endpoint: "e"},
+			{TS: ts(2000), Model: "m", Endpoint: "e", CodexWSDeltaReason: "epoch_reset"},
+			{TS: ts(1000), Model: "m", Endpoint: "e"},
+		},
+	}
+	rows := m.renderMainCallRows()
+	// header + 3 data rows + 1 separator after the epoch_reset row.
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows (header, row, epoch row, separator, row), got %d:\n%s",
+			len(rows), strings.Join(rows, "\n"))
+	}
+	if !strings.Contains(rows[3], "┈") {
+		t.Fatalf("expected dotted separator after epoch_reset row, got %q", rows[3])
+	}
+	if strings.Contains(rows[1], "┈") || strings.Contains(rows[2], "┈") || strings.Contains(rows[4], "┈") {
+		t.Fatalf("separator leaked into data rows:\n%s", strings.Join(rows, "\n"))
+	}
+}
+
+func TestRebuildSeparatorIndexesBetweenCalls(t *testing.T) {
+	entries := []fs.LedgerEntry{
+		{TS: ts(3000)}, // index 0 (newest)
+		{TS: ts(2000)}, // index 1
+		{TS: ts(1000)}, // index 2 (oldest)
+	}
+	// A rebuild at 2500 sits between row 0 (3000) and row 1 (2000).
+	rebuilds := []time.Time{time.Unix(2500, 0).UTC()}
+
+	got := rebuildSeparatorIndexes(entries, rebuilds)
+	if len(got) != 1 || !got[0] {
+		t.Fatalf("expected separator after index 0, got %v", got)
+	}
+}
+
+func TestRebuildSeparatorIndexesMultiple(t *testing.T) {
+	entries := []fs.LedgerEntry{
+		{TS: ts(4000)},
+		{TS: ts(3000)},
+		{TS: ts(2000)},
+		{TS: ts(1000)},
+	}
+	rebuilds := []time.Time{
+		time.Unix(3500, 0).UTC(), // between idx 0 and 1
+		time.Unix(1500, 0).UTC(), // between idx 2 and 3
+	}
+	got := rebuildSeparatorIndexes(entries, rebuilds)
+	if !got[0] || !got[2] {
+		t.Fatalf("expected separators after index 0 and 2, got %v", got)
+	}
+	if got[1] || got[3] {
+		t.Fatalf("unexpected separators at 1 or 3: %v", got)
+	}
+}
+
+func TestRebuildSeparatorIndexesNoneWhenOutOfRange(t *testing.T) {
+	entries := []fs.LedgerEntry{
+		{TS: ts(3000)},
+		{TS: ts(2000)},
+	}
+	// Rebuilds older than all rows or newer than all rows produce no
+	// in-list separator (best effort: no marker).
+	rebuilds := []time.Time{
+		time.Unix(500, 0).UTC(),  // older than oldest
+		time.Unix(9000, 0).UTC(), // newer than newest
+	}
+	got := rebuildSeparatorIndexes(entries, rebuilds)
+	if len(got) != 0 {
+		t.Fatalf("expected no separators, got %v", got)
+	}
+}
+
+func TestRebuildSeparatorIndexesEmptyInputs(t *testing.T) {
+	if got := rebuildSeparatorIndexes(nil, []time.Time{time.Unix(1, 0)}); len(got) != 0 {
+		t.Fatalf("expected none for no entries, got %v", got)
+	}
+	entries := []fs.LedgerEntry{{TS: ts(1000)}}
+	if got := rebuildSeparatorIndexes(entries, nil); len(got) != 0 {
+		t.Fatalf("expected none for no rebuilds, got %v", got)
+	}
+}
+
+func TestRenderMainCallRowsInsertsSeparator(t *testing.T) {
+	m := PropsModel{
+		detailRecent: []fs.LedgerEntry{
+			{TS: ts(3000), Model: "m", Endpoint: "e"},
+			{TS: ts(1000), Model: "m", Endpoint: "e"},
+		},
+		detailRebuilds: []time.Time{time.Unix(2000, 0).UTC()},
+	}
+	rows := m.renderMainCallRows()
+	// header + 2 data rows + 1 separator
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows (header, row, separator, row), got %d:\n%s",
+			len(rows), strings.Join(rows, "\n"))
+	}
+	if !strings.Contains(rows[2], "┈") {
+		t.Fatalf("expected dotted separator on row index 2, got %q", rows[2])
+	}
+	if strings.Contains(rows[1], "┈") || strings.Contains(rows[3], "┈") {
+		t.Fatalf("separator leaked into data rows:\n%s", strings.Join(rows, "\n"))
+	}
+}
+
+func TestRenderMainCallRowsNoSeparatorWithoutRebuild(t *testing.T) {
+	m := PropsModel{
+		detailRecent: []fs.LedgerEntry{
+			{TS: ts(3000), Model: "m", Endpoint: "e"},
+			{TS: ts(1000), Model: "m", Endpoint: "e"},
+		},
+		detailRebuilds: nil,
+	}
+	rows := m.renderMainCallRows()
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows with no separator, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if strings.Contains(r, "┈") {
+			t.Fatalf("unexpected separator without rebuild marker: %q", r)
+		}
+	}
+}
+
+func TestRebuildSeparatorIndexesSkipsMalformedTS(t *testing.T) {
+	entries := []fs.LedgerEntry{
+		{TS: "not-a-time"},
+		{TS: ts(2000)},
+		{TS: ts(1000)},
+	}
+	rebuilds := []time.Time{time.Unix(1500, 0).UTC()} // between idx 1 and 2
+	got := rebuildSeparatorIndexes(entries, rebuilds)
+	if len(got) != 1 || !got[1] {
+		t.Fatalf("expected separator after index 1 only, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add dotted context-reconstruct separators in `/kanban` Ctrl+D agent detail recent-call ledger rows
- use the token ledger's `codex_ws_delta_reason=epoch_reset` row as the primary reconstruct boundary, so the line appears after the low-cache reset call and before the next older pre-reconstruct row
- add a separate dotted `molt` separator using best-effort `psyche_molt` times from `logs/log.sqlite`, with JSONL fallback reading only the last 1000 lines via a backward tail reader (no full scan)

## Validation
- `git diff --check -- .`
- `(cd tui && go test ./internal/fs/ ./internal/sqlitelog/ ./internal/tui/ ./i18n/)`
- `(cd tui && go vet ./internal/fs/ ./internal/sqlitelog/ ./internal/tui/)`
- `(cd tui && make build)`

## Notes
- Also tried `(cd tui && go test ./...)`; it still fails in existing `internal/config` Homebrew install-method tests (`TestManualTUIUpdateHomebrewRoutesThroughUpdater`, `TestDetectTUIInstallMethodHomebrewFromPathAndEnv`) unrelated to this `/kanban` ledger change.