### PR TITLE
Emit lingtai seed in generated init.json

### DIFF
--- a/tui/internal/preset/preset.go
+++ b/tui/internal/preset/preset.go
@@ -1765,7 +1765,7 @@ func GenerateInitJSONWithOpts(p Preset, agentName, dirName, lingtaiDir, globalDi
 		"env_file":        config.EnvFilePath(globalDir),
 		"venv_path":       filepath.Join(globalDir, "runtime", "venv"),
 		"pad":             "",
-		"prompt":          "",
+		"lingtai":         "",
 	}
 
 	// Decide which addons to wire.

--- a/tui/internal/preset/preset_lingtai_seed_test.go
+++ b/tui/internal/preset/preset_lingtai_seed_test.go
@@ -1,0 +1,43 @@
+package preset
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateInitJSONWritesLingtaiSeedNotLegacyPrompt(t *testing.T) {
+	tmp := t.TempDir()
+	lingtaiDir := filepath.Join(tmp, ".lingtai")
+	globalDir := filepath.Join(tmp, ".lingtai-tui")
+	agentDir := filepath.Join(lingtaiDir, "alice")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := GenerateInitJSONWithOpts(DefaultPreset(), "alice", "alice", lingtaiDir, globalDir, DefaultAgentOpts()); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(agentDir, "init.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, present := got["prompt"]; present {
+		t.Fatal("init.json must not write legacy prompt; kernel no longer treats it as lingtai")
+	}
+	if seed, present := got["lingtai"]; !present {
+		t.Fatal("init.json should write the current lingtai seed field")
+	} else if seed != "" {
+		t.Fatalf("lingtai seed = %#v, want empty string", seed)
+	}
+}


### PR DESCRIPTION
## Summary
- change generated `init.json` from legacy `prompt: ""` to current `lingtai: ""`
- add a preset-generator regression test that the generated init omits legacy `prompt` and includes the empty `lingtai` seed

## Context
Jason asked for a separate TUI-side PR after the NoKV bot spawn failure exposed that TUI generation still wrote the old `prompt` key while current kernel schema uses `lingtai` semantics.

## Validation
- `git diff --check`
- `cd tui && go test -count=1 ./internal/preset`

## Local full-suite note
- `cd tui && go test ./...` currently reaches this patch's affected package successfully, but fails in unrelated `internal/config` install-method tests on this machine (`TestManualTUIUpdateHomebrewRoutesThroughUpdater`, `TestDetectTUIInstallMethodHomebrewFromPathAndEnv`) due the local Homebrew/source metadata detection environment.
