### PR TITLE
docs: backfill TUI ANATOMY frontmatter

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -1,3 +1,29 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - portal/ANATOMY.md
+  - docs/ANATOMY.md
+  - README.md
+  - README.zh.md
+  - README.wen.md
+  - RELEASING.md
+  - CLAUDE.md
+  - install.sh
+  - tui/main.go
+  - tui/go.mod
+  - tui/Makefile
+  - portal/main.go
+  - portal/embed.go
+  - portal/go.mod
+  - portal/Makefile
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # lingtai
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill (at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`, ships to `~/.lingtai-tui/utilities/lingtai-tui-anatomy/`). **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues (mail or `discussions/<name>-patch.md`); do not silently fix.

--- a/docs/ANATOMY.md
+++ b/docs/ANATOMY.md
@@ -1,3 +1,24 @@
+---
+related_files:
+  - ANATOMY.md
+  - README.md
+  - README.zh.md
+  - README.wen.md
+  - docs/beginner-work-manual.zh.md
+  - docs/beginner-work-manual-stick-figure.zh.html
+  - docs/known-limitations.md
+  - docs/status.md
+  - docs/graphify.md
+  - docs/i18n-vocab.md
+  - docs/tool-descriptions.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # docs/
 
 Human- and developer-facing documentation for the Go-side LingTai repo.

--- a/portal/ANATOMY.md
+++ b/portal/ANATOMY.md
@@ -1,3 +1,33 @@
+---
+related_files:
+  - ANATOMY.md
+  - tui/ANATOMY.md
+  - portal/internal/api/ANATOMY.md
+  - portal/internal/fs/ANATOMY.md
+  - portal/internal/migrate/ANATOMY.md
+  - portal/main.go
+  - portal/embed.go
+  - portal/Makefile
+  - portal/go.mod
+  - portal/i18n/i18n.go
+  - portal/i18n/en.json
+  - portal/i18n/zh.json
+  - portal/i18n/wen.json
+  - portal/web/package.json
+  - portal/web/src/App.tsx
+  - portal/web/src/Graph.tsx
+  - portal/web/src/BottomBar.tsx
+  - portal/web/src/FilterPanel.tsx
+  - portal/web/src/api.ts
+  - portal/web/src/types.ts
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # portal
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues; do not silently fix.

--- a/portal/internal/api/ANATOMY.md
+++ b/portal/internal/api/ANATOMY.md
@@ -1,3 +1,22 @@
+---
+related_files:
+  - portal/ANATOMY.md
+  - portal/internal/fs/ANATOMY.md
+  - portal/internal/api/server.go
+  - portal/internal/api/handlers.go
+  - portal/internal/api/handlers_test.go
+  - portal/internal/api/replay.go
+  - portal/internal/api/replay_test.go
+  - portal/main.go
+  - portal/embed.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # portal/internal/api
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill. **Coding agents** update this file in the same commit as code changes.

--- a/portal/internal/fs/ANATOMY.md
+++ b/portal/internal/fs/ANATOMY.md
@@ -1,3 +1,32 @@
+---
+related_files:
+  - portal/ANATOMY.md
+  - portal/internal/api/ANATOMY.md
+  - tui/internal/fs/ANATOMY.md
+  - portal/internal/fs/types.go
+  - portal/internal/fs/agent.go
+  - portal/internal/fs/agent_test.go
+  - portal/internal/fs/contacts.go
+  - portal/internal/fs/heartbeat.go
+  - portal/internal/fs/ledger.go
+  - portal/internal/fs/location.go
+  - portal/internal/fs/mail.go
+  - portal/internal/fs/mail_test.go
+  - portal/internal/fs/network.go
+  - portal/internal/fs/network_test.go
+  - portal/internal/fs/reconstruct.go
+  - portal/internal/fs/reconstruct_test.go
+  - portal/internal/fs/resolve.go
+  - portal/internal/fs/resolve_test.go
+  - portal/internal/fs/signal.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # portal/internal/fs — Filesystem Reader (Portal)
 
 > **Maintenance:** see `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`.

--- a/portal/internal/migrate/ANATOMY.md
+++ b/portal/internal/migrate/ANATOMY.md
@@ -1,3 +1,32 @@
+---
+related_files:
+  - portal/ANATOMY.md
+  - tui/internal/migrate/ANATOMY.md
+  - portal/internal/migrate/migrate.go
+  - portal/internal/migrate/migrate_test.go
+  - portal/internal/migrate/collision_repair_test.go
+  - portal/internal/migrate/m001_topology.go
+  - portal/internal/migrate/m002_tape_normalize.go
+  - portal/internal/migrate/m003_character_to_lingtai.go
+  - portal/internal/migrate/m004_relative_addressing.go
+  - portal/internal/migrate/m015_timemachine_gitignore.go
+  - portal/internal/migrate/m026_preset_path_form.go
+  - portal/internal/migrate/m027_strip_media_capabilities.go
+  - portal/internal/migrate/m028_addons_to_mcp.go
+  - portal/internal/migrate/m029_preset_allowed_list.go
+  - portal/internal/migrate/m030_preset_dir_split.go
+  - portal/internal/migrate/m031_drop_legacy_intrinsic_capabilities.go
+  - portal/internal/migrate/m035_remove_brief.go
+  - portal/internal/migrate/m038_agent_init_skills_paths.go
+  - portal/internal/migrate/m039_agent_init_context_preset_repair.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # portal/internal/migrate — Migration Registry (Portal)
 
 > **Maintenance:** see `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`.

--- a/tui/ANATOMY.md
+++ b/tui/ANATOMY.md
@@ -1,3 +1,37 @@
+---
+related_files:
+  - ANATOMY.md
+  - portal/ANATOMY.md
+  - tui/internal/tui/ANATOMY.md
+  - tui/internal/config/ANATOMY.md
+  - tui/internal/fs/ANATOMY.md
+  - tui/internal/migrate/ANATOMY.md
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/processscan/ANATOMY.md
+  - tui/main.go
+  - tui/Makefile
+  - tui/go.mod
+  - tui/i18n/i18n.go
+  - tui/i18n/en.json
+  - tui/i18n/zh.json
+  - tui/i18n/wen.json
+  - tui/list_common.go
+  - tui/list_common_test.go
+  - tui/list_unix.go
+  - tui/list_windows.go
+  - tui/purge_unix.go
+  - tui/purge_windows.go
+  - tui/suspend_unix.go
+  - tui/suspend_windows.go
+  - tui/upgrade.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # tui — the `lingtai-tui` binary
 
 > **Maintenance:** see `lingtai-tui-anatomy` (at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`).

--- a/tui/internal/config/ANATOMY.md
+++ b/tui/internal/config/ANATOMY.md
@@ -1,3 +1,25 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/tui/ANATOMY.md
+  - tui/internal/config/devmode.go
+  - tui/internal/config/devmode_test.go
+  - tui/internal/config/devmode_runtime_test.go
+  - tui/internal/config/global.go
+  - tui/internal/config/global_test.go
+  - tui/internal/config/registry.go
+  - tui/internal/config/venv.go
+  - tui/internal/config/venv_doctor_test.go
+  - tui/main.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # config — bootstrap, venv, global config
 
 > **Maintenance:** see `lingtai-tui-anatomy` (at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`).

--- a/tui/internal/fs/ANATOMY.md
+++ b/tui/internal/fs/ANATOMY.md
@@ -1,3 +1,42 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/tui/ANATOMY.md
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/migrate/ANATOMY.md
+  - portal/internal/fs/ANATOMY.md
+  - tui/internal/fs/types.go
+  - tui/internal/fs/agent.go
+  - tui/internal/fs/agent_test.go
+  - tui/internal/fs/activity.go
+  - tui/internal/fs/activity_test.go
+  - tui/internal/fs/daemon_ledger.go
+  - tui/internal/fs/daemon_ledger_test.go
+  - tui/internal/fs/heartbeat.go
+  - tui/internal/fs/heartbeat_test.go
+  - tui/internal/fs/mail.go
+  - tui/internal/fs/mail_test.go
+  - tui/internal/fs/network.go
+  - tui/internal/fs/network_test.go
+  - tui/internal/fs/session.go
+  - tui/internal/fs/session_rebuild_test.go
+  - tui/internal/fs/session_tail_test.go
+  - tui/internal/fs/signal.go
+  - tui/internal/fs/signal_test.go
+  - tui/internal/fs/resolve.go
+  - tui/internal/fs/resolve_test.go
+  - tui/internal/fs/ledger.go
+  - tui/internal/fs/location.go
+  - tui/internal/fs/project_hash.go
+  - tui/internal/fs/contacts.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # fs
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`. Coding agents update this file in same-commit as code changes.

--- a/tui/internal/migrate/ANATOMY.md
+++ b/tui/internal/migrate/ANATOMY.md
@@ -1,3 +1,33 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/fs/ANATOMY.md
+  - tui/internal/preset/ANATOMY.md
+  - tui/internal/processscan/ANATOMY.md
+  - portal/internal/migrate/ANATOMY.md
+  - tui/internal/migrate/migrate.go
+  - tui/internal/migrate/migrate_test.go
+  - tui/internal/migrate/collision_repair_test.go
+  - tui/internal/migrate/m001_topology.go
+  - tui/internal/migrate/m015_timemachine_gitignore.go
+  - tui/internal/migrate/m026_preset_path_form.go
+  - tui/internal/migrate/m029_preset_allowed_list.go
+  - tui/internal/migrate/m030_preset_dir_split.go
+  - tui/internal/migrate/m033_strip_codex_api_key_env.go
+  - tui/internal/migrate/m034_library_skills_caps.go
+  - tui/internal/migrate/m035_remove_brief.go
+  - tui/internal/migrate/m036_sqlite_log_backfill.go
+  - tui/internal/migrate/m037_preset_skills_paths.go
+  - tui/internal/migrate/m038_agent_init_skills_paths.go
+  - tui/internal/migrate/m039_agent_init_context_preset_repair.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # migrate (TUI)
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`. Coding agents update this file in same-commit as code changes. **Cross-binary contract:** when bumping `CurrentVersion`, also bump `portal/internal/migrate/migrate.go`.

--- a/tui/internal/preset/ANATOMY.md
+++ b/tui/internal/preset/ANATOMY.md
@@ -1,3 +1,30 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/config/ANATOMY.md
+  - tui/internal/fs/ANATOMY.md
+  - tui/internal/migrate/ANATOMY.md
+  - tui/internal/tui/ANATOMY.md
+  - tui/internal/preset/preset.go
+  - tui/internal/preset/preset_test.go
+  - tui/internal/preset/recipe_apply.go
+  - tui/internal/preset/recipe_apply_test.go
+  - tui/internal/preset/recipes.go
+  - tui/internal/preset/recipes_test.go
+  - tui/internal/preset/rehydrate.go
+  - tui/internal/preset/state.go
+  - tui/internal/preset/state_test.go
+  - tui/internal/preset/preset_allowed_revoke_test.go
+  - tui/internal/preset/preset_propagate_test.go
+  - tui/internal/preset/preset_agent_json_merge_test.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # preset
 
 > **Maintenance:** see the `lingtai-tui-anatomy` skill at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`. Coding agents update this file in same-commit as code changes.

--- a/tui/internal/processscan/ANATOMY.md
+++ b/tui/internal/processscan/ANATOMY.md
@@ -1,3 +1,19 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/migrate/ANATOMY.md
+  - tui/internal/processscan/check.go
+  - tui/internal/process/check.go
+  - tui/internal/process/check_test.go
+  - tui/internal/migrate/m036_sqlite_log_backfill.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # processscan
 
 > **Maintenance:** see `lingtai-tui-anatomy` (at `~/.lingtai-tui/utilities/lingtai-tui-anatomy/SKILL.md`). Update this file in the same commit as code changes.

--- a/tui/internal/tui/ANATOMY.md
+++ b/tui/internal/tui/ANATOMY.md
@@ -1,3 +1,53 @@
+---
+related_files:
+  - tui/ANATOMY.md
+  - tui/internal/config/ANATOMY.md
+  - tui/internal/fs/ANATOMY.md
+  - tui/internal/preset/ANATOMY.md
+  - tui/main.go
+  - tui/internal/tui/app.go
+  - tui/internal/tui/app_test.go
+  - tui/internal/tui/layout.go
+  - tui/internal/tui/layout_test.go
+  - tui/internal/tui/auto_refresh.go
+  - tui/internal/tui/firstrun.go
+  - tui/internal/tui/firstrun_test.go
+  - tui/internal/tui/mail.go
+  - tui/internal/tui/props.go
+  - tui/internal/tui/library.go
+  - tui/internal/tui/doctor.go
+  - tui/internal/tui/doctor_intrinsic.go
+  - tui/internal/tui/preset_editor.go
+  - tui/internal/tui/preset_library.go
+  - tui/internal/tui/settings.go
+  - tui/internal/tui/addon.go
+  - tui/internal/tui/login.go
+  - tui/internal/tui/system.go
+  - tui/internal/tui/codex.go
+  - tui/internal/tui/codex_entries.go
+  - tui/internal/tui/mailbox.go
+  - tui/internal/tui/mailbox_entries.go
+  - tui/internal/tui/daemons.go
+  - tui/internal/tui/notification.go
+  - tui/internal/tui/goal.go
+  - tui/internal/tui/projects.go
+  - tui/internal/tui/mdviewer.go
+  - tui/internal/tui/help.go
+  - tui/internal/tui/input.go
+  - tui/internal/tui/palette.go
+  - tui/internal/tui/styles.go
+  - tui/internal/tui/oauth.go
+  - tui/internal/tui/claude_auth.go
+  - tui/internal/tui/detect.go
+  - tui/internal/tui/toolcall_display.go
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+
 # tui/internal/tui — Bubble Tea screens
 
 > **Maintenance:** see `lingtai-tui-anatomy` (at `tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md`).


### PR DESCRIPTION
## Summary
- prepend the new ANATOMY frontmatter contract to all 13 main-worktree `ANATOMY.md` files
- add repo-relative `related_files` for source/test/config files and meaningful neighboring `ANATOMY.md` links
- keep anatomy-to-anatomy links bidirectional and avoid isolated/complete graphs

## Validation
- `git diff --check`
- parent frontmatter/path/graph validation: 13 ANATOMY files, 24 undirected anatomy edges, all paths valid, all anatomy edges bidirectional, no isolated nodes, not complete graph

## Notes
- Body text is intentionally unchanged in this PR. Existing drift hazards (migration count prose, folder-relative citation style, LOC notes) are reported for follow-up rather than fixed here.
