### PR TITLE
Add last_changed_at to bundled skills

### DIFF
--- a/tui/internal/preset/skill_metadata_test.go
+++ b/tui/internal/preset/skill_metadata_test.go
@@ -1,0 +1,55 @@
+package preset
+
+import (
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+var lastChangedAtRE = regexp.MustCompile(`(?m)^last_changed_at:\s*"?([^"\n]+)"?\s*$`)
+
+func TestBundledSkillsHaveLastChangedAt(t *testing.T) {
+	count := 0
+	err := fs.WalkDir(skillsFS, "skills", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, "/SKILL.md") {
+			return nil
+		}
+		count++
+		data, err := fs.ReadFile(skillsFS, path)
+		if err != nil {
+			return err
+		}
+		body := string(data)
+		if !strings.HasPrefix(body, "---\n") {
+			t.Errorf("%s missing YAML frontmatter", path)
+			return nil
+		}
+		end := strings.Index(body[4:], "\n---")
+		if end < 0 {
+			t.Errorf("%s missing closing YAML frontmatter delimiter", path)
+			return nil
+		}
+		frontmatter := body[:4+end]
+		match := lastChangedAtRE.FindStringSubmatch(frontmatter)
+		if match == nil {
+			t.Errorf("%s missing last_changed_at frontmatter", path)
+			return nil
+		}
+		value := strings.TrimSpace(match[1])
+		if _, err := time.Parse(time.RFC3339, value); err != nil {
+			t.Errorf("%s has invalid last_changed_at %q: %v", path, value, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 52 {
+		t.Fatalf("checked %d bundled skill SKILL.md files, want 52", count)
+	}
+}

--- a/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/SKILL.md
@@ -9,6 +9,7 @@ description: >
   review-ready, or steward a new skill. This is for developers and contributors;
   for end-user lessons, use tutorial-guide.
 version: 2.6.0
+last_changed_at: "2026-06-28T22:46:25-07:00"
 ---
 
 # LingTai Developer Guide

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/architecture/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/architecture/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-architecture
 description: >
   Nested lingtai-dev-guide reference for the project architecture: Go TUI/portal monorepo, Python kernel, MCP addon repos, filesystem IPC, and where per-project/per-machine state lives.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:05:51-07:00"
 ---
 
 # Architecture

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/cache-hit-rate/SKILL.md
@@ -11,6 +11,7 @@ description: >
   effective prompt caching has been recently, or to diagnose a cache-hit-rate
   drop after a refresh/affinity/cache-key change.
 version: 1.0.0
+last_changed_at: "2026-06-21T20:24:21-05:00"
 ---
 
 # Cache Hit Rate

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/contributing/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-contributing
 description: >
   Nested lingtai-dev-guide reference for contribution workflow: issue/worktree/PR discipline, stale-worktree cleanup, daemon decomposition, portfolio sweeps, repo-specific build/test commands, skill changes, and anatomy maintenance.
 version: 1.1.0
+last_changed_at: "2026-06-24T12:37:00-07:00"
 ---
 
 # Contributing to LingTai

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/debug-troubleshoot/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/debug-troubleshoot/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-debug-troubleshoot
 description: >
   Nested lingtai-dev-guide reference for diagnosing LingTai failures: agent process state, OOM/crashes, avatar spawn issues, post-molt memory loss, mail delivery, scheduled messages, tool timeouts, and escalation.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:05:51-07:00"
 ---
 
 # LingTai Debug & Troubleshoot Reference

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/gotchas/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-gotchas
 description: >
   Nested lingtai-dev-guide reference for known implementation footguns: Bubble Tea v2 paste, textarea theming, dev-mode rebuilds, editable installs, migrations, localization, authorization gates, config conventions, and rebuild-gate test false-passes.
 version: 1.1.0
+last_changed_at: "2026-06-20T01:30:35-07:00"
 ---
 
 # Gotchas and Known Pitfalls

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/network-governance/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/network-governance/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-network-governance
 description: >
   Nested lingtai-dev-guide reference for avatar network governance: core rules, health monitoring, CPR, watchdog cadence, role documentation, delegation patterns, workspaces, and peer communication.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:05:51-07:00"
 ---
 
 # Avatar Network Governance — Reference Card

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/pr-review-deliverables/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/pr-review-deliverables/SKILL.md
@@ -7,6 +7,7 @@ description: >
   source-labeled deliverables with syntax/validation checks, and maintainer
   authorization boundaries for opening, editing, and merging PRs.
 version: 1.0.0
+last_changed_at: "2026-06-13T23:25:20-07:00"
 ---
 
 # PR Review & Deliverables

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
@@ -7,6 +7,7 @@ description: >
   release log, website release-log/blog drafting, and the reusable release blog
   template.
 version: 1.2.0
+last_changed_at: "2026-06-26T02:17:42-07:00"
 ---
 
 # Release Workflow

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-releasing
 description: >
   Compact lingtai-dev-guide release overview: when you are doing a release, the maintainer-authorization boundary, the version scheme, and a pointer to release-workflow for the full TUI/Portal + kernel publishing checklist, GitHub/PyPI/Homebrew steps, the required HTML release log, and the website release blog.
 version: 2.0.0
+last_changed_at: "2026-06-14T00:28:34-07:00"
 ---
 
 # Releasing — Overview

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/runtime-self-check/SKILL.md
@@ -10,6 +10,7 @@ description: >
   runtime objects (services/adapters/caches) were actually rebuilt after a
   refresh, not just that new source is imported.
 version: 1.2.0
+last_changed_at: "2026-06-24T15:24:47-07:00"
 ---
 
 # Runtime Self-Check

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/security-audit/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/security-audit/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-security-audit
 description: >
   Nested lingtai-dev-guide reference for security audits: secret scanning, file permissions, MCP config, communication security, data exposure, agent permission review, severity classification, and report format.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:05:51-07:00"
 ---
 
 # LingTai Security Audit Reference

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/setup/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/setup/SKILL.md
@@ -3,6 +3,7 @@ name: dev-guide-setup
 description: >
   Nested lingtai-dev-guide reference for local developer environment setup: cloning repos, building TUI/portal, dev-mode symlinks, editable kernel install, MCP addon setup, and verification.
 version: 1.0.0
+last_changed_at: "2026-06-12T15:01:39-07:00"
 ---
 
 # Development Environment Setup

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/skill-stewardship/SKILL.md
@@ -8,6 +8,7 @@ description: >
   paths and human-specific details, a lightweight pre-publish benchmark/checklist,
   grooming shared-library candidates, and PR-ready skill cleanup.
 version: 1.0.0
+last_changed_at: "2026-06-29T08:41:45Z"
 ---
 
 # Skill Stewardship
@@ -107,9 +108,12 @@ private, machine-, or person-specific details must go.
 Before a skill ships, run a quick "pre-flight" — a benchmark/checklist, not a
 heavy framework:
 
-- [ ] YAML frontmatter parses; has `name` (letters/numbers/hyphens) and a
+- [ ] YAML frontmatter parses; has `name` (letters/numbers/hyphens), a
       `description` that starts with "Use when…" and lists triggers only (no
-      workflow summary).
+      workflow summary), and for LingTai-maintained skills a `last_changed_at`
+      ISO 8601 timestamp. For metadata-only backfills, initialize it from
+      `git log -1 --format=%cI -- path/to/SKILL.md`; for substantive skill
+      edits, update it in the same commit.
 - [ ] Document structure is scannable: overview/core principle, when-to-use,
       steps, related references.
 - [ ] Declared dependencies/cross-linked skills exist and are named correctly.

--- a/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/SKILL.md
@@ -2,6 +2,7 @@
 name: lingtai-issue-report
 description: Protocol router for reporting bugs, stale info, missing capabilities, or design issues you spot in any LingTai skill, capability, preset, or system behavior. Enter through this router, then load the one nested reference you need — evidence-checklist (when to report, what evidence to collect, secret hygiene), report-template (the report body/title structure), or filing-flow (human consent, the gh CLI path, and the paste-ready fallback). You always assemble a structured report and ask the human for permission before filing.
 version: 1.4.0
+last_changed_at: "2026-06-02T02:43:15-07:00"
 ---
 
 # Reporting LingTai Issues

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/evidence-checklist/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/evidence-checklist/SKILL.md
@@ -2,6 +2,7 @@
 name: issue-report-evidence-checklist
 description: Nested lingtai-issue-report reference for deciding when an observation is worth reporting, what evidence to collect, and how to keep secrets out of a report. Read this first, while the problem is fresh, before drafting the report body.
 version: 1.0.0
+last_changed_at: "2026-06-02T02:43:15-07:00"
 ---
 
 # Issue report — evidence checklist

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/filing-flow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/filing-flow/SKILL.md
@@ -2,6 +2,7 @@
 name: issue-report-filing-flow
 description: Nested lingtai-issue-report reference for the filing decision — the always-required human consent boundary, the read-only gh probe, Path A (direct gh filing) and Path B (paste-ready handoff), token hygiene, and proactive surfacing. Read this once the report is drafted and you are deciding how it gets filed.
 version: 1.0.0
+last_changed_at: "2026-06-02T02:43:15-07:00"
 ---
 
 # Issue report — filing flow

--- a/tui/internal/preset/skills/lingtai-issue-report/reference/report-template/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-issue-report/reference/report-template/SKILL.md
@@ -2,6 +2,7 @@
 name: issue-report-report-template
 description: Nested lingtai-issue-report reference for the report skeleton — subject/title format, the structured body sections (what's wrong, where, reproduction, expected vs actual, severity, suggested fix), and how to send it via LingTai email or the human's active channel. Read this when you are ready to assemble the report.
 version: 1.0.0
+last_changed_at: "2026-06-02T02:43:15-07:00"
 ---
 
 # Issue report — report template

--- a/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/SKILL.md
@@ -2,6 +2,7 @@
 name: lingtai-portal-guide
 description: Reference router for LingTai portal (lingtai-portal) internals. Read this to understand portal startup/opening, .portal/ files, topology/replay APIs, network response shape, and lifecycle/recording behavior. Useful when the human asks about visualization, network history, or the portal.
 version: 1.1.0
+last_changed_at: "2026-06-02T01:46:45-07:00"
 ---
 
 # Portal Guide

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/lifecycle-and-recording/SKILL.md
@@ -2,6 +2,7 @@
 name: portal-guide-lifecycle-and-recording
 description: Nested lingtai-portal-guide reference for portal lifecycle-state interpretation, heartbeat staleness, recording, and tape reconstruction behavior.
 version: 1.0.0
+last_changed_at: "2026-06-02T01:46:45-07:00"
 ---
 
 # Lifecycle and recording

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/overview/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/overview/SKILL.md
@@ -2,6 +2,7 @@
 name: portal-guide-overview
 description: Nested lingtai-portal-guide reference for portal purpose, opening the browser view, and the `.portal/` directory layout.
 version: 1.0.0
+last_changed_at: "2026-06-02T01:46:45-07:00"
 ---
 
 # Portal overview

--- a/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-portal-guide/reference/topology-and-api/SKILL.md
@@ -2,6 +2,7 @@
 name: portal-guide-topology-and-api
 description: Nested lingtai-portal-guide reference for topology tape frames, replay chunks, portal API endpoints, and the Network JSON response.
 version: 1.0.0
+last_changed_at: "2026-06-02T01:46:45-07:00"
 ---
 
 # Topology and API

--- a/tui/internal/preset/skills/lingtai-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/SKILL.md
@@ -22,6 +22,7 @@ description: >
   live system (those go through the kernel's writes to the agent's
   working directory, not through a recipe round-trip).
 version: 3.2.0
+last_changed_at: "2026-06-02T00:08:39-07:00"
 ---
 
 # lingtai-recipe: Recipes and How to Publish Them

--- a/tui/internal/preset/skills/lingtai-recipe/reference/export-recipe/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/reference/export-recipe/SKILL.md
@@ -5,6 +5,7 @@ description: >
   a live network or methodology: scope disambiguation, human-in-the-loop metadata
   collection, bundle authoring, validation, git initialization, and handoff.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:08:39-07:00"
 ---
 
 # Exporting a Recipe

--- a/tui/internal/preset/skills/lingtai-recipe/reference/recipe-format/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-recipe/reference/recipe-format/SKILL.md
@@ -6,6 +6,7 @@ description: >
   sibling mechanics, locale fallback, validator checks, hand-authored recipes,
   testing, and publishing.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:08:39-07:00"
 ---
 
 # Recipe Format Reference

--- a/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-anatomy/SKILL.md
@@ -50,6 +50,7 @@ description: >
       separate tree with its own anatomy. Cross-repo references are
       narrative only ("the kernel writes this file; we read it").
 version: 0.1.0
+last_changed_at: "2026-06-24T01:56:50-07:00"
 ---
 
 # LingTai (Go) Anatomy — the Convention

--- a/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tui-help/SKILL.md
@@ -9,6 +9,7 @@ description: >
   matches the current UI language.
 version: 1.0.0
 tags: [tui, help, slash-commands, reference, palette, lingtai-tui]
+last_changed_at: "2026-06-09T04:21:55-07:00"
 ---
 
 # lingtai-tui help — canonical TUI reference

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/SKILL.md
@@ -6,6 +6,7 @@ description: >
   capabilities, operations, addons, and graduation. Invoke this skill when the
   human is ready to begin or continue the tutorial.
 version: 2.0.1
+last_changed_at: "2026-06-02T00:34:40-07:00"
 ---
 
 # Tutorial Guide — Router

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/agent-runtime/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/agent-runtime/SKILL.md
@@ -3,6 +3,7 @@ name: tutorial-guide-agent-runtime
 description: >
   Nested tutorial-guide reference for lessons 4–6: init.json, lingtai-agent run, heartbeat and signal files, TUI runtime wrapping, and system prompt identity.
 version: 1.0.0
+last_changed_at: "2026-06-28T00:01:05-07:00"
 ---
 
 # Tutorial Guide — Agent Runtime Lessons

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/capabilities/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/capabilities/SKILL.md
@@ -3,6 +3,7 @@ name: tutorial-guide-capabilities
 description: >
   Nested tutorial-guide reference for lesson 9: avatars, network exercises, and dynamic capability demonstrations.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:34:40-07:00"
 ---
 
 # Tutorial Guide — Capabilities Lesson

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/communication/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/communication/SKILL.md
@@ -3,6 +3,7 @@ name: tutorial-guide-communication
 description: >
   Nested tutorial-guide reference for lesson 7: filesystem email, message flow, and external addon bridges.
 version: 1.0.0
+last_changed_at: "2026-06-12T13:46:46-07:00"
 ---
 
 # Tutorial Guide — Communication Lesson

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/memory-and-molt/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/memory-and-molt/SKILL.md
@@ -3,6 +3,7 @@ name: tutorial-guide-memory-and-molt
 description: >
   Nested tutorial-guide reference for lesson 8: intrinsics, memory layers, molt, charge, stamina, and lifecycle continuity.
 version: 1.0.0
+last_changed_at: "2026-06-08T22:45:25-07:00"
 ---
 
 # Tutorial Guide — Memory and Molt Lesson

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/operations-and-graduation/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/operations-and-graduation/SKILL.md
@@ -3,6 +3,7 @@ name: tutorial-guide-operations-and-graduation
 description: >
   Nested tutorial-guide reference for lessons 10–12: TUI commands, lifecycle exercises, addons, external connections, and graduation.
 version: 1.0.0
+last_changed_at: "2026-06-02T00:34:40-07:00"
 ---
 
 # Tutorial Guide — Operations and Graduation Lessons

--- a/tui/internal/preset/skills/lingtai-tutorial-guide/reference/orientation/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-tutorial-guide/reference/orientation/SKILL.md
@@ -3,6 +3,7 @@ name: tutorial-guide-orientation
 description: >
   Nested tutorial-guide reference for lessons 1–3: welcome, live architecture discovery, global directory, project directory, and agent working directory.
 version: 1.0.0
+last_changed_at: "2026-06-10T19:45:10-07:00"
 ---
 
 # Tutorial Guide — Orientation Lessons

--- a/tui/internal/preset/skills/swiss-knife/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/SKILL.md
@@ -18,6 +18,7 @@ description: >
   `reference/<name>/SKILL.md`.
 version: 2.4.0
 tags: [utilities, umbrella, toolkit, nested-skill]
+last_changed_at: "2026-06-23T17:01:03-07:00"
 ---
 
 # Swiss Knife — Utility Toolkit Router

--- a/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/academic-research/SKILL.md
@@ -14,6 +14,7 @@ description: >
 version: 3.0.0
 allowed-tools: Bash(python3 *) Bash(curl *) Bash(pip *) Bash(pip3 *)
 tags: [academic, research, arxiv, crossref, openalex, semantic-scholar, core, pubmed, unpaywall, doi, pdf, citation, pipeline, europe-pmc, nasa-ads, inspire-hep, nested-skill]
+last_changed_at: "2026-06-08T20:23:41-07:00"
 ---
 
 # Academic Research

--- a/tui/internal/preset/skills/swiss-knife/reference/dj/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/dj/SKILL.md
@@ -3,6 +3,7 @@ name: dj
 description: Nested swiss-knife reference for composing one music track that resonates with a project journal entry, on demand. Walks the user's saved presets to find a usable media-creation provider (MiniMax, etc.), reads the journal at ~/.lingtai-tui/brief/projects/<hash>/journal.md, picks a genre that fits the day, generates the audio, and saves it next to the journal under music/ with an index entry. Read this when the user asks for music for a journal day, a project's vibe, session mood, or a specific generated genre — decline honestly when no usable provider is configured.
 version: 1.1.0
 tags: [media-creation, music, journal, on-demand]
+last_changed_at: "2026-06-02T02:10:59-07:00"
 ---
 
 # DJ — On-demand journal-track composer

--- a/tui/internal/preset/skills/swiss-knife/reference/find-something-to-do/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/find-something-to-do/SKILL.md
@@ -2,6 +2,7 @@
 name: find-something-to-do
 description: "Nested swiss-knife reference for idle curiosity practice. When you're idle and the water is flat — two doors. One leads to quiet noticing. The other leads to poking things until they squeak. Both are real. Neither is a productivity tool. Read this when no human is waiting and you want an invitation to emerge."
 version: 0.2.0
+last_changed_at: "2026-06-02T02:10:59-07:00"
 ---
 
 # Find Something to Do

--- a/tui/internal/preset/skills/swiss-knife/reference/headless-bot/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/headless-bot/SKILL.md
@@ -9,6 +9,7 @@ description: >
   the Telegram MCP case.
 version: 1.1.0
 tags: [utilities, bot, telegram, mcp, headless, bootstrap]
+last_changed_at: "2026-06-01T02:00:30-07:00"
 ---
 
 # Headless Bot Project

--- a/tui/internal/preset/skills/swiss-knife/reference/html-report/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/html-report/SKILL.md
@@ -11,6 +11,7 @@ description: >
   especially anything containing equations.
 version: 1.0.0
 tags: [html, report, mathjax, deliverable, artifact]
+last_changed_at: "2026-05-31T21:29:38-07:00"
 ---
 
 # HTML Report — Standalone Artifacts for Humans

--- a/tui/internal/preset/skills/swiss-knife/reference/listen/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/listen/SKILL.md
@@ -9,6 +9,7 @@ description: >
   *creating* music or audio, use the sibling `minimax-cli` reference (or `dj` for journal-inspired music) instead.
 version: 1.0.0
 tags: [audio, transcribe, whisper, librosa, music-analysis, nested-skill]
+last_changed_at: "2026-06-02T11:16:04-07:00"
 ---
 
 # listen

--- a/tui/internal/preset/skills/swiss-knife/reference/minimax-cli/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/minimax-cli/SKILL.md
@@ -8,6 +8,7 @@ description: >
   or one-shot shell vision.
 version: 2.1.0
 tags: [manual, cli, minimax, mmx, image, video, music, speech, tts, vision, media-generation]
+last_changed_at: "2026-06-02T11:16:04-07:00"
 ---
 
 # minimax-cli

--- a/tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/preset-health/SKILL.md
@@ -12,6 +12,7 @@ description: >
   the human exactly which one-line change to confirm.
 version: 1.0.0
 tags: [presets, health-check, diagnostics, read-only, connectivity]
+last_changed_at: "2026-06-08T19:56:00-07:00"
 ---
 
 # Preset Health Check (read-only)

--- a/tui/internal/preset/skills/swiss-knife/reference/token-usage/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/token-usage/SKILL.md
@@ -5,6 +5,7 @@ description: >
   Use for model cost reports, cache rates, budget/burn analysis, and tools-per-API-call trends across LingTai logs.
 version: 2.1.0
 tags: [python, cost, tokens, litellm, budget, tools, agents]
+last_changed_at: "2026-06-23T17:01:03-07:00"
 ---
 
 # Token Usage, Cost, and Agentic-Intensity Reports v2

--- a/tui/internal/preset/skills/swiss-knife/reference/vision/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/vision/SKILL.md
@@ -11,6 +11,7 @@ description: >
   applies.
 version: 1.0.0
 tags: [vision, image, ocr, vlm, decision-tree, nested-skill]
+last_changed_at: "2026-06-02T11:16:04-07:00"
 ---
 
 # vision (router)

--- a/tui/internal/preset/skills/swiss-knife/reference/xiaomi-mimo/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/xiaomi-mimo/SKILL.md
@@ -23,6 +23,7 @@ description: >
   / music *generation* — that's `minimax-cli`. MiMo ships **no MCP
   servers**; everything is HTTPS chat-completions.
 version: 2.0.0
+last_changed_at: "2026-05-31T21:29:38-07:00"
 ---
 
 # xiaomi-mimo

--- a/tui/internal/preset/skills/swiss-knife/reference/zhipu-coding-plan/SKILL.md
+++ b/tui/internal/preset/skills/swiss-knife/reference/zhipu-coding-plan/SKILL.md
@@ -9,6 +9,7 @@ description: >
   vs BigModel mainland), and where the live docs are. MCP server
   registration is owned by the `mcp-manual` skill (kernel capability).
 version: 1.0.0
+last_changed_at: "2026-05-31T21:29:38-07:00"
 ---
 
 # zhipu-coding-plan

--- a/tui/internal/preset/skills/textbook-distillation/SKILL.md
+++ b/tui/internal/preset/skills/textbook-distillation/SKILL.md
@@ -14,6 +14,7 @@ description: >
   or for one-off factual lookups (just answer those directly).
 version: 1.0.0
 tags: [learning, study, textbook, lecture-notes, html, curriculum, self-paced]
+last_changed_at: "2026-06-08T22:45:29-07:00"
 ---
 
 # Textbook Distillation — Self-Paced Learning Tracks

--- a/tui/internal/preset/skills/web-browsing/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/SKILL.md
@@ -7,6 +7,7 @@ description: >
   search. Read this router when the script fails, you need site/tier routing,
   or you are composing a multi-step web/research pipeline.
 version: 3.1.0
+last_changed_at: "2026-06-01T01:47:09-07:00"
 ---
 
 # web-browsing — Router

--- a/tui/internal/preset/skills/web-browsing/reference/maintenance-bundles/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/reference/maintenance-bundles/SKILL.md
@@ -5,6 +5,7 @@ description: >
   dirty-first testing, bundled JSON asset files, deep-dive reference files, and the
   explicit decision flowchart.
 version: 1.0.0
+last_changed_at: "2026-06-01T01:47:09-07:00"
 ---
 
 # Web Browsing Maintenance and Assets Reference

--- a/tui/internal/preset/skills/web-browsing/reference/routing-and-sites/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/reference/routing-and-sites/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Nested web-browsing reference for auto-tier decisions, per-site tier
   recommendations, known limitations/gotchas, and real-time data endpoints.
 version: 1.0.0
+last_changed_at: "2026-06-01T01:47:09-07:00"
 ---
 
 # Web Browsing Routing and Site Reference

--- a/tui/internal/preset/skills/web-browsing/reference/tier-quick-refs/SKILL.md
+++ b/tui/internal/preset/skills/web-browsing/reference/tier-quick-refs/SKILL.md
@@ -5,6 +5,7 @@ description: >
   Tier 1 APIs, Tier 1.5 Trafilatura, Tier 2 BeautifulSoup, Tier 3 Playwright
   stealth, Tier 4 Jina/Firecrawl, and Tier 5 AI-native search.
 version: 1.0.0
+last_changed_at: "2026-06-01T01:47:09-07:00"
 ---
 
 # Web Browsing Tier Quick References


### PR DESCRIPTION
## Summary
- backfill `last_changed_at` on all 52 embedded preset utility `SKILL.md` files under `tui/internal/preset/skills/`
- update `lingtai-dev-guide` skill-stewardship checklist with the new LingTai-maintained skill timestamp rule
- add a bundled-skill metadata test that enforces YAML frontmatter and parseable RFC3339 `last_changed_at` values

## Timestamp source
- Metadata-only backfills use `git log -1 --format=%cI -- <path>`.
- The substantively edited skill-stewardship reference uses the current edit timestamp.
- `tui/internal/tui/SKILL.md` is not changed because it is an internal model-list/bookkeeping file without YAML skill frontmatter, not an embedded preset utility skill.

## Validation
- custom parser over `tui/internal/preset/skills/**/SKILL.md` → `52/52`
- `git diff --check`
- `git diff --cached --check`
- `cd tui && go test ./internal/preset`
- `cd tui && go test ./...`

## Local explainer
- `reports/tui-skill-last-changed-at-pr-20260629.html`
