### PR TITLE
Tidy dev guide skill metadata

### DIFF
--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: >
   release log, website release-log/blog drafting, and the reusable release blog
   template.
 version: 1.2.0
-last_changed_at: "2026-06-26T02:17:42-07:00"
+last_changed_at: "2026-06-29T02:13:00-07:00"
 ---
 
 # Release Workflow
@@ -335,7 +335,7 @@ At minimum, the HTML release log must include:
 
 Format rules:
 
-- **Self-contained:** inline CSS, no remote fonts/scripts/assets, no dependency
+- **Self-contained:** inline CSS, no remote fonts, scripts, or assets; no dependency
   on local paths.
 - **Shareable:** write for an external reader, not an agent; no secrets, no raw
   private paths (public repo paths are fine), no internal message IDs.

--- a/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
+++ b/tui/internal/preset/skills/lingtai-dev-guide/reference/releasing/SKILL.md
@@ -3,7 +3,7 @@ name: dev-guide-releasing
 description: >
   Compact lingtai-dev-guide release overview: when you are doing a release, the maintainer-authorization boundary, the version scheme, and a pointer to release-workflow for the full TUI/Portal + kernel publishing checklist, GitHub/PyPI/Homebrew steps, the required HTML release log, and the website release blog.
 version: 2.0.0
-last_changed_at: "2026-06-14T00:28:34-07:00"
+last_changed_at: "2026-06-29T02:13:00-07:00"
 ---
 
 # Releasing — Overview
@@ -51,6 +51,6 @@ blog must land first.
 - final public-surface verification and the maintainer report;
 - the **required shareable HTML release log** (per-release, self-contained) and
   its validation, plus `../release-html-log-template.html`;
-- the **website release blog** and its reusable `../release-workflow/assets/release-blog-template.md`.
+- the **website release blog** and the reusable `release-blog-template.md` asset documented in `reference/release-workflow/SKILL.md`.
 
 Start there for any real publish operation.


### PR DESCRIPTION
## Summary
- add `last_changed_at` to the new nested `dev-guide-repo-watch` skill
- rephrase two lingtai-dev-guide release references that the skill validator interprets as broken root-relative `scripts/` / `assets/` paths
- update the bundled-skill metadata test count for the newly added nested SKILL.md

## Validation
- `python3 .../skills/scripts/validate.py --require-last-changed-at tui/internal/preset/skills/lingtai-dev-guide`
- `python3 .../skills/scripts/validate.py --require-last-changed-at tui/internal/preset/skills/lingtai-dev-guide/reference/release-workflow`
- `python3 .../skills/scripts/validate.py --require-last-changed-at tui/internal/preset/skills/lingtai-dev-guide/reference/releasing`
- `python3 .../skills/scripts/validate.py --require-last-changed-at tui/internal/preset/skills/lingtai-dev-guide/reference/repo-watch`
- `git diff --check`
- `cd tui && go test -count=1 ./internal/preset`

## Notes
This is the follow-up cleanup requested after moving `lingtai-repo-watch` under `lingtai-dev-guide`. It intentionally keeps broader non-dev-guide skill-health findings out of scope.
