### PR TITLE
Fix bundled skill timestamp count

### DIFF
--- a/tui/internal/preset/skill_metadata_test.go
+++ b/tui/internal/preset/skill_metadata_test.go
@@ -49,7 +49,7 @@ func TestBundledSkillsHaveLastChangedAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 52 {
-		t.Fatalf("checked %d bundled skill SKILL.md files, want 52", count)
+	if count != 53 {
+		t.Fatalf("checked %d bundled skill SKILL.md files, want 53", count)
 	}
 }

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/repo-watch/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/repo-watch/SKILL.md
@@ -7,6 +7,7 @@ description: >
   idempotent repository-health digest. This is a nested lingtai-dev-guide
   reference, not a top-level intrinsic skill.
 version: 1.0.0
+last_changed_at: "2026-06-29T01:44:32-07:00"
 ---
 
 # LingTai Repo Watch


### PR DESCRIPTION
## Summary
- add `last_changed_at` to the newly merged `lingtai-dev-guide/reference/repo-watch` bundled skill
- update the bundled skill metadata test count from 52 to 53

## Why
PR #462 was created from an older `origin/main`. After #462 merged, current `main` also contained `skills/lingtai-dev-guide/reference/repo-watch/SKILL.md`, which had no `last_changed_at`, so the new metadata test failed on the merged main during local rebuild.

## Validation
- custom parser over `tui/internal/preset/skills/**/SKILL.md` → `53/53`
- `git diff --check`
- `git diff --cached --check`
- `cd tui && go test ./internal/preset`
- `cd tui && go test ./...`
