### PR TITLE
Fix Codex OAuth health check refresh semantics

### DIFF
--- a/tui/internal/tui/login.go
+++ b/tui/internal/tui/login.go
@@ -243,17 +243,15 @@ func checkHealth(e loginEntry) loginHealthMsg {
 		out.Detail = detail
 		return out
 	}
+
+	if e.IsOAuth {
+		return checkCodexOAuthHealth(e, mk)
+	}
 	if e.BaseURL == "" || e.Key == "" {
 		return mk(loginInvalid, "no endpoint")
 	}
 
-	var url string
-	if e.IsOAuth {
-		url = strings.TrimRight(e.BaseURL, "/") + "/codex/models?client_version=1.0.0"
-	} else {
-		url = strings.TrimRight(e.BaseURL, "/") + "/models"
-	}
-
+	url := strings.TrimRight(e.BaseURL, "/") + "/models"
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -276,6 +274,54 @@ func checkHealth(e loginEntry) loginHealthMsg {
 	default:
 		return mk(loginError, fmt.Sprintf("HTTP %d", resp.StatusCode))
 	}
+}
+
+// refreshCodexTokensForLoginHealth is a test seam for the /setup credentials
+// Codex health check. Production uses the same refreshCodexTokens implementation
+// as startup validation; tests override it so no real OAuth/token endpoint is hit.
+var refreshCodexTokensForLoginHealth = refreshCodexTokens
+
+// checkCodexOAuthHealth treats the refresh-token grant as the source of truth.
+// A short-lived access_token can expire while the TUI is open; probing
+// /codex/models with that stale access token makes /setup credentials claim
+// "invalid credentials" even though the runtime can still refresh and run.
+// Only a malformed token file or refresh-token revocation should be shown as a
+// re-login condition; transient refresh failures are health errors, not proof
+// that OAuth is invalid.
+func checkCodexOAuthHealth(e loginEntry, mk func(loginStatus, string) loginHealthMsg) loginHealthMsg {
+	if e.CodexPath == "" {
+		return mk(loginInvalid, "no token file")
+	}
+	tokens, ok := readCodexTokenFile(e.CodexPath)
+	if !ok {
+		return mk(loginInvalid, "invalid credentials")
+	}
+
+	const refreshBufferSeconds = 300
+	if tokens.AccessToken != "" && tokens.ExpiresAt > time.Now().Unix()+refreshBufferSeconds {
+		return mk(loginValid, "")
+	}
+
+	fresh, err := refreshCodexTokensForLoginHealth(tokens.RefreshToken, tokens)
+	if err != nil {
+		if errors.Is(err, ErrCodexAuthRevoked) {
+			return mk(loginInvalid, "invalid credentials")
+		}
+		return mk(loginError, "refresh unavailable")
+	}
+	data, err := json.MarshalIndent(fresh, "", "  ")
+	if err != nil {
+		return mk(loginError, "save failed")
+	}
+	tmpPath := e.CodexPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return mk(loginError, "save failed")
+	}
+	if err := os.Rename(tmpPath, e.CodexPath); err != nil {
+		os.Remove(tmpPath)
+		return mk(loginError, "save failed")
+	}
+	return mk(loginValid, "")
 }
 
 // ---------------------------------------------------------------------------
@@ -470,9 +516,11 @@ func (m LoginModel) startCodexLogin(deviceCode bool) (LoginModel, tea.Cmd) {
 // activeCodexPath is recomputed so the (active) marker tracks the new binding.
 func (m LoginModel) setActiveCodexAccount(entry loginEntry) LoginModel {
 	// Gate on validity: prefer the live health result, but a freshly-listed
-	// account may still be loginChecking — fall back to parsing the token file.
+	// account may still be loginChecking, and transient refresh/network errors
+	// should not force a needless re-login if the token file still carries a
+	// refresh_token. Only loginInvalid is a hard block.
 	valid := entry.Status == loginValid
-	if entry.Status == loginChecking {
+	if !valid && entry.Status != loginInvalid {
 		valid = codexAuthPathValid(entry.CodexPath)
 	}
 	if !valid {

--- a/tui/internal/tui/login_active_test.go
+++ b/tui/internal/tui/login_active_test.go
@@ -91,6 +91,41 @@ func TestLoginModel_EnterOnCodexSetsActiveAppliesToSavedPresets(t *testing.T) {
 	}
 }
 
+func TestLoginModel_EnterOnCodexAllowsTransientHealthErrorWithValidTokenFile(t *testing.T) {
+	_, globalDir := withTempCodexHome(t)
+	saveCodexPresetForTest(t, "codex-a", "")
+
+	acctPath := filepath.Join(globalDir, codexAuthSubdir, "work.json")
+	writeCodexTokenAt(t, acctPath, "work@example.com")
+
+	m := NewLoginModel("", globalDir)
+	idx := -1
+	for i := range m.entries {
+		if m.entries[i].Provider == "codex" && m.entries[i].CodexPath == acctPath {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("could not find the per-account codex entry; entries=%#v", m.entries)
+	}
+	m.cursor = idx
+	m.entries[idx].Status = loginError
+	m.entries[idx].Detail = "refresh unavailable"
+
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("Enter to set active after a transient health error must not start a network command")
+	}
+	wantRef := codexAuthRefForPath(globalDir, acctPath)
+	if ref, ok := reloadSavedRef(t, "codex-a"); !ok || ref != wantRef {
+		t.Fatalf("transient health error with valid refresh-token file should still apply active account; ref=%q present=%v want=%q", ref, ok, wantRef)
+	}
+	if !m.messageOK {
+		t.Fatalf("setting active after transient health error should be confirmation feedback; message=%q", m.message)
+	}
+}
+
 // TestLoginModel_EnterOnLegacyResetsSavedPresets verifies Enter on the legacy
 // account row resets saved Codex presets back to the legacy fallback (no
 // codex_auth_path key).

--- a/tui/internal/tui/login_test.go
+++ b/tui/internal/tui/login_test.go
@@ -2,10 +2,15 @@ package tui
 
 import (
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -27,6 +32,111 @@ func seedLoginCodexAuth(t *testing.T, dir string) string {
 		t.Fatalf("write codex-auth.json: %v", err)
 	}
 	return p
+}
+
+func withLoginHealthRefresh(t *testing.T, fn func(string, CodexTokens) (*CodexTokens, error)) {
+	t.Helper()
+	old := refreshCodexTokensForLoginHealth
+	refreshCodexTokensForLoginHealth = fn
+	t.Cleanup(func() { refreshCodexTokensForLoginHealth = old })
+}
+
+func TestCheckHealth_CodexOAuthUsesTokenFileNotAccessProbe(t *testing.T) {
+	dir := t.TempDir()
+	authPath := seedLoginCodexAuth(t, dir)
+
+	var called atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		http.Error(w, "stale access token", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	msg := checkHealth(loginEntry{
+		Provider:  "codex",
+		IsOAuth:   true,
+		BaseURL:   srv.URL,
+		Key:       "stale-access-token",
+		CodexPath: authPath,
+	})
+
+	if called.Load() {
+		t.Fatal("Codex OAuth health check must not probe /codex/models with a short-lived access token")
+	}
+	if msg.Status != loginValid {
+		t.Fatalf("Codex OAuth with a valid refresh-token file should be valid; status=%v detail=%q", msg.Status, msg.Detail)
+	}
+}
+
+func TestCheckHealth_CodexOAuthRefreshesExpiredTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "codex-auth.json")
+	oldTokens := CodexTokens{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
+		Email:        "stub@example.com",
+	}
+	data, _ := json.Marshal(oldTokens)
+	if err := os.WriteFile(authPath, data, 0o600); err != nil {
+		t.Fatalf("write expired token fixture: %v", err)
+	}
+
+	withLoginHealthRefresh(t, func(refresh string, existing CodexTokens) (*CodexTokens, error) {
+		if refresh != "old-refresh" {
+			t.Fatalf("refresh token = %q, want old-refresh", refresh)
+		}
+		fresh := existing
+		fresh.AccessToken = "new-access"
+		fresh.ExpiresAt = time.Now().Add(time.Hour).Unix()
+		return &fresh, nil
+	})
+
+	msg := checkHealth(loginEntry{Provider: "codex", IsOAuth: true, CodexPath: authPath})
+	if msg.Status != loginValid {
+		t.Fatalf("expired access token with refresh success should be valid; status=%v detail=%q", msg.Status, msg.Detail)
+	}
+	got, ok := readCodexTokenFile(authPath)
+	if !ok {
+		t.Fatal("refreshed token file should parse")
+	}
+	if got.AccessToken != "new-access" {
+		t.Fatalf("refreshed token file access token = %q, want new-access", got.AccessToken)
+	}
+}
+
+func TestCheckHealth_CodexOAuthDistinguishesRevokedAndTransientRefresh(t *testing.T) {
+	dir := t.TempDir()
+	authPath := filepath.Join(dir, "codex-auth.json")
+	tokens := CodexTokens{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
+	}
+	data, _ := json.Marshal(tokens)
+	if err := os.WriteFile(authPath, data, 0o600); err != nil {
+		t.Fatalf("write expired token fixture: %v", err)
+	}
+
+	t.Run("revoked", func(t *testing.T) {
+		withLoginHealthRefresh(t, func(string, CodexTokens) (*CodexTokens, error) {
+			return nil, ErrCodexAuthRevoked
+		})
+		msg := checkHealth(loginEntry{Provider: "codex", IsOAuth: true, CodexPath: authPath})
+		if msg.Status != loginInvalid {
+			t.Fatalf("revoked refresh token should be invalid; status=%v detail=%q", msg.Status, msg.Detail)
+		}
+	})
+
+	t.Run("transient", func(t *testing.T) {
+		withLoginHealthRefresh(t, func(string, CodexTokens) (*CodexTokens, error) {
+			return nil, errors.New("temporary network failure")
+		})
+		msg := checkHealth(loginEntry{Provider: "codex", IsOAuth: true, CodexPath: authPath})
+		if msg.Status != loginError {
+			t.Fatalf("transient refresh failure should be a health error, not invalid; status=%v detail=%q", msg.Status, msg.Detail)
+		}
+	})
 }
 
 // TestLoginModel_DelTwoPressDeletesCodex verifies the two-press Del


### PR DESCRIPTION
## Summary
- Make `/setup credentials` validate stored Codex OAuth accounts with refresh-token grant semantics instead of probing `/codex/models` with the short-lived access token from the token file.
- Keep malformed/no-refresh-token files and revoked refresh grants as `invalid credentials`, but report transient refresh/network/write failures as health errors rather than forcing re-login.
- Permit selecting an account as active after a transient health error when its token file still parses with a refresh token, so temporary outages do not push users into a browser login flow.

## Root cause
The setup health check used the saved access token directly against `/codex/models`. When that short-lived token expired or otherwise failed while the refresh token remained valid, the UI displayed `invalid credentials` and nudged the user toward re-authentication even though runtime startup can refresh the account and continue.

## Fix
Codex OAuth health now treats the token file plus refresh-token grant as the source of truth, matching runtime startup validation more closely. Expired access tokens are refreshed and atomically written back via a `.tmp` file and rename; revoked refresh grants remain invalid; transient failures remain visible as health errors.

## Scope note
This PR only covers the TUI setup-credentials health-check path. It does not cover browser launches initiated by the external Codex desktop app/CLI or by an already-running older `lingtai-tui` binary before this change is released or locally applied.

## Out of scope
- OAuth alias/rename.
- Profile visibility, preset details/editor UI, fingerprints, or used-by display.
- Changes to the `applyActiveCodexAccount` batch-apply semantics.

## Tests
- `git diff --check HEAD~1..HEAD`
- `cd tui && go test ./internal/tui -run 'TestCheckHealth_CodexOAuth|TestLoginModel_EnterOnCodexAllowsTransientHealthErrorWithValidTokenFile' -count=1`
- `cd tui && go test -count=1 ./...`
